### PR TITLE
Add tagged push to all docker release

### DIFF
--- a/.github/workflows/build-push-docker-module.yml
+++ b/.github/workflows/build-push-docker-module.yml
@@ -13,6 +13,10 @@ on:
         description: "Push to AWS ECR"
         type: boolean
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-push:
     name: Build and Push Docker Image

--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -7,12 +7,17 @@
 # This workflow will run on:
 # - Manual trigger
 # - Periodic scheduled runs
+# - Tagged version releases
 
 name: Build all Docker images
 on:
   schedule:
     # run monthly on the 1st
     - cron: "0 0 1 * *"
+  push:
+    # build and push all on tagged release
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       push-ecr:
@@ -34,7 +39,7 @@ jobs:
     uses: ./.github/workflows/build-push-docker-module.yml
     with:
       module: ${{ matrix.module }}
-      push-ecr: ${{ inputs.push-ecr }}
+      push-ecr: ${{ github.event_name == 'push' || inputs.push-ecr }}
 
   check-jobs:
     name: Check Job Status


### PR DESCRIPTION
A small PR to add pushing docker images when there is a semantically tagged release of the repository as a whole.

This somehow slipped through earlier docker image building updates.
