### PR TITLE
Adding missing fields to troubleshooting template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/troubleshooting.yml
+++ b/.github/DISCUSSION_TEMPLATE/troubleshooting.yml
@@ -1,3 +1,5 @@
+name: "Troubleshooting"
+body:
 - type: textarea
   attributes:
     label: Summary


### PR DESCRIPTION
## Purpose

After merging the troubleshooting discussion template, I received the error below. [This information](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms) leads me to believe that I may be missing fields. I added what I _think_ is missing.

<img width="1125" alt="Screenshot 2024-03-11 at 12 48 31 PM" src="https://github.com/AlexsLemonade/OpenScPCA-analysis/assets/87316564/cff29d80-3d4a-44b7-87ed-f6f3f7592a87">

## Issue Addressed

This issue further addresses #129.

## Any comments, concerns, or questions important for reviewers

I think we'll have to merge this again to see if it fixes the error. Unless anything else stands out to you!
