### PR TITLE
Remove index.md file from comm tools

### DIFF
--- a/docs/communications-tools/index.md
+++ b/docs/communications-tools/index.md
@@ -1,5 +1,0 @@
-# Tools for communication
-
-_This content is a stub._
-
-This section will contain information about communications, including using Slack, GitHub Issues, and GitHub Discussions.


### PR DESCRIPTION
## Purpose

Removing `index.md` file since `tools-for-communication.md` summarizes the section.

## Issue Addressed

## Any comments, concerns, or questions important for reviewers
