### PR TITLE
Moving tools for communication docs and adding details

### DIFF
--- a/docs/communications-tools/index.md
+++ b/docs/communications-tools/index.md
@@ -1,5 +1,0 @@
-# Tools for communication
-
-_This content is a stub._
-
-This section will contain information about communications, including using Slack, GitHub Issues, and GitHub Discussions.

--- a/docs/communications-tools/tools-for-communication.md
+++ b/docs/communications-tools/tools-for-communication.md
@@ -1,0 +1,111 @@
+# Tools for communication
+
+OpenScPCA community members will use the following tools for communication and collaboration. Learn more about using:
+
+* [GitHub Discussions](#github-discussions)
+* [GitHub Issues](#github-issues)
+* [Slack](#slack)
+
+## GitHub Discussions
+
+[GitHub Discussions](https://docs.github.com/en/discussions/quickstart) is the community forum for the project, [which can be found here](https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions) in the `OpenScPCA-Analysis` repository.
+You are most likely to engage with the project for the first time via Discussions.
+
+⚠️Please read this pinned discussion from the Data Lab before creating your first post!
+
+### How and When to Use Discussions
+
+Discussions are organized by category.
+Please [read the description of each category](https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions/new/choose) to make sure you are posting in the correct place. 
+
+**Participate in community conversations.** 
+Discuss big picture ideas, brainstorm, and develop plans for analyses before implementing them.
+
+**Propose a new analysis.** 
+Propose a new analysis in the [`Analysis Ideas` category](https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions/categories/analysis-ideas), before committing it to an issue. 
+Create a post to explain why you are proposing an analysis and an overview of your planned methods. 
+Project maintainers will ask clarifying questions, raise any concerns, and come to a decision about proceeding.
+
+**Ask questions.**
+Get help from project maintainers and/or community members. 
+
+* Use the [`Q&A` category](https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions/categories/q-a) to ask non-urgent questions. (Ex. where to find information)
+* Use the [`Troubleshooting` category](https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions/categories/troubleshooting) to get help from project maintainers. (Ex. challenges with setting up your local environment, trouble running an analysis)
+
+**View announcements related to the project.** 
+Project maintainers will post in the [`Announcements` category](https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions/categories/announcements) when there is news that the community should know about. 
+For example, if the Data Lab staff will be offline for a few days, we will post about it here!
+
+**Provide feedback about the project.**
+We may share [`Polls`](https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions/categories/polls) to ask the community for feedback.
+
+## GitHub Issues
+
+[GitHub issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues) are used to plan, define, and track pieces of work.
+They also help us prioritize, schedule tasks, and identify blockers.
+
+Issues should be focused and manageable in scope. 
+Smaller chunks of work are easier to accomplish and review!
+An issue will eventually be linked to a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+We always aim for a ratio of one issue to one pull request.
+
+Please read the Data Lab's documentation on:
+
+* How we use GitHub issues 
+* Writing good issues 
+  
+⚠️ Please engage with project maintainers before filing your first issue in the `OpenScPCA-Analysis` repository. 
+We will provide you with further guidance!
+
+### How and When to Use Issues
+
+**File an issue for a proposed analysis that has been accepted.** 
+*After* you have proposed an analysis on the discussions forum and it has been accepted by project maintainers, then you can file an issue.
+The ideal issue will describe the scope and scientific goals of the analysis, the planned methods to address the scientific goals, and a proposed timeline for the analysis. 
+
+**Identify a planned analysis that you wish to tackle.** 
+There are existing issues for planned analyses that others may not be working on yet.
+If you would like to take on a planned analysis, you can comment on the issue to note your interest and ask any clarifying questions.
+Here, you can propose a solution for project maintainers to review and discuss further.
+
+**Report a bug.**
+If you encounter a bug, please file an issue to help us make improvements! 
+Provide a clear and detailed description of the problem.
+Include any relevant error messages or reports.
+
+## Slack
+
+### #open-scpca Slack channel
+
+As part of onboarding, we will add you to the `#open-scpca` channel in our [Cancer Data Science Slack](https://cancer-data-science.slack.com/). 
+After joining, please feel free to send a message to  introduce yourself to the community!
+
+### When to Use the Slack Channel
+
+We encourage you to ask questions on Slack, so they are visible to the entire OpenScPCA community. 
+For example, post questions on the channel about:
+
+* an error you encountered while getting set up 
+* an analysis you are working on
+* the data and tools you are using as part of this project
+
+If you have a question, it's likely that someone else has a similar one! 
+Posting on Slack makes it possible for any project maintainer or community member to help you.
+We cannot always respond immediately, but we will do our best to answer to all messages within 24 hours. 
+
+**Helpful tips:**
+
+* Please try to use threads for responses to questions or ongoing conversations about the same topic.
+* Slack messages are not permanent and will disappear after 30 days. If there is a post that contains information you want to refer back to, we recommend that you save it elsewhere. 
+
+### Direct messages
+
+If you need to address a private matter or have a question that is highly specific to you, you may direct message a Data Lab staff member.
+In all other cases, please use the `#open-scpca` Slack channel to reach us.
+
+Direct messages can be sent to `Jen O'Malley`, `Jaclyn Taroni`, `Ally Hawkins`, `Josh Shapiro`, or `Stephanie Spielman`.
+
+We may direct you back to the `#open-scpca` channel or to another staff member when appropriate.
+
+In some cases, you may use Slack to report a concern to a Data Lab staff member.
+See the [reporting section of the Code of Conduct](https://github.com/AlexsLemonade/OpenScPCA-admin/blob/main/code-of-conduct/code-of-conduct.md#report-an-incident) to learn more about when to use Slack for reporting.


### PR DESCRIPTION
### Which issue does this address?

This PR addresses #63.

### Briefly describe the scope of the added docs file, including whether you link out to any external docs.
<!-- If you are adding more than one docs file, how are they related to one another?-->
<!-- Are you adding any visual aids? Or, see next section if you think these docs would benefit from viz. -->

This documentation is about how/when to use communication tools including GitHub Discussions, issues, and Slack. I am moving the internal documentation from `OpenScPCA-admin` to this repo and adding more details. This documentation will link to GitHub docs on discussions and issues, a pinned discussion post, other docs within this repo on issues, our Slack channel and our code of conduct.

### Will you need additional visual aids for these docs?

No

### Any other comments for reviewers?

### Author checklist

- [ ] The docs page has been added to the `nav` section in `mkdocs.yml`
- [ ] The docs adhere to the style guide [**structure directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#structure)?
- [ ] The docs adhere to the style guide [**language directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#structure)?
- [ ] The docs adhere to the style guide [**tone directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#tone)?




### Reviewer checklist

Please refer to the [docs style guide](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md) while reviewing this pull request.

- [ ] Do the docs adhere to the style guide [**structure directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#structure)?
- [ ] Do the docs adhere to the style guide [**language directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#structure)?
- [ ] Do the docs adhere to the style guide [**tone directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#tone)?

