### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,8 @@
 
 ## Reporting a Vulnerability
 
-To notify us about a security issue or flaw, please email a description of the issue, as well as any steps for mitigation (if known), to report@ccdatalab.org.
-**Please do not file an issue, start a GitHub Discussion, or file a pull request to report a security issue.**
+To notify us about a security issue or flaw, please email a description of the issue, as well as any steps for mitigation (if known), to <report@ccdatalab.org>.
+
+**Please do not file an issue, start a GitHub Discussion, file a pull request, or post in any other public forum (e.g., Cancer Data Science Slack) to report a security issue.**
 
 We will do our best to investigate and fix the problem quickly. 


### PR DESCRIPTION
Closes https://github.com/alexsLemonade/openscpca-admin/issues/82. My rationale is that we want to direct people to disclose security issues privately via email instead of the many other ways we encourage people to interact with the project.