### PR TITLE
Add token permissions to Docker build/push workflow

### DIFF
--- a/.github/workflows/build-push-docker-module.yml
+++ b/.github/workflows/build-push-docker-module.yml
@@ -13,6 +13,10 @@ on:
         description: "Push to AWS ECR"
         type: boolean
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-push:
     name: Build and Push Docker Image


### PR DESCRIPTION
We need to fetch a token for this workflow ([ref](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#adding-permissions-settings)). I expect that would fix the error we saw in: https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/runs/9569918033/workflow