### PR TITLE
Add download script option to download metadata

### DIFF
--- a/analyses/simulate-sce/scripts/move-anndata-counts.R
+++ b/analyses/simulate-sce/scripts/move-anndata-counts.R
@@ -1,4 +1,4 @@
-#!usr/bin/env Rscript
+#!/usr/bin/env Rscript
 
 # Script to move the logcounts layer to the X slot in an anndata object
 
@@ -28,16 +28,16 @@ anndata_files <- list.files(
 
 
 # load basilisk
-proc <- basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = 'anndata')
+proc <- basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = "anndata")
 on.exit(basiliskStop(proc))
 
 
 # run a function in the basilisk environment to move elements of files
-basiliskRun(proc, fun = function(files){
+basiliskRun(proc, fun = function(files) {
   adata <- reticulate::import("anndata")
-  for(afile in files){
+  for (afile in files) {
     h5ad <- adata$read_h5ad(afile)
-    if (!is.null(h5ad$layers$get("logcounts"))){
+    if (!is.null(h5ad$layers$get("logcounts"))) {
       h5ad$raw <- h5ad
       h5ad$X <- h5ad$layers["logcounts"]
       h5ad$uns$X_name <- "logcounts"

--- a/download-data.py
+++ b/download-data.py
@@ -225,8 +225,10 @@ def download_release_data(
     ### Print summary messages ###
     print("\n\n\033[1mDownload Summary\033[0m")  # bold
     print("Release:", release)
-    print("Data Format:", ", ".join(formats))
-    print("Processing levels:", ", ".join(stages))
+    if formats:
+        print("Data Format:", ", ".join(formats))
+    if stages:
+        print("Processing levels:", ", ".join(stages))
     if projects:
         print("Projects:", ", ".join(projects))
     if samples:

--- a/download-data.py
+++ b/download-data.py
@@ -321,7 +321,8 @@ def main() -> None:
     parser.add_argument(
         "--include-reports",
         action="store_true",
-        help="Include html report files in the download.",
+        help="Include html report files in the download."
+        " Note that test data does not include report files.",
     )
     parser.add_argument(
         "--data-dir",

--- a/download-data.py
+++ b/download-data.py
@@ -172,7 +172,7 @@ def download_release_data(
     download_dir = data_dir / release
 
     # Always include json, tsv metadata files and DATA_USAGE.md
-    patterns = ["*.json", "*.tsv", "DATA_USAGE.md"]
+    patterns = ["*.json", "*_metadata.tsv", "DATA_USAGE.md"]
 
     # separate bulk from other stages
     include_bulk = "bulk" in stages
@@ -312,6 +312,13 @@ def main() -> None:
         " To switch back, rerun this script with the `--release current` option.",
     )
     parser.add_argument(
+        "--metadata-only",
+        action="store_true",
+        help="Download only the metadata files and not the data files."
+        " To also download QC reports, combined with the --include-reports option."
+        " Can be combined with --projects, but not with --samples. --format and --process-stage are ignored.",
+    )
+    parser.add_argument(
         "--include-reports",
         action="store_true",
         help="Include html report files in the download.",
@@ -364,7 +371,7 @@ def main() -> None:
         )
         sys.exit(1)
 
-    # Check that only a release to test-data was set, and set buckets and default release
+    # Check that only a release or test-data was set, and set buckets and default release
     if args.release and args.test_data:
         print(
             "Only one of `--release` or `--test-data` can be set.",
@@ -380,6 +387,12 @@ def main() -> None:
     if args.projects and args.samples:
         print(
             "Using both `--projects` and `--samples` options together is not supported.",
+            file=sys.stderr,
+        )
+
+    if args.metadata_only and args.samples:
+        print(
+            "Using both `--metadata-only` and `--samples` options together is not supported.",
             file=sys.stderr,
         )
 
@@ -434,6 +447,10 @@ def main() -> None:
             file=sys.stderr,
         )
         sys.exit(1)
+
+    if args.metadata_only:
+        formats = set()
+        stages = set()
 
     ### Download the data ###
     download_release_data(

--- a/download-data.py
+++ b/download-data.py
@@ -347,7 +347,7 @@ def main() -> None:
     args = parser.parse_args()
 
     ### Validate the arguments ###
-
+    validation_error = False
     # Check formats are valid and make a set
     sce_formats = {"sce", "rds"}
     anndata_formats = {"anndata", "h5ad", "hdf5"}
@@ -358,7 +358,7 @@ def main() -> None:
             "Must be 'SCE', 'AnnData', or a comma separated list of those options.",
             file=sys.stderr,
         )
-        sys.exit(1)
+        validation_error = True
 
     # Check include levels are valid & make a set
     process_stages = {"unfiltered", "filtered", "processed", "bulk"}
@@ -369,7 +369,7 @@ def main() -> None:
             "Must be 'processed', 'filtered','unfiltered', 'bulk', or a comma separated list of those.",
             file=sys.stderr,
         )
-        sys.exit(1)
+        validation_error = True
 
     # Check that only a release or test-data was set, and set buckets and default release
     if args.release and args.test_data:
@@ -377,7 +377,7 @@ def main() -> None:
             "Only one of `--release` or `--test-data` can be set.",
             file=sys.stderr,
         )
-        sys.exit(1)
+        validation_error = True
     elif args.test_data:
         bucket = TEST_BUCKET
     else:
@@ -389,12 +389,17 @@ def main() -> None:
             "Using both `--projects` and `--samples` options together is not supported.",
             file=sys.stderr,
         )
+        validation_error = True
 
     if args.metadata_only and args.samples:
         print(
             "Using both `--metadata-only` and `--samples` options together is not supported.",
             file=sys.stderr,
         )
+        validation_error = True
+
+    if validation_error:
+        sys.exit(1)
 
     # check project and sample names
     projects = {p.strip() for p in args.projects.split(",")} if args.projects else {}


### PR DESCRIPTION
Closes #445

I did this a pretty simple way, by just setting the formats and stages to empty sets before download if the metadata option was set. It seems to work, but may need more testing.

While I was at it, I let the argument validation complete before exiting, so people will see multiple errors at once, rather than having to fix one only to get another. 
