### PR TITLE
Make use of posit package manager & bioc version default

### DIFF
--- a/create-analysis-module.py
+++ b/create-analysis-module.py
@@ -153,6 +153,7 @@ def main() -> None:
                 repos = list(CRAN = "https://p3m.dev/cran/latest"),
                 settings = list(
                     ppm.enabled = TRUE,
+                    r.version = "4.3.3",
                     bioconductor.version = "3.18"
                 )
             )


### PR DESCRIPTION
This small PR updates the `--use-renv` section of the module creation script to specify the posit package manager (for binary packages on linux) and sets the bioconductor version for new modules.