### PR TITLE
Adding email section to tools for communication doc

### DIFF
--- a/docs/communications-tools/tools-for-communication.md
+++ b/docs/communications-tools/tools-for-communication.md
@@ -121,7 +121,7 @@ See the [reporting section of the Code of Conduct](https://github.com/AlexsLemon
 
 ## Email
 
-You can email (email@email.email) with queries related to administration.
+You can email [report@ccdatalab.org](mailto:report@ccdatalab.org) with queries related to administration.
 
 You can email us to: 
 - Report security issues
@@ -129,5 +129,5 @@ You can email us to:
 - Copyright violations
 - Other such administration related items
 
-If you are not sure where to direct your question, please ask in Slack or Github Discussions.
+If you are not sure where to direct your question, please ask in [Slack](https://cancer-data-science.slack.com/) or [Github Discussions](https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions).
 If it is a private matter, you may [direct message](#direct-messages) one of the Data Lab members on Slack.


### PR DESCRIPTION
### Which issue does this address?
#174 

Stacked on #112 

### Briefly describe the scope of the added docs file, including whether you link out to any external docs.
<!-- If you are adding more than one docs file, how are they related to one another?-->
<!-- Are you adding any visual aids? Or, see next section if you think these docs would benefit from viz. -->

Added an email section in the tools for communication docs

### Will you need additional visual aids for these docs?
No

### Any other comments for reviewers?
I have put in a dummy email, we can update the during review.

### Author checklist

- [X] The docs page has been added to the `nav` section in `mkdocs.yml`
- [X] The docs adhere to the style guide [**structure directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#structure)?
- [X] The docs adhere to the style guide [**language directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#structure)?
- [X] The docs adhere to the style guide [**tone directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#tone)?




### Reviewer checklist

Please refer to the [docs style guide](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md) while reviewing this pull request.

- [x] Do the docs adhere to the style guide [**structure directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#structure)?
- [x] Do the docs adhere to the style guide [**language directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#structure)?
- [x] Do the docs adhere to the style guide [**tone directions**](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/docs/general-style-guide.md#tone)?

