### PR TITLE
Update to python 3.11 in base env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python=3.10
-  - awscli=2.15.21
-  - jq=1.7.1
-  - pre-commit=3.6.2
+  - python=3.11
+  - awscli=2.15
+  - jq=1.7
+  - pre-commit=3.6


### PR DESCRIPTION
When I originally made this environment, I just used what I had currently installed for python, because it seemed fine and at a good lifecycle stage. But I just read that one of the major changes in Python 3.11 is a substantial speed boost, so it seems like that is a better place to start.

I also removed the minor point versions from the environment for other packages. People will still record full versions within modules, but I figured we could be a bit more lax here. 