### PR TITLE
Revise in light of getting access to resources

### DIFF
--- a/docs/getting-started/making-your-first-analysis-contribution.md
+++ b/docs/getting-started/making-your-first-analysis-contribution.md
@@ -37,7 +37,7 @@ Together you will continue to develop your analysis plans and make decisions abo
 
 ### Getting access to resources
 
-* Once you've met [the criteria for Amazon Web Services (AWS) account creation](accessing-resources/index.md#getting-access-toaws), which includes discussing an analysis, we will create an AWS account for you.
+* Once you've met [the criteria for Amazon Web Services (AWS) account creation](accessing-resources/index.md#getting-access-to-aws), which includes discussing an analysis, we will create an AWS account for you.
 * You will need to accept the invitation to join [as described in our AWS documentation](../software-platforms/aws/index.md#joining-iam-identity-center) to complete one of the steps in environment setup mentioned below.
 
 ## Implementation


### PR DESCRIPTION
### Which issue does this address?

Closes #324

### Briefly describe the scope of the added docs file, including whether you link out to any external docs.
<!-- If you are adding more than one docs file, how are they related to one another?-->
<!-- Are you adding any visual aids? Or, see next section if you think these docs would benefit from viz. -->

This is updating #318 in light of some open PRs that I do not expect to change wildly in structure:

- #325 adds a section to the Getting Access to Resources index doc that explains the criteria for gaining access to AWS
- #327 adds the following:
  - A section to the AWS index doc that describes accepting an invitation to IAM Identity Center
  - Adding AWS CLI configuration to setting up, which means that the bullet "Set up [additional dependencies](../technical-setup/environment-setup/index.md) on your computer that you'll need to contribute to OpenScPCA" will encompass AWS CLI configuration

That means these links will not work yet.

I suggest ignoring whitespace changes with this one; my editor strips trailing whitespace.