### PR TITLE
Make sync verbose again

### DIFF
--- a/scripts/sync-results.py
+++ b/scripts/sync-results.py
@@ -124,7 +124,7 @@ def main() -> None:
     if args.profile:
         sync_cmd += ["--profile", args.profile]
 
-    sync_result = subprocess.run(sync_cmd, capture_output=True, text=True)
+    sync_result = subprocess.run(sync_cmd)
     if sync_result.returncode:
         print(
             f"Error syncing to S3 bucket '{bucket}'.\n"


### PR DESCRIPTION
In #468 I thought I was making the sync script be a bit nicer about errors, but I was really removing all of the output, which was not great. So here I am reverting a line of that change. 