### PR TITLE
Adding a file that will redirect contributors from issues to discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,5 +9,3 @@ contact_links:
   - name: Get help with an error
     url: https://github.com/AlexsLemonade/OpenScPCA-analysis/discussions/new?category=troubleshooting
     about: Request help with a specific error or problem.
- 
-


### PR DESCRIPTION
## Purpose

I am adding a config.yml file to redirect people from issues to discussions in certain cases.

- Propose an analysis -> Propose an analysis discussion category form
- Ask a question -> Q&A category
- Get help with an error -> Troubleshooting discussions category form

## Issue Addressed

This PR (partially) addresses #38.

## Any comments, concerns, or questions important for reviewers

So far, I have only added the discussion redirects. I have not ordered the existing issue templates. I am not sure if we have added all templates yet, and if/how we want to rearrange the current order. We can discuss that here and I can do it in this PR. Or we can revisit if we're not ready for that step yet.