### PR TITLE
GHAs should run on reproducibility branch

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - reproducibility-docs
+      - feature/*
     paths:
       - docs/**
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,7 +1,9 @@
 name: Check docs links
 on:
   pull_request:
-    branches: main
+    branches:
+      - main
+      - reproducibility-docs
     paths:
       - docs/**
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - reproducibility-docs
+      - feature/*
     paths:
       - docs/**
   workflow_dispatch:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,7 +1,9 @@
 name: Check Spelling
 on:
   pull_request:
-    branches: main
+    branches:
+      - main
+      - reproducibility-docs
     paths:
       - docs/**
   workflow_dispatch:


### PR DESCRIPTION
This PR cherry-picks a commit from #503 to get it in sooner - we should run the link check and spell check actions on the reproducibility branch.