### PR TITLE
Actions for building docker images, alternative model

### DIFF
--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -1,0 +1,33 @@
+# This is a workflow to all of the analysis module workflows
+#
+# This workflow will run with the following triggers
+# - Manual trigger
+# - Periodic running on a timer
+
+name: Run all analysis workflows
+on:
+  workflow_dispatch:
+    inputs:
+      push-ecr:
+        description: "Push to AWS ECR"
+        type: boolean
+        required: false
+
+jobs:
+  # Modules to build Docker images for
+  # Note: only 20 modules can be run per workflow
+  simulate-sce:
+    uses: ./.github/workflows/docker_simulate-sce.yml
+    with:
+      push-ecr: ${{ inputs.push-ecr }}
+
+  ## Add additional modules above this comment, and to the needs list below
+  check-jobs:
+    if: ${{ always() }}
+    needs:
+      - simulate-sce
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures or cancelled jobs
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: echo "Job failed" && exit 1

--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -1,10 +1,9 @@
-# This is a workflow to all of the analysis module workflows
+# This is a workflow to build and optionally push all module Docker images
 #
-# This workflow will run with the following triggers
-# - Manual trigger
-# - Periodic running on a timer
+# This workflow will run only on manual triggers
 
-name: Run all analysis workflows
+
+name: Build all Docker images
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker_simulate-sce.yml
+++ b/.github/workflows/docker_simulate-sce.yml
@@ -23,15 +23,20 @@ on:
       - analyses/simulate-sce/conda-lock.yml
   workflow_dispatch:
     inputs:
-      push:
+      push-ecr:
         description: "Push to AWS ECR"
         type: boolean
         required: false
+  workflow_call:
+    inputs:
+      push-ecr:
+        description: "Push to AWS ECR"
+        type: boolean
 
 jobs:
   test-build:
     name: Test Build Docker Image
-    if: github.event_name == 'pull_request' || !inputs.push
+    if: github.event_name == 'pull_request' || !inputs.push-ecr
     runs-on: ubuntu-latest
 
     steps:
@@ -48,7 +53,7 @@ jobs:
 
   build-push:
     name: Build and Push Docker Image
-    if: github.event_name == 'push' || inputs.push
+    if: github.event_name == 'push' || inputs.push-ecr
     environment: prod
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker_simulate-sce.yml
+++ b/.github/workflows/docker_simulate-sce.yml
@@ -1,8 +1,6 @@
 name: Build docker image for simulate-sce
 env:
   MODULE: simulate-sce
-  MODULE_PATH: analyses/simulate-sce
-  REGISTRY_ALIAS: openscpca
 
 on:
   pull_request:
@@ -23,18 +21,39 @@ on:
       - analyses/simulate-sce/.dockerignore
       - analyses/simulate-sce/renv.lock
       - analyses/simulate-sce/conda-lock.yml
-
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push to AWS ECR"
+        type: boolean
+        required: false
 
 jobs:
-  build:
-    name: Build Docker Image
+  test-build:
+    name: Test Build Docker Image
+    if: github.event_name == 'pull_request' || !inputs.push
     runs-on: ubuntu-latest
 
     steps:
-      - name: Configure AWS Credentials
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:analyses/${{ env.MODULE }}"
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-push:
+    name: Build and Push Docker Image
+    if: github.event_name == 'push' || inputs.push
+    environment: prod
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::992382809252:role/GithubOpenId
@@ -43,18 +62,15 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        if: github.event_name == 'push'
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
 
       - name: Create ECR repository if needed
         id: create-ecr
-        if: github.event_name == 'push'
         run: |
           aws ecr-public describe-repositories --repository-names ${{ env.MODULE }} \
           || aws ecr-public create-repository --repository-name ${{ env.MODULE }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -62,20 +78,15 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: public.ecr.aws/${{ env.REGISTRY_ALIAS }}/${{ env.MODULE }}
-          # tag with 'latest' for main branch pushes, semantic version for releases/tags, and the branch name for PRs
-          # PR tags are just for convenience and to avoid warnings, as those builds are not pushed
+          images: public.ecr.aws/openscpca/${{ env.MODULE }}
+          # tag with 'latest' for main branch pushes, semantic version for releases/tags
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{raw}}
-            type=ref,event=pr
-
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:${{ env.MODULE_PATH }}"
-          push: ${{ github.event_name == 'push'}}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR is an alternative approach to that taken in #459.

Rather than have one workflow that builds and pushes all of the docker images, with separate workflows for each individual module to test the build only, this keeps both build only and build-push workflows together for each module.
To build all modules, we then have a separate workflow that calls all the others.

The logic in this version is substantially simpler, as each workflow determines when it is triggered, so we save the step of having to determine for ourselves which modules have been modified: if the trigger files are modified, the workflow gets triggered.

The one disadvantage is that while the matrix workflow could incorporate up to 256 individual docker images, the workflow job here can only do 20, so we would potentially need multiple workflows.

There is an alternative here though, which I just thought of: we could move the build-push job out to its own workflow, then have the run-all version use that as well, as a matrix job. Assuming that all workflows have the same steps, that ought to work. I'm going to stack that version onto this one.