### PR TITLE
Add tip for environment.yml creation

### DIFF
--- a/docs/ensuring-repro/managing-software/using-conda.md
+++ b/docs/ensuring-repro/managing-software/using-conda.md
@@ -28,7 +28,14 @@ You can activate the environment by running the following command:
 conda activate openscpca-{module_name}
 ```
 
-If no `environment.yml` file is present, you can create and activate a new environment for the module by running the following command from the module's root directory, replacing `{module_name}` with the name of the module you are working on:
+If no `environment.yml` file is present, you can create and activate a new environment for the module by running the following command from the module's root directory, replacing `{module_name}` with the name of the module you are working on.
+
+!!! tip
+    Before you create an `environment.yml` file, make sure you have already activated the `openscpca` environment by running the following:
+
+    ```bash
+    conda activate openscpca
+    ```
 
 ```bash
 conda env create --file environment.yml --name openscpca-{module_name}

--- a/docs/ensuring-repro/managing-software/using-conda.md
+++ b/docs/ensuring-repro/managing-software/using-conda.md
@@ -28,7 +28,7 @@ You can activate the environment by running the following command:
 conda activate openscpca-{module_name}
 ```
 
-If you are working on an existing module for the first time,  and an `environment.yml` file is present, you can create and activate a new environment for the module by running the following command from the module's root directory, replacing `{module_name}` with the name of the module you are working on:
+If you are working on an existing module for the first time and an `environment.yml` file is present, you can create and activate a new environment for the module by running the following command from the module's root directory, replacing `{module_name}` with the name of the module you are working on:
 
 ```bash
 conda env create --file environment.yml --name openscpca-{module_name}

--- a/docs/ensuring-repro/managing-software/using-conda.md
+++ b/docs/ensuring-repro/managing-software/using-conda.md
@@ -28,14 +28,7 @@ You can activate the environment by running the following command:
 conda activate openscpca-{module_name}
 ```
 
-If no `environment.yml` file is present, you can create and activate a new environment for the module by running the following command from the module's root directory, replacing `{module_name}` with the name of the module you are working on.
-
-!!! tip
-    Before you create an `environment.yml` file, make sure you have already activated the `openscpca` environment by running the following:
-
-    ```bash
-    conda activate openscpca
-    ```
+If you are working on an existing module for the first time,  and an `environment.yml` file is present, you can create and activate a new environment for the module by running the following command from the module's root directory, replacing `{module_name}` with the name of the module you are working on:
 
 ```bash
 conda env create --file environment.yml --name openscpca-{module_name}


### PR DESCRIPTION
~Closes #449~

I was looking over our freshly rearranged docs to determine what we really need to do for #449. It turns out that the docs rearrangement really did make a difference here! The only thing I really thought to add was a tip to make sure you're creating the new environment from the `openscpca` environment. Note that I also opened #521 to make sure we document this more generally (we only currently say it during conda setup).
