### PR TITLE
Make headers lowercase after first word

### DIFF
--- a/docs/contributing-to-analyses/determining-requirements/determining-compute-requirements.md
+++ b/docs/contributing-to-analyses/determining-requirements/determining-compute-requirements.md
@@ -1,4 +1,4 @@
-# Compute Requirements
+# Compute requirements
 
 We use the term **compute requirements** to refer to the computational resources, such as the number of CPUs or the amount of RAM, that are required for your analysis to run.
 Reporting the compute requirements for running your analysis to project organizers helps us plan for allocating resources on Amazon Web Services (AWS) and to determine how to [review your pull requests](../pr-review-and-merge/index.md) (e.g., using our laptops vs. using AWS). <!-- STUB_LINK: may replace with review-specific page -->

--- a/docs/contributing-to-analyses/determining-requirements/determining-software-requirements.md
+++ b/docs/contributing-to-analyses/determining-requirements/determining-software-requirements.md
@@ -1,4 +1,4 @@
-# Software Requirements
+# Software requirements
 
 ## Determining and managing software dependencies in R
 

--- a/docs/getting-started/accessing-resources/getting-access-to-compute.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-compute.md
@@ -1,4 +1,4 @@
-# Getting Access to Compute
+# Getting access to compute
 
 ## Lightsail for Research
 

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -1,4 +1,4 @@
-# Getting Access to Data
+# Getting access to data
 
 To participate in the OpenScPCA Project, you will need access to the Single-cell Pediatric Cancer Atlas (ScPCA) data.
 Here, we describe several ways to access data.

--- a/docs/getting-started/accessing-resources/index.md
+++ b/docs/getting-started/accessing-resources/index.md
@@ -1,4 +1,4 @@
-# Getting Access to Resources
+# Getting access to resources
 
 We use Amazon Web Services (AWS) to grant contributors access to data and Linux virtual computers.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ This project aims to:
 </div>
 
 
-## Benefits of Participating
+## Benefits of participating
 
 :material-tools:{ .lg .middle }
 **Access to data and tools**


### PR DESCRIPTION
I did a whole sweep of the website and all links seemed good! (#301 ✅ )

But I did find a couple headers that don't follow the overall style of only capitalizing the first word, so I fixed those here.