### PR TITLE
Add Docker GHA docs

### DIFF
--- a/docs/ensuring-repro/workflows/build-docker-gha.md
+++ b/docs/ensuring-repro/workflows/build-docker-gha.md
@@ -1,0 +1,28 @@
+# Automated Dockerfile building
+
+We use [GitHub Actions](https://docs.github.com/en/actions) (GHAs) to build Dockerfiles and push images to [Amazon ECR](https://aws.amazon.com/ecr/), a registry of containers such as Docker images.
+
+Docker building GHAs are automatically run in two circumstances:
+
+- When a pull request is filed with changes to any module's environment files, such as `renv.lock`, `conda.lock`, or the `Dockerfile` itself
+- When new `OpenScPCA-analysis` releases are made
+
+
+These pushed images are used in a variety of ways:
+
+- The `OpenScPCA-nf` workflow pulls module-specific Docker images to reprodubibly run modules and generate results <!-- STUB_LINK openscpca-nf -->
+- [Module testing GHAs](./run-module-gha.md) will, as the given analysis module matures, pull the Docker-specific Docker image to create the environment used in the workflow
+- OpenScPCA contributors, as well as the wider research community, can freely pull module-specific images to reproducibly run OpenScPCA analysis modules, for example to locally run analysis modules or to develop within a Docker container
+
+For examples of existing Docker building GHAs, see the example `simulate-sce` GHA [`docker_simulate-sce.yml`](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/.github/workflows/docker_simulate-sce.yml).
+
+
+## Writing a Docker building GHA
+
+!!! tip
+    The Data Lab will generally maintain and write Docker building GHAs, but you are welcome to do so as well if you are interested!
+    See this GitHub documentation to learn about [workflow syntax for GHAs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+
+When you [create a new module](../../contributing-to-analyses/analysis-modules/creating-a-module.md), a Docker building GHA workflow file is created in the file `.github/workflows/docker_{module-name}.yml`.
+This initial file is inactive, meaning it will not run automatically run on the two aforementioned triggers.
+As analysis module matures over time, the Data Lab staff will activate this GHA file so the Docker image can be built and pushed to the Amazon ECR registry for general use.

--- a/docs/ensuring-repro/workflows/index.md
+++ b/docs/ensuring-repro/workflows/index.md
@@ -1,3 +1,10 @@
-# OpenScPCA workflows
+# OpenScPCA GitHub Action workflows
 
-_Content forthcoming._
+OpenScPCA uses [GitHub Actions](https://docs.github.com/en/actions) to automatically run several workflows that support overall reproducibility.
+
+This section highlights two of these workflows:
+
+1. [A module-testing workflow](./run-module-gha.md) which ensures that analysis modules can run without errors
+2. [A Docker-building workflow](./build-docker-gha.md) which builds and pushes module-specific Docker images to a public registry
+
+Generally, the Data Lab maintains and writes these GHA workflow files, but you are welcome to contribute as well if you are interested.

--- a/docs/ensuring-repro/workflows/run-module-gha.md
+++ b/docs/ensuring-repro/workflows/run-module-gha.md
@@ -41,7 +41,7 @@ Each module testing GHA is initially created with these steps, which should be u
     - Use the [`download-data.py`](../../getting-started/accessing-resources/getting-access-to-data.md#using-the-download-data-script) and/or [`download-results.py`](../../getting-started/accessing-resources/getting-access-to-data.md#accessing-scpca-module-results) scripts to specify the set of input files you need, with the `--test-data` flag to specify downloading the test data.
     - After this step, the `data/current` directory will point to the test data, ensuring the module GHA runs using the test data.
 - Set up the module environment
-    - Depending on [the flags used when creating your module](../../contributing-to-analyses/analysis-modules/creating-a-module.md#module-creation-script-flags), this will steps steps needed to install the [`renv` and/or conda environment](../managing-software/index.md) from existing environment files (`renv.lock` and/or `conda-lock.yml`, respectively).
+    - Depending on [the flags used when creating your module](../../contributing-to-analyses/analysis-modules/creating-a-module.md#module-creation-script-flags), these steps will install the [`renv` and/or conda environment](../managing-software/index.md) from existing environment files (`renv.lock` and/or `conda-lock.yml`, respectively).
 - Run the analysis module
     - Generally, this will involve calling the [module's run script](../../contributing-to-analyses/analysis-modules/running-a-module.md).
 

--- a/docs/ensuring-repro/workflows/run-module-gha.md
+++ b/docs/ensuring-repro/workflows/run-module-gha.md
@@ -28,9 +28,9 @@ This way, the module testing GHA can directly call this script to execute the en
     The Data Lab will generally maintain and write module testing GHAs, but you are welcome to do so as well if you are interested!
     See this GitHub documentation to learn about [workflow syntax for GHAs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
 
-When you [create a new module](../../contributing-to-analyses/analysis-modules/creating-a-module.md), a GHA workflow file is created in the file `.github/workflows/run_{module-name}.yml`.
+When you [create a new module](../../contributing-to-analyses/analysis-modules/creating-a-module.md), a moduel testing GHA workflow file is created in the file `.github/workflows/run_{module-name}.yml`.
 This initial file is inactive, meaning it will not run automatically run on the two aforementioned triggers.
-As analysis module begins to mature over time, the Data Lab staff will activate this workflow file so the module can be regularly tested.
+As analysis module matures over time, the Data Lab staff will activate this GHA file so the module can be regularly tested.
 
 ### GHA steps
 

--- a/docs/ensuring-repro/workflows/run-module-gha.md
+++ b/docs/ensuring-repro/workflows/run-module-gha.md
@@ -45,5 +45,5 @@ Each module testing GHA is initially created with these steps, which should be u
 - Run the analysis module
     - Generally, this will involve calling the [module's run script](../../contributing-to-analyses/analysis-modules/running-a-module.md).
 
-As an analysis module matures, the GHA will be updated to run the analysis in the module's Docker image, rather than using the `renv` and/or conda environment files.
+As an analysis module matures, the GHA will be updated to run the analysis in the [module's Docker image](../docker/docker-images.md), rather than using the `renv` and/or conda environment files.
 Module testing GHAs can use their module's Docker images once the image has been built and pushed to the registry. <!-- STUB LINK building/updating docker images -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
     - OpenScPCA workflows:
       - ensuring-repro/workflows/index.md
       - ensuring-repro/workflows/run-module-gha.md
+      - ensuring-repro/workflows/build-docker-gha.md
     - Managing module software:
       - ensuring-repro/managing-software/index.md
       - ensuring-repro/managing-software/using-renv.md


### PR DESCRIPTION
Closes #518 
Closes #514 

Here, I'm adding docs for the docker building GHA as well as the index file (which is pretty brief) for this section. I made a few wording tweaks the module GHA docs as well for consistency, and also there was one part that was simply wrong/bad....

Originally, I had planned to also mention something in these docs about the order of operations for updating modules and docker images. But, it seemed to me that that information made better sense in #497 (where we already plan to write about it anyways), and it didn't quite fit into the overall logic of this page, which I ended up writing to largely mirror the module GHA page. This page has somewhat fewer details because, well, I think this GHA has fewer details to communicate! Please let me know which missing details should make the cut.