### PR TITLE
Fix a small typo in error message for download scripts

### DIFF
--- a/download-data.py
+++ b/download-data.py
@@ -391,7 +391,7 @@ def main() -> None:
             "Some project ids do not start with 'SCPCP' as expected.",
             file=sys.stderr,
         )
-    if samples and not all(s.startswith("SCPS") for s in samples):
+    if samples and not all(s.startswith("SCPCS") for s in samples):
         print(
             "Some sample ids do not start with 'SCPCS' as expected.",
             file=sys.stderr,

--- a/download-results.py
+++ b/download-results.py
@@ -234,7 +234,7 @@ def main() -> None:
             "Some project ids do not start with 'SCPCP' as expected.",
             file=sys.stderr,
         )
-    if samples and not all(s.startswith("SCPS") for s in samples):
+    if samples and not all(s.startswith("SCPCS") for s in samples):
         print(
             "Some sample ids do not start with 'SCPCS' as expected.",
             file=sys.stderr,


### PR DESCRIPTION
This just fixes a small typo I found when using the data download script where `SCPCS` was accidentally spelled with `SCPS`. 
