### PR TITLE
Update simulation scripts to match openscpca-nf

### DIFF
--- a/analyses/simulate-sce/scripts/permute-bulk.R
+++ b/analyses/simulate-sce/scripts/permute-bulk.R
@@ -21,7 +21,7 @@ option_list <- list(
     c("-o", "--output_dir"),
     type = "character",
     default = NULL,
-    help = "The output directory. Output files will be given the same names as input"
+    help = "The output directory for the permuted bulk data. Output files will be given the same names as input"
   ),
   make_option(
     c("--seed"),

--- a/analyses/simulate-sce/scripts/permute-metadata.R
+++ b/analyses/simulate-sce/scripts/permute-metadata.R
@@ -17,7 +17,7 @@ option_list <- list(
     c("-o", "--output_file"),
     type = "character",
     default = NULL,
-    help = "The output file path."
+    help = "The output file path for the permuted metadata file."
   ),
   make_option(
     c("--seed"),

--- a/analyses/simulate-sce/scripts/sce-to-anndata.R
+++ b/analyses/simulate-sce/scripts/sce-to-anndata.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env Rscript
 
 # This script takes a directory containing SingleCellExperiment objects as `rds` files and converts each
-# object to an AnnData object or objects saved as an hdf5 file.
+# object to an AnnData object or objects saved as an h5ad file.
 # RNA and ADT data (if present) are saved as separate AnnData objects.
 
 # The AnnData objects being exported by this script is formatted to fit CZI schema: 3.0.0
@@ -38,7 +38,7 @@ suppressPackageStartupMessages({
 
 outfile_name <- function(sce_filename, feature) {
   # create the output file name for each feature
-  suffix <- glue::glue("_{feature}.hdf5")
+  suffix <- glue::glue("_{feature}.h5ad")
   feature_filename <- stringr::str_replace(sce_filename, ".rds$", suffix)
   return(feature_filename)
 }

--- a/analyses/simulate-sce/scripts/simulate-sce.R
+++ b/analyses/simulate-sce/scripts/simulate-sce.R
@@ -111,7 +111,7 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
 
   # define a subset of cells to simulate
   ncells <- min(ncells, ncol(sce))
-  cell_subset <- sample.int(ncol(sce), ncells)
+  cell_subset <- sample(colnames(sce), ncells)
   sce_sim <- sce[, cell_subset]
 
   ### Reduce and remove metadata -----------------------------------------------
@@ -136,10 +136,12 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
 
   # reduce the cell type data matrices, if present
   if (!is.null(metadata(sce_sim)$singler_results)) {
-    metadata(sce_sim)$singler_results <- metadata(sce_sim)$singler_results[cell_subset, ]
+    sim_cells <- cell_subset[cell_subset %in% rownames(metadata(sce_sim)$singler_results)]
+    metadata(sce_sim)$singler_results <- metadata(sce_sim)$singler_results[sim_cells, ]
   }
   if (!is.null(metadata(sce_sim)$cellassign_predictions)) {
-    metadata(sce_sim)$cellassign_predictions <- metadata(sce_sim)$cellassign_predictions[cell_subset, ]
+    sim_cells <- cell_subset[cell_subset %in% rownames(metadata(sce_sim)$cellassign_predictions)]
+    metadata(sce_sim)$cellassign_predictions <- metadata(sce_sim)$cellassign_predictions[sim_cells, ]
   }
 
   # Adjust cluster/cell type labels --------------------------------------------
@@ -247,7 +249,8 @@ simulate_sce <- function(sce, ncells, replacement_metadata, processed) {
 
 set.seed(opts$seed)
 
-metadata <- readr::read_tsv(opts$metadata_file, show_col_types = FALSE)
+# make sure sex is read as a character to prevent all females -> logical false
+metadata <- readr::read_tsv(opts$metadata_file, col_types = readr::cols(sex = "c"))
 
 # get file list
 sce_files <- list.files(


### PR DESCRIPTION
Here I am copying over the script changes from the `openscpca-nf` repository. These make the output files h5ad files and fix a couple of bugs encountered along the way related to potential mismatches between cells in typing results and processed files. 