### PR TITLE
Force rebuild/push of doublet Dockerfile

### DIFF
--- a/analyses/doublet-detection/Dockerfile
+++ b/analyses/doublet-detection/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile for doublet-detection module
+# Dockerfile for the doublet-detection module
 FROM bioconductor/r-ver:3.19
 # Labels following the Open Containers Initiative (OCI) recommendations
 # For more information, see https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1


### PR DESCRIPTION
Last week, the GHA failed to push the `doublet-detection` Dockerfile to the registry due to a credentials issue. We think this _may_ have been fixed, so this PR is really just meant to see if it's fixed! With any luck, this image gets pushed to our registry upon merge. I modified the Dockerfile enough to trigger the GHA, but not enough to actually change the Dockerfile in a meaningful way.