### PR TITLE
Adding a discussions template for troubleshooting

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/troubleshooting.yml
+++ b/.github/DISCUSSION_TEMPLATE/troubleshooting.yml
@@ -19,7 +19,7 @@
 - type: textarea
   attributes:
     label: Observed outcome or error message
-    description: What was the observed outcome and/or error message?
+    description: What was the observed outcome and/or error message? Include screenshots as needed. 
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
## Purpose

I am adding a discussion template for the `troubleshooting` category to guide contributors who are posting about a problem.

## Issue Addressed

This PR addresses #129.

## Any comments, concerns, or questions important for reviewers

@dvenprasad and @sjspielman already gave me some feedback on the content of this discussion template. (Thank you!) Interested in anything else you think we should ask or be more specific about. I thought you might want to see this too @jaclyn-taroni.

Also interested in making sure I created the template correctly!
