### PR TITLE
AWS index final touches and remove commented out link in privacy policy

### DIFF
--- a/docs/policies/privacy-policy.md
+++ b/docs/policies/privacy-policy.md
@@ -180,9 +180,6 @@ information, please contact us as described below. To the extent you
 believe we have not addressed your concerns or otherwise choose to do
 so, you have the right to lodge a complaint with a supervisory
 authority in the country where you reside and/or in the United States.
-<!-- For information on how you can file a privacy complaint with the
-Federal Trade Commission, please visit:
-<https://www.ftccomplaintassistant.gov/> -->
 
 9\.  **Important Notices to Non-United States Residents**
 
@@ -220,4 +217,4 @@ that stores information for the OpenScPCA Project.
 Any questions or feedback about the OpenScPCA Project or this Privacy
 Policy should be directed to <ccdl@alexslemonade.org>.
 
-Last Updated: March 28, 2024
+Last Updated: April 5, 2024

--- a/docs/software-platforms/aws/index.md
+++ b/docs/software-platforms/aws/index.md
@@ -6,6 +6,7 @@ We use Amazon Web Services (AWS) to grant contributors access to data and Linux 
     See [Getting Access to Resources](../../getting-started/accessing-resources/index.md) for more information about getting AWS access.
 
     Once we have created an AWS account for you, you can proceed to [set up your account](./joining-aws.md).
+
     Note that your use of AWS services described in this section counts towards your [monthly budget](../../getting-started/accessing-resources/getting-access-to-compute.md#monthly-budget).
 
 ## S3: Data storage with AWS
@@ -16,14 +17,13 @@ All contributors will have a designated [researcher bucket](working-with-s3-buck
 
 Please refer to these pages about working with S3:
 
-- [Locally logging into AWS](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session)
+- [Configuring and logging into AWS from the command line](../../technical-setup/environment-setup/configure-aws-cli.md)
 - [Accessing project data from S3](../../getting-started/accessing-resources/getting-access-to-data.md#accessing-data-on-s3)
 - [Using your researcher bucket](working-with-s3-buckets.md)
 
-## LSfR: Virtual computing with AWS
+## Lightsail for Research: Virtual computing with AWS
 
 As an OpenScPCA contributor, you are eligible for a monthly allocation on [Lightsail for Research (LSfR)](https://aws.amazon.com/lightsail/research/), an Amazon product that allows you to work on a virtual Ubuntu (Linux) Desktop computer in your browser.
-
 
 Please refer to these pages to learn more about setting up and using LSfR:
 

--- a/docs/software-platforms/aws/starting-development-on-lsfr.md
+++ b/docs/software-platforms/aws/starting-development-on-lsfr.md
@@ -1,4 +1,4 @@
-# Getting started with development on Lightsail for Research
+# Developing on Lightsail for Research
 
 Once you have [created a virtual computer](creating-vcs.md), [attached a disk](working-with-volumes.md), and [accessed the operating system](creating-vcs.md#how-to-access-a-virtual-computer) you are ready to start development on Lightsail for Research by taking the following steps:
 


### PR DESCRIPTION
### Which issue does this address?

Closes #79

### Briefly describe the scope of the added docs file, including whether you link out to any external docs.
<!-- If you are adding more than one docs file, how are they related to one another?-->
<!-- Are you adding any visual aids? Or, see next section if you think these docs would benefit from viz. -->

Minor changes to the AWS index:

- Spacing for readability/scannability of the note
- Changing the link to logging into the CLI to be more general
- Spelling out Lightsail for Research (I know S3 is also an acronym, but it is one I expect many people have heard of)

I am also removing the commented-out broken FTC link from the privacy policy, as I have now cleared that with the legal team.

### Will you need additional visual aids for these docs?

No

### Any other comments for reviewers?

Nope