### PR TITLE
Add typos to dictionary

### DIFF
--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -10,6 +10,7 @@ anonymized
 authenticator
 benchmarking
 bioinformatics
+Bleijs
 Carpentries
 CellAssign
 CLI
@@ -31,12 +32,14 @@ dropdown
 enforceability
 enure
 et
+ewings
 formatters
 Generis
 GFM
 GitHub
 GitKraken
 GitKraken's
+Goodspeed
 GPUs
 HPC
 IAM
@@ -88,6 +91,7 @@ Rtools
 SaaS
 SCE
 ScPCA
+SCPCP
 SemVar
 SingleR
 socio
@@ -105,6 +109,7 @@ TSV
 UMAP
 vCPU
 vCPUs
+Visser
 VSCodium
 WIPO
 WisCon


### PR DESCRIPTION
Closes #388 

This PR fixes some typos flagged by our spellchecker. All "typos" seemed reasonable to me, so I added everything to the dictionary. 
I thought about putting `SCPCP` in backticks instead of adding it to the dictionary, but dictionary seemed like less work especially as more contributors start joining on - this may be a common "typo" and it's easier to have it in the dictionary than fix every instance.