### PR TITLE
Add Docker image building for simulate-sce

### DIFF
--- a/.github/workflows/docker_simulate-sce.yml
+++ b/.github/workflows/docker_simulate-sce.yml
@@ -15,13 +15,12 @@ on:
       - analyses/simulate-sce/conda-lock.yml
   push:
     branches:
-      - jashapiro/docker-simulate-sce
       - main
-    # paths:
-    #   - analyses/simulate-sce/Dockerfile
-    #   - analyses/simulate-sce/.dockerignore
-    #   - analyses/simulate-sce/renv.lock
-    #   - analyses/simulate-sce/conda-lock.yml
+    paths:
+      - analyses/simulate-sce/Dockerfile
+      - analyses/simulate-sce/.dockerignore
+      - analyses/simulate-sce/renv.lock
+      - analyses/simulate-sce/conda-lock.yml
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -31,7 +30,6 @@ jobs:
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
-    environment: "prod"
 
     steps:
       - name: Configure AWS Credentials
@@ -41,14 +39,15 @@ jobs:
           role-session-name: githubActionSession
           aws-region: us-east-1
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Log in to Amazon ECR
         id: login-ecr
+        if: github.event_name == 'push'
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker metadata
         id: meta
@@ -67,5 +66,5 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=public.ecr.aws/${{ env.REGISTRY }}/${{ env.MODULE }}:buildcache
-          cache-to: type=registry,ref=public.ecr.aws/${{ env.REGISTRY }}/${{ env.MODULE }}:buildcache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker_simulate-sce.yml
+++ b/.github/workflows/docker_simulate-sce.yml
@@ -1,0 +1,71 @@
+name: Build docker image for simulate-sce
+env:
+  MODULE: simulate-sce
+  MODULE_PATH: analyses/simulate-sce
+  REGISTRY: openscpca
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - analyses/simulate-sce/Dockerfile
+      - analyses/simulate-sce/.dockerignore
+      - analyses/simulate-sce/renv.lock
+      - analyses/simulate-sce/conda-lock.yml
+  push:
+    branches:
+      - jashapiro/docker-simulate-sce
+      - main
+    # paths:
+    #   - analyses/simulate-sce/Dockerfile
+    #   - analyses/simulate-sce/.dockerignore
+    #   - analyses/simulate-sce/renv.lock
+    #   - analyses/simulate-sce/conda-lock.yml
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    environment: "prod"
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::992382809252:role/GithubOpenId
+          role-session-name: githubActionSession
+          aws-region: us-east-1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: public.ecr.aws/${{ env.REGISTRY }}/${{ env.MODULE }}
+          # tag with semver for releases (will also tag latest), edge for main branch
+          tags: |
+            type=semver,pattern={{raw}}
+            type=edge,branch=main
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:${{ env.MODULE_PATH }}"
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=public.ecr.aws/${{ env.REGISTRY }}/${{ env.MODULE }}:buildcache
+          cache-to: type=registry,ref=public.ecr.aws/${{ env.REGISTRY }}/${{ env.MODULE }}:buildcache,mode=max


### PR DESCRIPTION
As part of #443, I am making a test workflow for building the docker image for the simulate-sce workflow and pushing it to Amazon ECR.

This PR should build only and not require logging in to AWS. Then on push an image should be built and pushed.