### PR TITLE
Edit authorship policy

### DIFF
--- a/docs/policies/authorship.md
+++ b/docs/policies/authorship.md
@@ -4,19 +4,19 @@
 
 Authorship criteria for any future OpenScPCA publication(s) will follow [guidance from the International Committee of Medical Journal Editors (ICJME)](https://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html).
 
-In particular, [the four criteria recommended by ICJME](https://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html#two):
+In particular, the following [four criteria recommended by ICJME](https://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html#two) must be met:
 
 > - Substantial contributions to the conception or design of the work; or the acquisition, analysis, or interpretation of data for the work; AND
 > - Drafting the work or reviewing it critically for important intellectual content; AND
 > - Final approval of the version to be published; AND
 > - Agreement to be accountable for all aspects of the work in ensuring that questions related to the accuracy or integrity of any part of the work are appropriately investigated and resolved.
 
-We encourage you to review [the ICJME guidance](https://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html) in full.
-
 We expect contributors to participate in the conception and design of the work through Discussions, issues, and review, and to contribute analyses and interpretation by filing pull requests to the `OpenScPCA-analysis` repository.
 To meet the criteria for authorship, these contributions must lead to a portion of results included in a publication.
 
 OpenScPCA contributors who do not meet the criteria for authorship may still be acknowledged with their permission.
+
+We encourage you to review [the ICJME guidance](https://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html) in full.
 
 ## Contributor Roles Taxonomy (CRediT)
 


### PR DESCRIPTION
Stacked on #307

### Which issue does this address?

#172

### Briefly describe the scope of the added docs file, including whether you link out to any external docs.
<!-- If you are adding more than one docs file, how are they related to one another?-->
<!-- Are you adding any visual aids? Or, see next section if you think these docs would benefit from viz. -->

These are my edits regarding #307. The meeting notes I asked you to use were more incomplete than I realized, @Jen-OMalley, so this is my fault.

CRediT is a way to describe contributions to a work but can not be used as authorship criteria alone. Norms – as well as most _policies_ at institutions, journals, etc. – dictate that you must make substantial contributions (e.g., conception, design, analysis, interpretation) to the work that produces results. (This is "science rules" part of the meeting notes.)

To quote from the ICMJE recommendations included in my draft:

> Examples of activities that alone (without other contributions) do not qualify a contributor for authorship are acquisition of funding; general supervision of a research group or general administrative support; and writing assistance, technical editing, language editing, and proofreading

So if we were to use CRediT in the way originally described in #307, someone with only a Funding Acquisition role would be included as an author, which would be inappropriate.

I'm also making this a little more MkDocs friendly and better in line with our style guide:

- Shortening the H1 header 
- Removing the separate ToC because there will be one on the righthand side
- Using bulleted lists