### PR TITLE
Use matrix for multiple modules

### DIFF
--- a/.github/workflows/build-push-docker-module.yml
+++ b/.github/workflows/build-push-docker-module.yml
@@ -1,0 +1,57 @@
+name: Build and push a docker image for a module
+
+on:
+  workflow_call:
+    inputs:
+      module:
+        required: true
+        type: string
+      push-ecr:
+        description: "Push to AWS ECR"
+        type: boolean
+
+jobs:
+  build-push:
+    name: Build and Push Docker Image
+    if: inputs.push-ecr
+    environment: prod
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::992382809252:role/GithubOpenId
+          role-session-name: githubActionSession
+          aws-region: us-east-1
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Create ECR repository if needed
+        id: create-ecr
+        run: |
+          aws ecr-public describe-repositories --repository-names ${{ inputs.module }} \
+          || aws ecr-public create-repository --repository-name ${{ inputs.module }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: public.ecr.aws/openscpca/${{ inputs.module }}
+          # tag with 'latest' for main branch pushes, semantic version for releases/tags
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{raw}}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha

--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -2,7 +2,6 @@
 #
 # This workflow will run only on manual triggers
 
-
 name: Build all Docker images
 on:
   workflow_dispatch:
@@ -13,18 +12,21 @@ on:
         required: false
 
 jobs:
-  # Modules to build Docker images for
-  # Note: only 20 modules can be run per workflow
-  simulate-sce:
-    uses: ./.github/workflows/docker_simulate-sce.yml
+  build-docker-modules:
+    uses: ./.github/workflows/build-push-docker-module.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - simulate-sce
     with:
+      module: ${{ matrix.module }}
       push-ecr: ${{ inputs.push-ecr }}
 
-  ## Add additional modules above this comment, and to the needs list below
   check-jobs:
-    if: ${{ always() }}
+    if: always()
     needs:
-      - simulate-sce
+      - build-docker-modules
     runs-on: ubuntu-latest
     steps:
       - name: Check for failures or cancelled jobs

--- a/.github/workflows/docker_simulate-sce.yml
+++ b/.github/workflows/docker_simulate-sce.yml
@@ -1,6 +1,4 @@
 name: Build docker image for simulate-sce
-env:
-  MODULE: simulate-sce
 
 on:
   pull_request:
@@ -46,52 +44,14 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v5
         with:
-          context: "{{defaultContext}}:analyses/${{ env.MODULE }}"
+          context: "{{defaultContext}}:analyses/simulate-sce"
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   build-push:
-    name: Build and Push Docker Image
+    uses: ./.github/workflows/build-push-docker-module.yml
     if: github.event_name == 'push' || inputs.push-ecr
-    environment: prod
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::992382809252:role/GithubOpenId
-          role-session-name: githubActionSession
-          aws-region: us-east-1
-
-      - name: Log in to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registry-type: public
-
-      - name: Create ECR repository if needed
-        id: create-ecr
-        run: |
-          aws ecr-public describe-repositories --repository-names ${{ env.MODULE }} \
-          || aws ecr-public create-repository --repository-name ${{ env.MODULE }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: public.ecr.aws/openscpca/${{ env.MODULE }}
-          # tag with 'latest' for main branch pushes, semantic version for releases/tags
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{raw}}
-      - name: Build and push image
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+    with:
+      module: simulate-sce
+      push-ecr: true


### PR DESCRIPTION
Stacked on #474

This PR pulls out the docker build-push action to its own workflow and then calls that from both the individual docker build actions and the all-module action

The one concern I have with this one is whether the github variable info that determines the docker tags  in the build action will be passed on properly from the calling workflows. This should be easy enough to test in practice (as well as by reading the docs carefully), but I _think_ they will? If not, there are workarounds.

