### PR TITLE
Removing a field from troubleshooting template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/troubleshooting.yml
+++ b/.github/DISCUSSION_TEMPLATE/troubleshooting.yml
@@ -1,4 +1,3 @@
-name: "Troubleshooting"
 body:
 - type: textarea
   attributes:


### PR DESCRIPTION
## Purpose

Still receiving an error on the troubleshooting template. 

<img width="998" alt="Screenshot 2024-03-11 at 12 57 40 PM" src="https://github.com/AlexsLemonade/OpenScPCA-analysis/assets/87316564/1c5b1a54-5073-4654-a3c6-13c743b3bcce">



I looked at a `textarea` discussion template from another organization and it looks like this. Perhaps just the `body` field was missing...

<img width="418" alt="Screenshot 2024-03-11 at 12 58 14 PM" src="https://github.com/AlexsLemonade/OpenScPCA-analysis/assets/87316564/9233f918-946d-435a-bac3-313813e6ee9c">


## Issue Addressed

Addresses #129 

## Any comments, concerns, or questions important for reviewers

🤞🏻