### PR TITLE
Adding discussion templates for proposing and modifying an analysis

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/modify-an-existing-analysis.yml
+++ b/.github/DISCUSSION_TEMPLATE/modify-an-existing-analysis.yml
@@ -19,12 +19,6 @@ body:
     required: true
 - type: textarea
   attributes:
-    label: Additional data
-    description: Is there additional data you will need besides the current module input data?
-  validations:
-    required: true
-- type: textarea
-  attributes:
     label: Scientific literature
     description: Share any scientific literature that relates to the analysis.
   validations:

--- a/.github/DISCUSSION_TEMPLATE/propose-a-new-analysis.yml
+++ b/.github/DISCUSSION_TEMPLATE/propose-a-new-analysis.yml
@@ -26,7 +26,7 @@ body:
 - type: textarea
   attributes:
     label: Input data
-    description: What input data might this analysis use?
+    description: What input data might this analysis use? If you are not sure, please indicate this.
   validations:
     required: false
 - type: textarea


### PR DESCRIPTION
## Purpose

Adding two discussion templates to guide contributors in the `Propose a new analysis` and `Modify an existing analysis` categories. 

## Issue Addressed

This PR addresses #121.

## Any comments, concerns, or questions important for reviewers

Content is the same as what we came up with in the Google doc!

We have been able to see how discussion templates look after completing the `Troubleshooting` template! [View it here](https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions/new?category=troubleshooting). 