### PR TITLE
Stub in policies section of docs

### DIFF
--- a/docs/policies/index.md
+++ b/docs/policies/index.md
@@ -1,0 +1,5 @@
+# Policies
+
+_This content is a stub._
+
+This section will contain links to and information about policies associated with the OpenScPCA project.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,5 +50,5 @@ nav:
     - software-platforms/index.md
   - Getting Help and FAQ:      # troubleshooting and FAQ
     - troubleshooting-faq/index.md
-
-
+  - Policies: # CoC, Authorship, other policies
+    - policies/index.md


### PR DESCRIPTION
I explained myself here: https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/155#issuecomment-1994435049

> I am reading the document from our legal team, and I think we should have a section of the docs called **Policies** that includes the following:
> 
>     * The code of conduct (covered by this issue)
> 
>     * Authorship policy (discussed Friday, ticket forthcoming)
> 
>     * Terms of Use (coming soon)
> 
>     * Privacy Policy (if applicable)
> 
> 
> That would allow us to link to an overarching policies section, which would be very useful.

It's helpful for me to have the relevant URL **right now.**

I edited #61 to reflect the policies we know about now (cc: @dvenprasad, who will write the authorship policy ticket).


