### PR TITLE
Bug fixes and comment updates for sim-sce scritps

### DIFF
--- a/analyses/simulate-sce/scripts/permute-bulk.R
+++ b/analyses/simulate-sce/scripts/permute-bulk.R
@@ -1,8 +1,8 @@
 #!/usr/bin/env Rscript
 
-# Script to generate simulated single-cell data from a real dataset
+# Script to generate permuted bulk RNAseq data from a real dataset
 
-# Works on a single sample directory at a time, processing all SCE files within that directory.
+# Works on a single bulk file, and permutes the values within each gene
 
 
 # Parse arguments --------------------------------------------------------------

--- a/analyses/simulate-sce/scripts/permute-metadata.R
+++ b/analyses/simulate-sce/scripts/permute-metadata.R
@@ -37,7 +37,7 @@ stopifnot(
 
 set.seed(opts$seed)
 
-metadata <- readr::read_tsv(opts$metadata_file, show_col_types = FALSE)
+metadata <- readr::read_tsv(opts$metadata_file, col_types = readr::cols(.default = "c"))
 
 # fields that apply at library level
 library_fields <- c(

--- a/analyses/simulate-sce/scripts/simulate-sce.R
+++ b/analyses/simulate-sce/scripts/simulate-sce.R
@@ -110,6 +110,7 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
   )
 
   # define a subset of cells to simulate
+  ncells <- min(ncells, ncol(sce))
   cell_subset <- sample.int(ncol(sce), ncells)
   sce_sim <- sce[, cell_subset]
 


### PR DESCRIPTION
While working on https://github.com/AlexsLemonade/OpenScPCA-nf/issues/9, I found a few little bugs/edge cases in the simulation scripts. This PR fixes them:

- Always read the metadata as characters to prevent reading participant ids that look like numbers as floats (converting floats to factors with `forcats::fct_anon()` fails)
- Make sure there are at least `ncells` cells to select from before selecting. This one probably could be "fixed" by allowing resampling, but having a simulated dataset with fewer than 100 cells seems fine.