### PR TITLE
Fill out index for PR review and merge process

### DIFF
--- a/docs/contributing-to-analyses/pr-review-and-merge/index.md
+++ b/docs/contributing-to-analyses/pr-review-and-merge/index.md
@@ -1,8 +1,32 @@
-# Code review and merging
+# Code review and merging your pull request
 
-> _More content coming soon!_
+Once you have submitted your [pull request (PR)](../creating-pull-requests/index.md), your PR will be reviewed by a Data Lab team member.
+We will review your code contribution by:
 
-This section provides information about the code review process for [pull requests (PRs)](../creating-pull-requests/index.md) as well as the actions you should take after your PR is merged.
+- Checking for correctness, clarity, and reproducibility in the code
+- Evaluating methods and rationale for any proposed analysis
+- Ensuring that all necessary documentation is present and clear
 
-All PRs will undergo code review by a Data Lab member.
-PRs must be approved before they can be merged into `AlexsLemonade/OpenScPCA-analysis` repository.
+## Overview of the review process
+
+Below is a general overview of what you can expect during the code review process:
+
+1. In most cases, the first time your PR is reviewed a Data Lab member will provide comments and suggestions.
+Feel free to browse some [example reviewer comments](STUB_LINK to example review comments).
+
+1. You will then need to respond to those comments.
+Follow [these guidelines when addressing review comments](STUB_LINK to addressing review comments).
+
+1. Once you have fully addressed comments from the reviewer, then you will be able to re-request a review.
+
+The above steps will repeat until the reviewer feels that all comments have been addressed adequately.
+At that time, the PR will be approved.
+Bear in mind that it is _normal and expected_ for a pull request to undergo multiple rounds of review before it is approved.
+
+## Approved pull requests
+
+Once approved, the PR will be merged into the main branch of `AlexsLemonade/OpenScPCA-analysis` by a Data Lab team member.
+
+!!! tip
+
+    After your PR has been merged, be sure to [sync your fork with `AlexsLemonade/OpenScPCA-analysis`](../working-with-git/staying-in-sync-with-upstream.md) to ensure you are working with the most up to date code.

--- a/docs/contributing-to-analyses/pr-review-and-merge/index.md
+++ b/docs/contributing-to-analyses/pr-review-and-merge/index.md
@@ -11,7 +11,7 @@ We will review your code contribution by:
 
 Below is a general overview of what you can expect during the code review process:
 
-1. In most cases, the first time your PR is reviewed a Data Lab member will provide comments and suggestions.
+1. In most cases, the first time your PR is reviewed by a Data Lab member, they will provide comments and suggestions.
 Feel free to browse some [example reviewer comments](STUB_LINK to example review comments).
 
 1. You will then need to respond to those comments.

--- a/docs/contributing-to-analyses/pr-review-and-merge/index.md
+++ b/docs/contributing-to-analyses/pr-review-and-merge/index.md
@@ -12,10 +12,10 @@ We will review your code contribution by:
 Below is a general overview of what you can expect during the code review process:
 
 1. In most cases, the first time your PR is reviewed by a Data Lab member, they will provide comments and suggestions.
-Feel free to browse some [example reviewer comments](STUB_LINK to example review comments).
+<!-- Feel free to browse some [example reviewer comments](STUB_LINK to example review comments). -->
 
 1. You will then need to respond to those comments.
-Follow [these guidelines when addressing review comments](STUB_LINK to addressing review comments).
+<!-- Follow [these guidelines when addressing review comments](STUB_LINK to addressing review comments).-->
 
 1. Once you have fully addressed comments from the reviewer, then you will be able to re-request a review.
 

--- a/docs/contributing-to-analyses/pr-review-and-merge/index.md
+++ b/docs/contributing-to-analyses/pr-review-and-merge/index.md
@@ -17,7 +17,7 @@ Below is a general overview of what you can expect during the code review proces
 1. You will then need to respond to those comments.
 <!-- Follow [these guidelines when addressing review comments](STUB_LINK to addressing review comments).-->
 
-1. Once you have fully addressed comments from the reviewer, then you will be able to re-request a review.
+3. Once you have fully addressed comments from the reviewer, then you will be able to re-request a review.
 
 The above steps will repeat until the reviewer feels that all comments have been addressed adequately.
 At that time, the PR will be approved.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,7 +126,7 @@ nav:
       - contributing-to-analyses/creating-pull-requests/before-file-pr.md
       - contributing-to-analyses/creating-pull-requests/resolve-merge-conflicts.md
       - contributing-to-analyses/creating-pull-requests/file-pull-request.md
-    - Code review and merging:
+    - Code review and merging your pull request:
       - contributing-to-analyses/pr-review-and-merge/index.md
   - Software platforms:            # AWS (S3 & LSfR), Docker, etc
     - software-platforms/index.md


### PR DESCRIPTION
Closes #116 

This PR populates the index for the code review and merging process. I included some information on what we are looking for in code review and an outline of the steps for review. I added in stub links for the docs we plan on adding (example comments and addressing review comments). 

The last section is on what to do once your PR has been merged. Right now we have a separate doc for this, but I honestly don't think we need that. Unless I'm missing something all they have to do is sync with upstream and we already have a doc on that we can link them to? 

Edit: With the new link checking, should I remove any stub links at this point? And then just note on the issues for each of those docs to add in the links? 