### PR TITLE
Docs cleanup, Part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To set up, you will need a Git client, Miniconda, R or Python, and an editor of 
 Data is publicly available from the [ScPCA Portal](https://scpca.alexslemonade.org/) and from an AWS S3 bucket for OpenScPCA project contributors.
 We also provide a way to download smaller, simulated data files for you to play with.
 
-Please [Getting access to Data](https://openscpca.readthedocs.io/en/latest/getting-started/accessing-resources/getting-access-to-data/) for more details.
+Please reference [Getting access to Data](https://openscpca.readthedocs.io/en/latest/getting-started/accessing-resources/getting-access-to-data/) for more details.
 
 ### Running an analysis module
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ If desired, please [file an issue](https://github.com/AlexsLemonade/OpenScPCA-an
 
 To start contributing:
 
-1. Please review our [Policies](https://openscpca.readthedocs.io/policies).
+1. Please review our [Policies](https://openscpca.readthedocs.io/en/latest/policies/).
 
 2. Fill out the [interest form](https://share.hsforms.com/1MlLtkGYSQa6j23HY_0fKaw336z0).
 
-3. Visit [Getting Started](#STUB_LINK) for first steps.
+3. Visit [Getting Started](https://openscpca.readthedocs.io/en/latest/getting-started/making-your-first-analysis-contribution/) for first steps.
 
 ### Communicating
 
@@ -42,7 +42,7 @@ If you wish to report a security vulnerability, please [email](mailto:report@ccd
 Do NOT report it in a public forum.
 See our [security policy](./SECURITY.md) for more information.
 
-Please see our documentation on [Tools for communication](https://openscpca.readthedocs.io/communications-tools/) for more information.
+Please see our documentation on [Tools for communication](https://openscpca.readthedocs.io/en/latest/communications-tools/) for more information.
 
 ## Documentation
 
@@ -57,19 +57,19 @@ Please refer to it as you work on the project.
 
 ### Local Setup
 
-To set up, you will need a Git client, Miniconda, R or Python, and an editor of your choice. Please see our documentation on [Technical Setup](https://openscpca.readthedocs.io/technical-setup) for detailed instructions to create a local setup.
+To set up, you will need a Git client, Miniconda, R or Python, and an editor of your choice. Please see our documentation on [Technical Setup](https://openscpca.readthedocs.io/en/latest/technical-setup) for detailed instructions to create a local setup.
 
 ### Accessing Data
 
 Data is publicly available from the [ScPCA Portal](https://scpca.alexslemonade.org/) and from an AWS S3 bucket for OpenScPCA project contributors.
 We also provide a way to download smaller, simulated data files for you to play with.
 
-Please [Getting access to Data](#STUB_LINK) for more details.
+Please [Getting access to Data](https://openscpca.readthedocs.io/en/latest/getting-started/accessing-resources/getting-access-to-data/) for more details.
 
 ### Running an analysis module
 
-Each analysis module has a README which contains instructions to run that specific module.
-Please see the relevant analysis module's README for instructions.
+Each analysis module has a `README.md` file which contains instructions to run that specific module.
+Please see the relevant analysis module's `README.md` for instructions.
 
-Learn more about [running an analysis module](#STUB_LINK) here.
+Learn more about [running an analysis module](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/running-a-module/) here.
 

--- a/docs/getting-started/accessing-resources/getting-access-to-compute.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-compute.md
@@ -7,7 +7,7 @@ We use [Lightsail for Research](https://aws.amazon.com/lightsail/research/) to m
 You must meet the criteria for AWS account creation to gain access to Lightsail for Research.
 See [Getting access to AWS](index.md#getting-access-to-aws) for more information.
 
-See our docs about [Lightsail for Research](STUB_LINK) for more information on using this service.
+See our docs about [Lightsail for Research](../../software-platforms/lsfr/index.md) for more information on using this service.
 
 ### Monthly budget
 

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -26,7 +26,7 @@ Before filing a pull request, you should change your paths to reflect the direct
 Because we expect that contributors may want to work with many samples or analyze data on remote systems, we also provide access to the ScPCA on AWS S3 via a script for downloading data.
 
 Before you can access data in this manner, the Data Lab team needs to create an AWS account for you; these data are not publicly accessible.
-See [Getting Access to Resources](index.md) for more information.
+See our documentation [getting access to AWS](index.md#getting-access-to-aws) for more information.
 
 !!! info Review additional restrictions
     Please review the `DATA_USAGE.md` file included in all downloads for any additional restrictions on data usage (see [Policies](../../policies/index.md)).

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -40,7 +40,7 @@ See [Getting Access to Resources](index.md) for more information.
     - [Set up your environment](../../technical-setup/environment-setup/index.md)
     - [Configured the AWS CLI and logged in](../../technical-setup/environment-setup/configure-aws-cli.md) OR are [using Lightsail for Research](../../software-platforms/lsfr/index.md) (which doesn't require logging in via the AWS CLI)
 
-The `download-data.py` script is designed to download files from whatever release you specify to a folder named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`.
+The `download-data.py` script is designed to download files from whatever release you specify to a folder named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`. <!-- STUB_LINK link to the download script, or at least tell contributors where to find it -->
 
 We briefly cover some of the most common use cases below, but we encourage you to review all the options available to you.
 
@@ -50,7 +50,7 @@ You can list all the options for the download data script by running the followi
 ./download-data.py --help
 ```
 
-!!! tip No `--profile` necessary on Lightsail for Research
+!!! tip "No `--profile` necessary on Lightsail for Research"
     Omit `--profile openscpca` from the commands below if you're using Lightsail for Research.
 
 Assuming you created a profile called `openscpca` when [configuring the AWS CLI](../../technical-setup/environment-setup/configure-aws-cli.md), you can run the download script with all default options to download all processed samples from the most recent release in `SingleCellExperiment` format:
@@ -89,7 +89,7 @@ data
 └── current -> {Release}
 ```
 
-See the ScPCA documentation for more information about individual files: <https://scpca.readthedocs.io>.
+See the ScPCA documentation for [more information about individual files](https://scpca.readthedocs.io/en/latest/sce_file_contents.html).
 
 Data releases are dated using the following format: `YYYY-MM-DD`.
 By default, the data download script will download the most recent release.

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -40,7 +40,7 @@ See our documentation [getting access to AWS](index.md#getting-access-to-aws) fo
     - [Set up your environment](../../technical-setup/environment-setup/index.md)
     - [Configured the AWS CLI and logged in](../../technical-setup/environment-setup/configure-aws-cli.md) OR are [using Lightsail for Research](../../software-platforms/lsfr/index.md) (which doesn't require logging in via the AWS CLI)
 
-The `download-data.py` script is designed to download files from whatever release you specify to a folder named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`. <!-- STUB_LINK link to the download script, or at least tell contributors where to find it -->
+The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-data.py) is designed to download files from whatever release you specify to a folder named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`.
 
 We briefly cover some of the most common use cases below, but we encourage you to review all the options available to you.
 

--- a/docs/getting-started/accessing-resources/index.md
+++ b/docs/getting-started/accessing-resources/index.md
@@ -11,7 +11,7 @@ Before we create an AWS account for you, the following must be completed:
 
 There are technical limits to the number of accounts we can create, so we want to be sure contributors will use them prior to allocation.
 
-See our documentation on [AWS](STUB_LINK) for more information.
+See our documentation on [AWS](../../software-platforms/aws/index.md) for more information.
 
 ## Getting access to data
 

--- a/docs/getting-started/explore-analysis.md
+++ b/docs/getting-started/explore-analysis.md
@@ -26,7 +26,7 @@ This includes:
 Each existing module has its own folder in the repository's [`analyses` folder](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses).
 See our documentation on [analysis modules](../contributing-to-analyses/analysis-modules/index.md) to learn more about how analyses are structured.
 
-All instructions and files ([except data](#get-access-to-data-for-running-modules)) needed to run a given module are provided the module's folder.
+All instructions and files ([except data](#get-access-to-data-for-running-modules)) needed to run a given module are provided in the module's folder.
 
 - To [run existing modules](../contributing-to-analyses/analysis-modules/running-a-module.md), please refer to the `README.md` found in the root directory of that module.
 - The `README.md` will contain a description of the module, instructions to run the module, the list of input and output files, and any additional software or computing resources you may need.

--- a/docs/getting-started/explore-analysis.md
+++ b/docs/getting-started/explore-analysis.md
@@ -1,15 +1,11 @@
-# Explore existing analyses
+# Exploring existing analyses
 
 Before contributing to OpenScPCA, you can explore and run any existing [analysis modules](../contributing-to-analyses/analysis-modules/index.md) on your local machine.
 
 You can browse existing analysis modules in the repository in the [`analyses` folder](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses).
 This folder also contains a pair of example analyses, one for [performing analysis in R](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/hello-R) and one for [performing analysis in Python](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/hello-python).
 
-To run the example analysis or any other existing analyses, you will need to:
-
-- [Set up local environment](#set-up-local-environment)
-- [Run existing modules](#run-existing-modules)
-- [Accessing data for modules](#accessing-data-for-modules)
+To run the example analysis modules or any other existing modules, you will need to first [set up your local environment](#set-up-local-environment), and you may also need to get [access to the module's data](#obtain-data-to-run-a-module)
 
 ## Set up local environment
 
@@ -23,25 +19,24 @@ This includes:
 
 ## Run existing modules
 
-Each existing module will have it's own folder in `analyses`.
-All instructions and files needed to run a given module will be contained in the module's folder.
+Each existing module has its own folder in the repository's [`analyses` folder](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses).
+See our documentation on [analysis modules](../contributing-to-analyses/analysis-modules/index.md) to learn more about how analyses are structured.
+
+All instructions and files (except [data](#obtain-data-to-run-a-module)) needed to run a given module are provided the module's folder.
 
 - To [run existing modules](../contributing-to-analyses/analysis-modules/running-a-module.md), please refer to the `README.md` found in the root directory of that module.
-- The `README.md` will contain a description of the module, instructions to run the module, the list of input and output files, and any additional software or computing resources you may need.
+    - The `README.md` will contain a description of the module, instructions to run the module, the list of input and output files, and any additional software or computing resources you may need.
+    - The `README.md` will also contain information about the input data that the module takes.
 
-See [analysis module](../contributing-to-analyses/analysis-modules/index.md) to learn more about how analyses are structured.
+## Obtain data to run a module
 
-## Accessing data for modules
+For modules that use data obtained from the ScPCA Portal as input, you can directly download data from the [ScPCA Portal](https://scpca.alexslemonade.org/).
 
-The specific requirements for input data will be listed in the `README.md` for each module.
-For modules that use data obtained from the ScPCA Portal as input, data can be directly downloaded from the [ScPCA Portal](https://scpca.alexslemonade.org/).
-
-Additionally, you can use the [`simulate-sce`](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/simulate-sce) analysis module to create simulated data.
+Alternatively, you can use the [`simulate-sce`](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/simulate-sce) analysis module to create simulated data:
 
 - This module simulates data based on the properties of real ScPCA data.
 - The simulated data contains permuted labels and simulated counts data for a small number of cells, making it ideal for testing analyses modules.
 - The module requires either `SingleCellExperiment` or `AnnData` objects from the ScPCA Portal as input.
 
-Any modules that use input data obtained from another module are stored in an S3 bucket on Amazon Web Services and are available to contributors.
-<!--TODO: Fill in with link to getting access to data-->
-More information on getting access to data coming soon!
+In some cases, an analysis module's input data will be the results/output from a different module.
+These results are stored in an [S3 bucket on Amazon Web Services](../software-platforms/aws/index.md), and [are available to contributors](accessing-resources/getting-access-to-data.md).

--- a/docs/getting-started/explore-analysis.md
+++ b/docs/getting-started/explore-analysis.md
@@ -5,9 +5,13 @@ Before contributing to OpenScPCA, you can explore and run any existing [analysis
 You can browse existing analysis modules in the repository in the [`analyses` folder](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses).
 This folder also contains a pair of example analyses, one for [performing analysis in R](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/hello-R) and one for [performing analysis in Python](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/hello-python).
 
-To run the example analysis modules or any other existing modules, you will need to first [set up your local environment](#set-up-local-environment), and you may also need to get [access to the module's data](#obtain-data-to-run-a-module)
+To run the example analysis modules or any other existing modules, you will need to:
 
-## Set up local environment
+- [Set up your local environment](#set-up-your-local-environment)
+- [Follow instructions to run existing modules](#follow-instructions-to-run-existing-modules)
+- [Get access to data for running modules](#get-access-to-data-for-running-modules)
+
+## Set up your local environment
 
 Before you can run any analysis modules locally, you need to [set up your environment](../technical-setup/index.md).
 This includes:
@@ -15,29 +19,29 @@ This includes:
 - Downloading and setting up a [Git client](../technical-setup/install-a-git-client.md)
 - [Forking the `AlexsLemonade/OpenScPCA-analysis` repository](../technical-setup/fork-the-repo.md)-
 - [Cloning your fork](../technical-setup/clone-the-repo.md) to your computer
-- [Installing conda and necessary dependencies](../technical-setup/environment-setup/index.md) needed to run analysis
+- [Installing conda and necessary dependencies](../technical-setup/environment-setup/index.md) needed to run analyses
 
-## Run existing modules
+## Follow instructions to run existing modules
 
 Each existing module has its own folder in the repository's [`analyses` folder](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses).
 See our documentation on [analysis modules](../contributing-to-analyses/analysis-modules/index.md) to learn more about how analyses are structured.
 
-All instructions and files (except [data](#obtain-data-to-run-a-module)) needed to run a given module are provided the module's folder.
+All instructions and files ([except data](#get-access-to-data-for-running-modules)) needed to run a given module are provided the module's folder.
 
 - To [run existing modules](../contributing-to-analyses/analysis-modules/running-a-module.md), please refer to the `README.md` found in the root directory of that module.
 - The `README.md` will contain a description of the module, instructions to run the module, the list of input and output files, and any additional software or computing resources you may need.
- 
 
-## Obtain data to run a module
+
+## Get access to data for running modules
 
 For modules that use data obtained from the ScPCA Portal as input, you can directly download data from the [ScPCA Portal](https://scpca.alexslemonade.org/).
 
-Alternatively, you can use the [`simulate-sce`](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/simulate-sce) analysis module to create simulated data:
+Additionally, you can use the [`simulate-sce`](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/simulate-sce) analysis module to create simulated data:
 
 - This module simulates data based on the properties of real ScPCA data.
 - The simulated data contains permuted labels and simulated counts data for a small number of cells, making it ideal for testing analyses modules.
 - The module requires either `SingleCellExperiment` or `AnnData` objects from the ScPCA Portal as input.
 
 In some cases, an analysis module's input data will be the results/output from a different module.
-These results are stored in an [S3 bucket on Amazon Web Services](../software-platforms/aws/index.md), and are available to contributors. 
+These results are stored in an [S3 bucket on Amazon Web Services](../software-platforms/aws/index.md), and are available to contributors.
 Read more about [getting access to data](accessing-resources/getting-access-to-data.md).

--- a/docs/getting-started/explore-analysis.md
+++ b/docs/getting-started/explore-analysis.md
@@ -25,8 +25,8 @@ See our documentation on [analysis modules](../contributing-to-analyses/analysis
 All instructions and files (except [data](#obtain-data-to-run-a-module)) needed to run a given module are provided the module's folder.
 
 - To [run existing modules](../contributing-to-analyses/analysis-modules/running-a-module.md), please refer to the `README.md` found in the root directory of that module.
-    - The `README.md` will contain a description of the module, instructions to run the module, the list of input and output files, and any additional software or computing resources you may need.
-    - The `README.md` will also contain information about the input data that the module takes.
+- The `README.md` will contain a description of the module, instructions to run the module, the list of input and output files, and any additional software or computing resources you may need.
+ 
 
 ## Obtain data to run a module
 
@@ -39,4 +39,5 @@ Alternatively, you can use the [`simulate-sce`](https://github.com/AlexsLemonade
 - The module requires either `SingleCellExperiment` or `AnnData` objects from the ScPCA Portal as input.
 
 In some cases, an analysis module's input data will be the results/output from a different module.
-These results are stored in an [S3 bucket on Amazon Web Services](../software-platforms/aws/index.md), and [are available to contributors](accessing-resources/getting-access-to-data.md).
+These results are stored in an [S3 bucket on Amazon Web Services](../software-platforms/aws/index.md), and are available to contributors. 
+Read more about [getting access to data](accessing-resources/getting-access-to-data.md).

--- a/docs/technical-setup/clone-the-repo.md
+++ b/docs/technical-setup/clone-the-repo.md
@@ -5,7 +5,7 @@ Cloning provides you with a local copy of the repository to work with.
 You will need to clone the repository to every computer (or remote server) you want to use to contribute to the project.
 
 !!! note
-    You should clone your forked repository from `<username>/OpenScPCA-analysis`, _not_ `AlexsLemonade/OpenScPCA-analysis`.
+    You should clone your forked repository from `<YOUR_USERNAME>/OpenScPCA-analysis`, _not_ `AlexsLemonade/OpenScPCA-analysis`.
 
 
 ## Clone your forked repository

--- a/docs/technical-setup/environment-setup/configure-aws-cli.md
+++ b/docs/technical-setup/environment-setup/configure-aws-cli.md
@@ -5,7 +5,7 @@
     See [Getting Access to Resources](../../getting-started/accessing-resources/index.md) for more information.
 
 The Amazon Web Services (AWS) Command Line Interface (CLI) allows you to interact with AWS via the command line.
-Configuring the AWS CLI is required for using [the download data script](../../getting-started/accessing-resources/getting-access-to-data.md#accessing-data-on-s3) and [uploading your results to S3 for review](STUB_LINK).
+Configuring the AWS CLI is required for using [the download data script](../../getting-started/accessing-resources/getting-access-to-data.md#using-the-download-data-script) and [uploading your results to S3 for review](STUB_LINK).
 
 These instructions assume you have already installed AWS CLI during [conda set up](setup-conda.md#set-up-conda).
 ## Configuring the AWS CLI

--- a/docs/technical-setup/environment-setup/install-r-rstudio.md
+++ b/docs/technical-setup/environment-setup/install-r-rstudio.md
@@ -16,7 +16,7 @@ Please read these instructions carefully even if you already have any of these i
 The official OpenScPCA project version of R is `4.3.3`, so we recommend that you have at least this version installed.
 Please be aware that if you install a different R version and run existing modules, you may get different results.
 
-The instructions provided here are suitable for the vast majority of contributors, but please refer to [this section](#advanced-considerations) for advanced considerations about R installation.
+The instructions provided here are suitable for the vast majority of contributors, but please refer to our section on [advanced considerations about R installation](#advanced-considerations) for more information.
 
 
 ### Install R on macOS
@@ -37,10 +37,10 @@ These tools are available from the [R for macOS website](https://mac.r-project.o
     - You will then be prompted to enter your computer's password
   When you type, no symbols will appear - this is expected!
   Hit enter after your password, and the developer tools will proceed to install
-        - If you receive a message that begins with `xcode-select: note: Command line tools are already installed.`, then you have previously installed this on your system and are all set.
+        - If you receive a message that begins with `xcode-select: note: Command line tools are already installed.`, then you have previously installed this on your system and are all set with this step.
 
 1. Install the **GNU Fortran compiler**.
-Click the link on the [Tools - R for Mac OS](https://mac.r-project.org/tools/) page to download the installer package and follow all installation instructions.
+Click the link on the [Tools - R for Mac OS](https://mac.r-project.org/tools/) page to download the `gfortran` installer package and follow all installation instructions.
 
 <!--
 ### Install R on Windows
@@ -82,4 +82,4 @@ install.packages(c("renv", "BiocManager"))
 
 ## Advanced considerations
 
-If you need to have multiple versions of R installed on your computer, we recommend using the [`rig`](https://github.com/r-lib/rig) R Installation Manager.
+If you need to have multiple versions of R installed on your computer, we recommend using the [`rig` R Installation Manager](https://github.com/r-lib/rig).

--- a/docs/technical-setup/environment-setup/setup-conda.md
+++ b/docs/technical-setup/environment-setup/setup-conda.md
@@ -31,8 +31,8 @@ Miniconda is lightweight version of the full conda platform and includes the con
 To install Miniconda, [download the installer for your operating system](https://docs.anaconda.com/free/miniconda/), and follow all instructions.
 
   - If you are on a macOS computer, be sure to download one of the links ending in `pkg`, _not `bash`_:
-    - If you are on an Apple Silicon (M1-3) mac, download `Miniconda3 macOS Apple M1 64-bit pkg`
-    - If you are on an Intel mac, download `Miniconda3 macOS Intel x86 64-bit pkg`
+    - Apple Silicon (M1-3) mac users should download `Miniconda3 macOS Apple M1 64-bit pkg`
+    - Intel mac users should download `Miniconda3 macOS Intel x86 64-bit pkg`
 
 If you already have conda on your system, you do not need to re-install it.
 
@@ -65,7 +65,7 @@ Copy and paste the following command into the terminal, and hit enter.
     <!-- Do we want to suggest this instead? `conda env update --name base --file environment.yml`? -->
 
     - The [`awscli` package](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) will allow you to interact with [data stored in the Amazon Web Services (AWS) S3 bucket](../../software-platforms/aws/index.md)
-    - The [`conda-lock` package](https://conda.github.io/conda-lock/) is used to create fully reproducible, cross-platform [conda environments for analysis modules](../../contributing-to-analyses/determining-requirements/determining-software-requirements.md#managing-software-dependencies-in-Python-with-conda)
+    - The [`conda-lock` package](https://conda.github.io/conda-lock/) is used to create fully reproducible, cross-platform [conda environments for analysis modules](../../contributing-to-analyses/determining-requirements/determining-software-requirements.md#managing-software-dependencies-in-python-with-conda)
     - The [`jq` package](https://jqlang.github.io/jq/) provides JSON parsing capabilities
     - The [`pre-commit` package](https://pre-commit.com) will allow you to use [pre-commit hooks when contributing to analysis modules](../../contributing-to-analyses/working-with-git/making-commits.md#pre-commit-checks)
 

--- a/docs/technical-setup/environment-setup/setup-precommit.md
+++ b/docs/technical-setup/environment-setup/setup-precommit.md
@@ -37,7 +37,7 @@ We have set up some pre-commit hooks to manage basic code security and catch oth
 During [conda setup](./setup-conda.md/#set-up-conda), you should have installed the `pre-commit` software into your base environment.
 
 To turn on the pre-commit hooks for the OpenScPCA repository, you will need to run the command `pre-commit install` from a terminal window inside the repository.
-We recommend launching [a terminal window in GitKraken](../../software-platforms/general-tools/using-the-terminal.md#how-do-you-access-the-terminal) to do this.
+We recommend launching [a terminal window in GitKraken](../../software-platforms/general-tools/using-the-terminal.md#gitkraken) to do this.
 
 1. Open a terminal window and navigate to the `OpenScPCA` repository.
     - Remember, if you open the terminal within GitKraken, you're automatically in the repository - no extra navigation steps needed!
@@ -51,7 +51,7 @@ We recommend launching [a terminal window in GitKraken](../../software-platforms
 
 1. The terminal should then return this output message showing that you successfully set up your pre-commit hooks:
 
-    ```
+    ```{.bash .no-copy}
     pre-commit installed at .git/hooks/pre-commit
     ```
 
@@ -138,7 +138,7 @@ If you would like to use a code linter, we recommend using [`ruff`](https://docs
 Spell checking is another useful class of tools that can be added as a pre-commit hook.
 Because biological and computational words are often not in default dictionaries, it is most helpful to use a spell checker that looks for common errors rather than one that checks every word against a dictionary.
 
-One such tool is `typos`, which runs quickly to check both text and code for common mistakes.
+One such tool is [`typos`](https://github.com/crate-ci/typos), which runs quickly to check both text and code for common mistakes.
 `typos` can be installed as a pre-commit hook with the following code added to the `.pre-commit-local.yaml` file:
 
 ```yaml

--- a/docs/technical-setup/fork-the-repo.md
+++ b/docs/technical-setup/fork-the-repo.md
@@ -8,8 +8,10 @@ Just like the upstream `AlexsLemonade/OpenScPCA-analysis` repository, your fork 
 
 !!! info "Your fork will be public and openly licensed."
 	Code and other materials you commit to your fork and push to GitHub will be **publicly available** and licensed under the same license as the `AlexsLemonade` repository (Creative Commons Attribution 4.0 International and 3-Clause BSD licenses).
+
+
 	Be careful about what you commit!
-    See [Policies](../policies/index.md) for more information.
+    See our [Policies](../policies/index.md) page for more information.
 
 One benefit of using a fork is that changes you make will not affect the upstream project in `AlexsLemonade/OpenScPCA-analysis`.
 This means you can safely work on your analyses without worrying about messing anything up in the upstream repository.

--- a/docs/technical-setup/install-a-git-client.md
+++ b/docs/technical-setup/install-a-git-client.md
@@ -17,7 +17,8 @@ GitKraken is _free_ to use with public repositories like `OpenScPCA-analysis`; y
 
 ### Install GitKraken
 
-1. Install GitKraken [using this link](https://www.gitkraken.com/download). Note that installing GitKraken will also provide you with Git itself.
+1. Install GitKraken [using this link](https://www.gitkraken.com/download). 
+Note that installing GitKraken will also provide you with Git itself.
 
 1. Set up GitKraken on your machine by [directly signing in with your GitHub account](https://help.gitkraken.com/gitkraken-client/github-gitkraken-client/#sign-in-with-github).
 This will automatically provide you with the credentials you need to interact with GitHub without further setup.

--- a/docs/technical-setup/install-a-git-client.md
+++ b/docs/technical-setup/install-a-git-client.md
@@ -10,16 +10,16 @@ There are many platforms you can choose, but we recommend using either [**GitKra
     This option is best for contributors who are new to Git.
     The OpenScPCA documentation will primarily present how to use Git via GitKraken.
 
-GitKraken is a GUI (graphical-user interface) which lets you "point-and-click" to run all Git commands.
-GitKraken is a more user-friendly option which does not require you to use the command line (aka, terminal) or memorize Git commands.
-It also provides a more streamlined approach to using Git when working on a Windows machine, vs. using the Git command line interface.
-GitKraken is free to use with public repositories like `OpenScPCA-analysis`; you do not need to upgrade to a paid plan.
+GitKraken is a GUI (graphical-user interface) for using Git, meaning you can "point-and-click" to run all Git commands.
+It is therefore a user-friendly option which does not require you to use the command line (aka, terminal) or memorize Git commands.
+
+GitKraken is _free_ to use with public repositories like `OpenScPCA-analysis`; you do not need to upgrade to their paid plan!
 
 ### Install GitKraken
 
-1. Install GitKraken [using this link](https://www.gitkraken.com/download).
+1. Install GitKraken [using this link](https://www.gitkraken.com/download). Note that installing GitKraken will also provide you with Git itself.
 
-2. Set up GitKraken on your machine by [directly signing in with your GitHub account](https://help.gitkraken.com/gitkraken-client/github-gitkraken-client/#sign-in-with-github).
+1. Set up GitKraken on your machine by [directly signing in with your GitHub account](https://help.gitkraken.com/gitkraken-client/github-gitkraken-client/#sign-in-with-github).
 This will automatically provide you with the credentials you need to interact with GitHub without further setup.
 
 
@@ -50,7 +50,7 @@ For this, launch a Terminal window, enter the command shown below, and follow th
 xcode-select --install
 ```
 
-
+<!--
 ### Install Git on Windows
 
 We recommend installing the [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) with the default Ubuntu Linux distribution.
@@ -63,3 +63,4 @@ You can then install Git into your Ubuntu system:
 # Install git
 apt-get install git
 ```
+-->


### PR DESCRIPTION
I'm going through all docs pages and cleaning things up along the way, and this is the first PR to that end. Here, "cleaning up" means:
- Fixing links 
- Rephrasing where appropriate, and other language updates
- Removing deprecated content (eg more Windows)

Here, I've inventoried and cleaned up:

- The repo's README
- docs landing page
- `getting-started`
- `technical-setup`

The main place to look here is `docs/getting-started/explore-analysis.md`, where I made some larger changes. The TOC on this page didn't make much sense to me, so I tried to rearrange a little bit to make some more sense. Please let me know what you think of these changes.

In addition, I wanted to surface a circular link - 
https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/0988548c0dcffe5e7f30b949143b12b437a207c7/docs/getting-started/accessing-resources/getting-access-to-data.md?plain=1#L28-L29
On the `getting-access-to-data.md` page, we redirect them back to the `accessing-resources/index.md` for more information, but the only thing that `index.md` page does is sent them back to `getting-access-to-data.md`! Is there a different relative link we want to send them to? Or, should we remove the sentence entirely?