### PR TITLE
Docs: using docker images

### DIFF
--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -47,6 +47,7 @@ Dockerfile
 doxxing
 dropdown
 ECM
+ECR
 enforceability
 enure
 Ensembl

--- a/docs/ensuring-repro/docker/index.md
+++ b/docs/ensuring-repro/docker/index.md
@@ -12,9 +12,11 @@ By using the same Docker image, contributors can run the same analysis on differ
 
     For more information on Docker, see:
 
-    - [Docker for Data Science](https://www.datacamp.com/tutorial/docker-for-data-science-introduction)
     - [Why you should use Docker in your research](https://blog.zooniverse.org/2018/07/17/why-you-should-use-docker-in-your-research/)
-    - [Docker images and how we use them in OpenScPCA](docker-images.md)
+    - [Digging into Data Science Tools: Docker](https://towardsdatascience.com/digging-into-data-science-tools-docker-bbb9f3579c87)
+    - [A short guide to using Docker for your data science environment](https://towardsdatascience.com/a-short-guide-to-using-docker-for-your-data-science-environment-912617b3603e)
+    - [Docker for Data Science](https://www.datacamp.com/tutorial/docker-for-data-science-introduction)
+    - [Docker Desktop documentation](https://docs.docker.com/desktop/use-desktop/)
 
 ## Why do I need Docker?
 

--- a/docs/ensuring-repro/docker/using-images.md
+++ b/docs/ensuring-repro/docker/using-images.md
@@ -20,7 +20,7 @@ Images are named `openscpca/{module-name}`.
 
 To obtain a local copy of a Docker image, follow these steps:
 
-1. Open the Docker Desktop application and ensure sure it is running.
+1. Open the Docker Desktop application and ensure it is running.
 2. From a [terminal](../../getting-started/project-tools/using-the-terminal.md), pull the image using this command, where `{module-name}` is replaced with the given Docker image you wish to pull:
 
       ```sh

--- a/docs/ensuring-repro/docker/using-images.md
+++ b/docs/ensuring-repro/docker/using-images.md
@@ -15,15 +15,13 @@ The OpenScPCA Docker register is publicly available at <https://gallery.ecr.aws/
 
 ## Obtaining Docker images
 
-<!-- TODO: Instructions for using images on LSfR? -->
-
 You can see all available OpenScPCA Docker images at this URL: <https://gallery.ecr.aws/openscpca/>.
 Images are named `openscpca/{module-name}`.
 
 To obtain a local copy of a Docker image, follow these steps:
 
 1. Open the Docker Desktop application and ensure sure it is running.
-1. From a [terminal](../../getting-started/project-tools/using-the-terminal.md), pull the image using this command, where `{module-name}` is replaced with the given Docker image you wish to pull:
+2. From a [terminal](../../getting-started/project-tools/using-the-terminal.md), pull the image using this command, where `{module-name}` is replaced with the given Docker image you wish to pull:
 
       ```sh
       docker pull public.ecr.aws/openscpca/{module-name}:latest
@@ -36,10 +34,10 @@ To obtain a local copy of a Docker image, follow these steps:
           docker pull --platform linux/x86_64 public.ecr.aws/openscpca/{module-name}:latest
           ```
 
-1. We recommend updating your Docker Desktop resource settings to ensure Docker has access to sufficient compute resources to run the module. For more information on module compute requirements, please refer to the [module's `README.md` file](../../contributing-to-analyses/analysis-modules/compute-requirements.md#readme-files).
+3. We recommend updating your Docker Desktop resource settings to ensure Docker has access to sufficient compute resources to run the module. For more information on module compute requirements, please refer to the [module's `README.md` file](../../contributing-to-analyses/analysis-modules/compute-requirements.md#readme-files).
       - Follow these instructions to update your Docker Desktop settings for [Mac](https://docs.docker.com/desktop/settings/mac#resources) and [Windows](https://docs.docker.com/desktop/settings/windows/#resources) computers. You will need to click "Apply and Restart" to ensure these changes go through.
 
-1. You can now use the image to run code from the analysis module using [the `docker run` command](https://docs.docker.com/reference/cli/docker/container/run/) from a terminal.
+4. You can now use the image to run code from the analysis module using [the `docker run` command](https://docs.docker.com/reference/cli/docker/container/run/) from a terminal.
       - The analysis module's `README.md` file should contain documentation for what command(s) you need to issue to [run the module](../../contributing-to-analyses/analysis-modules/running-a-module.md).
       - You will also need to [mount a volume](https://docs.docker.com/storage/volumes/) as part of your command to ensure that the Docker container has access to all files needed, including any data files.
       - Note that containers for [images based on `bioconductor/r-ver`](./docker-images.md#r-based-images) can also be run in the browser as interactive RStudio Server sessions, [as described in the Bioconductor documentation](https://www.bioconductor.org/help/docker/).

--- a/docs/ensuring-repro/docker/using-images.md
+++ b/docs/ensuring-repro/docker/using-images.md
@@ -1,0 +1,47 @@
+# Using Docker images
+
+Once a module's Docker image has been [pushed to the OpenScPCA Docker registry in the Amazon ECR Public Gallery](#STUB_LINK/workflows/build-docker-gha.md), you can obtain the image to locally run modules in a reproducible environment.
+While modules can also be run within specified [conda and/or `renv` environments](../managing-software/index.md), using Docker images provides a more streamlined (but advanced) approach to ensuring a fully reproducible software environment.
+
+The OpenScPCA Docker register is publicly available at <https://gallery.ecr.aws/openscpca/> and contains Docker images with tags of the form `public.ecr.aws/openscpca/{module-name}:latest`.
+
+!!! note
+      This page presents the main steps for obtaining and running a module in a Docker image.
+      These instructions assume that you have already [downloaded Docker Desktop](./index.md#how-to-install-docker) and are familiar with using Docker images and launching containers.
+
+      To learn more about using Docker, see our recommended resources [on this page](./index.md).
+
+      If you would like to see additional dociumentation about working with Docker images, please [let us know by filing an issue](https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/new?assignees=&labels=docs-request&projects=&template=04-docs-request.yml&title=Docs+request%3A).
+
+## Obtaining Docker images
+
+<!-- TODO: Instructions for using images on LSfR? -->
+
+You can see all available OpenScPCA Docker images at this URL: <https://gallery.ecr.aws/openscpca/>.
+Images are named `openscpca/{module-name}`.
+
+To obtain a local copy of a Docker image, follow these steps:
+
+1. Open the Docker Desktop application and ensure sure it is running.
+1. From a [terminal](../../getting-started/project-tools/using-the-terminal.md), pull the image using this command, where `{module-name}` is replaced with the given Docker image you wish to pull:
+
+      ```sh
+      docker pull public.ecr.aws/openscpca/{module-name}:latest
+      ```
+
+    !!! tip "Macs with Apple silicon"
+          If you are using an Apple silicon (M1-3) Mac, you will need to use the additional flag `--platform linux/x86_64` when pulling an image:
+
+          ```sh
+          docker pull --platform linux/x86_64 public.ecr.aws/openscpca/{module-name}:latest
+          ```
+
+1. We recommend updating your Docker Desktop resource settings to ensure Docker has access to sufficient compute resources to run the module. For more information on module compute requirements, please refer to the [module's `README.md` file](../../contributing-to-analyses/analysis-modules/compute-requirements.md#readme-files).
+      - Follow these instructions to update your Docker Desktop settings for [Mac](https://docs.docker.com/desktop/settings/mac#resources) and [Windows](https://docs.docker.com/desktop/settings/windows/#resources) computers. You will need to click "Apply and Restart" to ensure these changes go through.
+
+1. You can now use the image to run code from the analysis module using [the `docker run` command](https://docs.docker.com/reference/cli/docker/container/run/) from a terminal.
+      - The analysis module's `README.md` file should contain documentation for what command(s) you need to issue to [run the module](../../contributing-to-analyses/analysis-modules/running-a-module.md).
+      - You will also need to [mount a volume](https://docs.docker.com/storage/volumes/) as part of your command to ensure that the Docker container has access to all files needed, including any data files.
+      - Note that containers for [images based on `bioconductor/r-ver`](./docker-images.md#r-based-images) can also be run in the browser as interactive RStudio Server sessions, [as described in the Bioconductor documentation](https://www.bioconductor.org/help/docker/).
+
+

--- a/docs/ensuring-repro/docker/using-images.md
+++ b/docs/ensuring-repro/docker/using-images.md
@@ -1,9 +1,8 @@
 # Using Docker images
 
+Each OpenScPCA analysis module has [its own Docker image](./docker-images.md) to create a fully reproducible environment for running the module.
 Once a module's Docker image has been [pushed to the OpenScPCA Docker registry in the Amazon ECR Public Gallery](#STUB_LINK/workflows/build-docker-gha.md), you can obtain the image to locally run modules in a reproducible environment.
 While modules can also be run within specified [conda and/or `renv` environments](../managing-software/index.md), using Docker images provides a more streamlined (but advanced) approach to ensuring a fully reproducible software environment.
-
-The OpenScPCA Docker register is publicly available at <https://gallery.ecr.aws/openscpca/> and contains Docker images with tags of the form `public.ecr.aws/openscpca/{module-name}:latest`.
 
 !!! note
       This page presents the main steps for obtaining and running a module in a Docker image.
@@ -15,8 +14,11 @@ The OpenScPCA Docker register is publicly available at <https://gallery.ecr.aws/
 
 ## Obtaining Docker images
 
-You can see all available OpenScPCA Docker images at this URL: <https://gallery.ecr.aws/openscpca/>.
-Images are named `openscpca/{module-name}`.
+The OpenScPCA Docker register is publicly available at <https://gallery.ecr.aws/openscpca/> and lists all available OpenScPCA Docker images, which are named with tags of the form `public.ecr.aws/openscpca/{module-name}:latest`.
+
+!!! tip "All Docker images have lowercase names"
+      OpenScPCA Docker images are named `openscpca/{module-name}`, where `{module-name}` is a lowercase version of the module name.
+      For example, the Docker image for a module called `hello-R` would be named `openscpca/hello-r`.
 
 To obtain a local copy of a Docker image, follow these steps:
 
@@ -28,18 +30,48 @@ To obtain a local copy of a Docker image, follow these steps:
       ```
 
     !!! tip "Macs with Apple silicon"
-          If you are using an Apple silicon (M1-3) Mac, you will need to use the additional flag `--platform linux/x86_64` when pulling an image:
+          If you are using an Apple silicon (M1-3) Mac, you will need to use the additional flag `--platform linux/x86_64` when pulling an image.
+          Note that the flag `--platform linux/x86_64` _must_ be provided before the image name.
 
           ```sh
           docker pull --platform linux/x86_64 public.ecr.aws/openscpca/{module-name}:latest
           ```
 
-3. We recommend updating your Docker Desktop resource settings to ensure Docker has access to sufficient compute resources to run the module. For more information on module compute requirements, please refer to the [module's `README.md` file](../../contributing-to-analyses/analysis-modules/compute-requirements.md#readme-files).
-      - Follow these instructions to update your Docker Desktop settings for [Mac](https://docs.docker.com/desktop/settings/mac#resources) and [Windows](https://docs.docker.com/desktop/settings/windows/#resources) computers. You will need to click "Apply and Restart" to ensure these changes go through.
+## Running Docker images
 
-4. You can now use the image to run code from the analysis module using [the `docker run` command](https://docs.docker.com/reference/cli/docker/container/run/) from a terminal.
-      - The analysis module's `README.md` file should contain documentation for what command(s) you need to issue to [run the module](../../contributing-to-analyses/analysis-modules/running-a-module.md).
-      - You will also need to [mount a volume](https://docs.docker.com/storage/volumes/) as part of your command to ensure that the Docker container has access to all files needed, including any data files.
-      - Note that containers for [images based on `bioconductor/r-ver`](./docker-images.md#r-based-images) can also be run in the browser as interactive RStudio Server sessions, [as described in the Bioconductor documentation](https://www.bioconductor.org/help/docker/).
+### Update your resource settings
+
+Before running any Docker image, we recommend updating your Docker Desktop resource settings to ensure Docker has access to sufficient compute resources to run the module. For more information on module compute requirements, please refer to the [module's `README.md` file](../../contributing-to-analyses/analysis-modules/compute-requirements.md#readme-files).
+
+Follow these instructions to update your Docker Desktop settings for [Mac](https://docs.docker.com/desktop/settings/mac#resources) and [Windows](https://docs.docker.com/desktop/settings/windows/#resources) computers. You will need to click "Apply and Restart" to ensure these changes go through.
+
+### Using `docker run`
+
+You can now use the image to run the analysis module in a container using [the `docker run` command](https://docs.docker.com/reference/cli/docker/container/run/) from a terminal.
+The analysis module's `README.md` file should contain documentation for what command(s) you need to issue to [run the module](../../contributing-to-analyses/analysis-modules/running-a-module.md).
+
+When launching a container, you should mount the `OpenScPCA-analysis` repository directory as a volume in the Docker image, rather than just the analysis module directory itself.
+This way, the Docker container will have access to the full project repository including the `data` directory where most module input data is stored.
+
+For example, you might launch a Bash session in a container with the following line, which will mount your `OpenScPCA-analysis` directory into the container's `/home` directory.
+Once launched, you can navigate to the analysis module of interest and run its code.
+
+```sh
+docker run \
+  -it \
+  --rm \
+  --mount type=bind,source=/local/path/to/OpenScPCA-analysis,target=/home/OpenScPCA-analysis \
+  public.ecr.aws/openscpca/{module-name}:latest \
+  bash
+```
+
+!!! tip "Macs with Apple silicon"
+      If you are using an Apple silicon (M1-3) Mac, you may see this warning when launching the container:
+
+      ```{.console .no-copy}
+      WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+      ```
+
+      You can safely ignore this warning, or you can silence it by providing the flag `--platform linux/x86_64` to your `docker run` command.
 
 

--- a/docs/ensuring-repro/docker/using-images.md
+++ b/docs/ensuring-repro/docker/using-images.md
@@ -41,9 +41,11 @@ To obtain a local copy of a Docker image, follow these steps:
 
 ### Update your resource settings
 
-Before running any Docker image, we recommend updating your Docker Desktop resource settings to ensure Docker has access to sufficient compute resources to run the module. For more information on module compute requirements, please refer to the [module's `README.md` file](../../contributing-to-analyses/analysis-modules/compute-requirements.md#readme-files).
+Before running any Docker image, we recommend updating your Docker Desktop resource settings to ensure Docker has access to sufficient compute resources to run the module. 
+For more information on module compute requirements, please refer to the [module's `README.md` file](../../contributing-to-analyses/analysis-modules/compute-requirements.md#readme-files).
 
-Follow these instructions to update your Docker Desktop settings for [Mac](https://docs.docker.com/desktop/settings/mac#resources) and [Windows](https://docs.docker.com/desktop/settings/windows/#resources) computers. You will need to click "Apply and Restart" to ensure these changes go through.
+Follow these instructions to update your Docker Desktop settings for [Mac](https://docs.docker.com/desktop/settings/mac#resources) and [Windows](https://docs.docker.com/desktop/settings/windows/#resources) computers. 
+You will need to click "Apply and Restart" to ensure these changes go through.
 
 ### Using `docker run`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
     - Working with Docker:
       - ensuring-repro/docker/index.md
       - ensuring-repro/docker/docker-images.md
+      - ensuring-repro/docker/using-images.md
   - Cloud storage and compute:  # AWS
     - aws/index.md
     - aws/joining-aws.md


### PR DESCRIPTION
Closes #496

This PR adds documentation for using Docker images. To start, I stayed fairly thin on details for how to use Docker in the first place, under the assumption that contributors who actually want to pull images and run in containers have a sense of what they're doing already. I included a note to this end, and I also added a couple more Docker resources (links from [training materials](https://github.com/AlexsLemonade/training-specific-template/blob/7d68771d0c07ebc74507ccde1d934ed8a361edec/additional-resources/using-environments-post-workshop.md?plain=1#L218)). 

Let me know if there are any particular details that I glossed over which you think I should mention and/or emphasize more. For example, should I say more about `docker run` flags or volumes?

One item that this PR does _not_ cover but we should probably open an issue for is running docker images in LSfR, which may be necessary for certain modules depending on their compute needs. Do you agree we should circle back to this?