### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# Default reviewers
+* @alexslemonade/openscpca-admins
+
+# CODEOWNER owner
+/.github/CODEOWNERS @jaclyn-taroni
+
+# Primary reviewers for docs and licenses changes
+/docs/ @dvenprasad @sjspielman
+/CONTRIBUTING.md @sjspielman
+/README.md @sjspielman
+/mkdocs.yml @sjspielman
+/LICENSE.md @jaclyn-taroni
+/SECURITY.md @jaclyn-taroni
+/code-of-conduct.md @jaclyn-taroni
+
+
+# Management scripts and templates
+/create-analysis-module.py @jashapiro
+/download-data.py @jashapiro
+/scripts/sync-results.py @jashapiro
+/templates/ @jashapiro
+/environment.yml @jashapiro
+/.pre-commit-config.yaml @jashapiro
+
+# Primary reviewers for analysis modules
+
+/analyses/hello-python/ @jashapiro
+/analyses/hello-r/ @jashapiro
+/analyses/simulate-sce/ @jashapiro


### PR DESCRIPTION
Closes #286

Here I am adding a codeowners file to allow automatic assignment of reviewers for new submissions. Mostly this is pretty straightforward, but I had to make some decisions that might be worthy of more discussion, so I am filing as a draft.

My general thought was that we would include all data science team members as owners for most of the repo, which would mean that we will all get assigned as reviewers for any new module. Which should be fine, but could get annoying. 
In general, having multiple people as owners will mean that everyone gets more review requests, but it is simple enough to unassign oneself, so it should be okay?

- Administrative and policy files will go to @jaclyn-taroni

- Docs reviews will go to @dvenprasad and @sjspielman (do we want both to be requested?)

- As other modules are developed, an individual owner would be chosen and added to each module: I added myself for the current modules as I have those.


One remaining question is if we want to use github teams to remove some of the overhead of adding and removing individual users when we assign many people. 4 is not too much to manage, but it could be useful for other github features as well, so I think we might want to consider it.