### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /.github/CODEOWNERS @jaclyn-taroni
 
 # Primary reviewers for docs and licenses changes
-/docs/ @dvenprasad @sjspielman
+/docs/ @sjspielman
 /CONTRIBUTING.md @dvenprasad @sjspielman
 /README.md @dvenprasad @sjspielman
 /mkdocs.yml @dvenprasad @sjspielman


### PR DESCRIPTION
This is a quick PR to update the CODEOWNERS file (I did it all in GitHub directly, hence not filed from fork). 

I was in the process of filing a docs PR, and Deepa was automatically set up as the reviewer. I realized we did not update CODEOWNERS based on this conversation - 

https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/366#issuecomment-2056809657
https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/366#issuecomment-2056841163

So, it is thusly updated. I think we might also want to update the next lines (mkdocs, readme, contributing) to default to me too? What do you think?

Something I can't tell though is whether Deepa was the reviewer because she's first, or because I filed it and therefore GitHub was smart enough to not request that I self-review. My guess is the latter.

Noting also for posterity that as I file this PR, indeed Jackie is already noted as the reviewer as expected!
