### PR TITLE
Add update-symlink argument to data download script

### DIFF
--- a/download-data.py
+++ b/download-data.py
@@ -152,19 +152,16 @@ def add_parent_dirs(patterns: List[str], dirs: List[str]) -> List[str]:
 
 
 def update_symlink(
+    data_dir: pathlib.Path,
     release: str
 ) -> None:
     """
     Update symlink when switching test and release data
     """
-    ### Update current link to point to new or test data if required ###
-    # only do this if we are using test data or the specified release is "current" or "latest", not for specific dates
-    if update_current and not dryrun:
-        # update the current symlink
-        current_symlink = data_dir / "current"
-        current_symlink.unlink(missing_ok=True)
-        current_symlink.symlink_to(release)
-        print(f"Updated 'current' symlink to point to '{release}'.")
+    current_symlink = data_dir / "current"
+    current_symlink.unlink(missing_ok=True)
+    current_symlink.symlink_to(release)
+    print(f"Updated 'current' symlink to point to '{release}'.")
 
 
 
@@ -263,7 +260,7 @@ def download_release_data(
     # only do this if we are using test data or the specified release is "current" or "latest", not for specific dates
     if update_current:
         if not dryrun:
-            update_symlink(release)
+            update_symlink(download_dir, release)
         else:
             print(f"\nIf this were not a dry run, the 'current' symlink would be updated to point to '{release}'.")
 
@@ -328,7 +325,7 @@ def main() -> None:
         "--test-data",
         action="store_true",
         help="Download test data from the test bucket and direct the `current` symlink to the test data directory."
-        " To switch back, rerun this script with the `--release current` option.",
+        " To switch back, rerun this script with either the `--release current` option, or the `--update-symlink release` option.",
     )
     parser.add_argument(
         "--metadata-only",
@@ -363,7 +360,12 @@ def main() -> None:
         default="",
         help="The AWS profile to use for the download. Uses the current default profile if undefined.",
     )
-
+    parser.add_argument(
+        "--update-symlink",
+        type=str,
+        default="",
+        help="Update the 'current' symlink to point to requested release without re-downloading data if it is already present."
+    )
     args = parser.parse_args()
 
     ### Validate the arguments ###

--- a/download-data.py
+++ b/download-data.py
@@ -171,7 +171,7 @@ def update_symlink(
     else:
         current_symlink = data_dir / "current"
         current_symlink.unlink(missing_ok=True)
-        current_symlink.symlink_to(target_path)
+        current_symlink.symlink_to(target)
         print(f"Updated 'current' symlink to point to '{target_path}'.")
 
 
@@ -374,7 +374,7 @@ def main() -> None:
         "--update-symlink",
         type=str,
         default="",
-        help="The release version to update the 'current' symlink to direct to. Release directory must be present. No data will be downloaded."
+        help="Update the 'current' symlink to point to the given release version. The release directory must be present. No data will be downloaded."
     )
     args = parser.parse_args()
 
@@ -456,10 +456,13 @@ def main() -> None:
 
     ### Update symlink if requested, without downloading data, if the target directory exists
     if args.update_symlink:
+        if args.update_symlink.casefold() in {"latest", "release"}:
+            # find the latest available release
+            ...
         if not args.dryrun:
             update_symlink(args.data_dir, args.update_symlink)
         else:
-            print(f"\nThe 'current' symlink would be updated to point to '{args.release}'.")
+            print(f"\nThe 'current' symlink would be updated to point to '{args.update_symlink}'.")
         sys.exit(0)
 
     ### List the available releases or modules ###

--- a/download-data.py
+++ b/download-data.py
@@ -472,7 +472,13 @@ def main() -> None:
 
         if target == "current":
             # find the most recent local release to use as target
-            dated_releases = (x.name for x in args.data_dir.iterdir() if x.is_dir and re.match("\d{4}-\d{2}-\d{2}$", x.name)
+            dated_releases = (
+              x.name
+              for x in args.data_dir.iterdir()
+              if x.is_dir()
+              and re.match("\d{4}-\d{2}-\d{2}$", x.name)
+              and x.name <= datetime.date.today().isoformat()
+            )
             most_recent = max(dated_releases)
             update_symlink(args.data_dir, most_recent, dryrun = args.dryrun)
         else:

--- a/download-data.py
+++ b/download-data.py
@@ -165,7 +165,7 @@ def update_symlink(
     # Ensure the target path exists before updating symlink
     if not target_path.exists():
         print(
-            f"\nThe requested target directory {target} for the 'current' symlink does not exist.\n",
+            f"\nThe requested target directory '{target}' does not exist, so the symlink will not be changed.\n",
             "Please instead download the desired release with the `--release` flag.",
             file=sys.stderr,
         )
@@ -465,29 +465,20 @@ def main() -> None:
     ### Update symlink if requested, without downloading data, if the target directory exists
     if args.update_symlink:
 
-        # find all non-hidden directories in data_dir, representing the local releases
-        local_releases = [x.stem for x in args.data_dir.iterdir() if re.match("^[^.]", x.name) and x.is_dir()]
-
         if args.test_data:
             target = "test"
         else:
             target = args.release
 
-        if not target in local_releases:
-            if args.dryrun:
-                print(f"\nThe '{target}' data release is not locally available. The symlink would not be updated.")
-            else:
-                print(f"\nThe '{target}' data release is not locally available. Could not update symlink.")
-            sys.exit(1)
+        if target == "current":
+            # find the most recent local release to use as target
+            dated_releases = [x.name for x in args.data_dir.iterdir() if x.is_dir and re.match("\d{4}-\d{2}-\d{2}$", x.name)]
+            most_recent = sorted(dated_releases)[-1]
+            update_symlink(args.data_dir, most_recent, dryrun = args.dryrun)
         else:
-            if target == "current":
-                # find the most recent local release
-                dated_releases = [x.name for x in args.data_dir.iterdir() if x.is_dir and re.match("\d{4}-\d{2}-\d{2}$", x.name)]
-                most_recent = sorted(dated_releases)[-1]
-                update_symlink(args.data_dir, most_recent, dryrun = args.dryrun)
-            else:
-                update_symlink(args.data_dir, target, dryrun = args.dryrun)
-            sys.exit(0)
+            update_symlink(args.data_dir, target, dryrun = args.dryrun)
+
+        sys.exit(0)
 
 
     ### List the available releases or modules ###

--- a/download-data.py
+++ b/download-data.py
@@ -482,11 +482,9 @@ def main() -> None:
         else:
             if target == "current":
                 # find the most recent local release
-                dated_releases = [x for x in local_releases if re.match("\d{4}-\d{2}-\d{2}", x)]
+                dated_releases = [x.name for x in args.data_dir.iterdir() if x.is_dir and re.match("\d{4}-\d{2}-\d{2}$", x.name)]
                 most_recent = sorted(dated_releases)[-1]
                 update_symlink(args.data_dir, most_recent, dryrun = args.dryrun)
-            elif target == "test" or args.test_data:
-                update_symlink(args.data_dir, "test", dryrun = args.dryrun)
             else:
                 update_symlink(args.data_dir, target, dryrun = args.dryrun)
             sys.exit(0)

--- a/download-data.py
+++ b/download-data.py
@@ -472,8 +472,8 @@ def main() -> None:
 
         if target == "current":
             # find the most recent local release to use as target
-            dated_releases = {x.name for x in args.data_dir.iterdir() if x.is_dir and re.match("\d{4}-\d{2}-\d{2}$", x.name)}
-            most_recent = sorted(dated_releases)[-1]
+            dated_releases = (x.name for x in args.data_dir.iterdir() if x.is_dir and re.match("\d{4}-\d{2}-\d{2}$", x.name)
+            most_recent = max(dated_releases)
             update_symlink(args.data_dir, most_recent, dryrun = args.dryrun)
         else:
             update_symlink(args.data_dir, target, dryrun = args.dryrun)

--- a/download-data.py
+++ b/download-data.py
@@ -156,13 +156,23 @@ def update_symlink(
     target: str
 ) -> None:
     """
-    Update symlink to direct to target
+    Update the {data_dir}/current symlink to direct to target
     """
-    current_symlink = data_dir / "current"
-    current_symlink.unlink(missing_ok=True)
-    current_symlink.symlink_to(target)
-    print(f"Updated 'current' symlink to point to '{target}'.")
+    target_path = data_dir / target
 
+    # Ensure the target path exists before updating symlink
+    if not target_path.exists():
+        print(
+            f"\nThe requested target directory {target_path} for the 'current' symlink does not exist.\n",
+            "Please instead download the desired release with the `--release` flag.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    else:
+        current_symlink = data_dir / "current"
+        current_symlink.unlink(missing_ok=True)
+        current_symlink.symlink_to(target_path)
+        print(f"Updated 'current' symlink to point to '{target_path}'.")
 
 
 def download_release_data(
@@ -446,18 +456,11 @@ def main() -> None:
 
     ### Update symlink if requested, without downloading data, if the target directory exists
     if args.update_symlink:
-        current_symlink = args.data_dir / "current"
-        desired_target = args.data_dir / args.update_symlink
-        if desired_target.exists():
+        if not args.dryrun:
             update_symlink(args.data_dir, args.update_symlink)
-            sys.exit(0)
         else:
-            print(
-                f"The requested target directory {args.update_symlink} for the 'current' symlink does not exist.\n",
-                " Please instead download the desired release with the `--release` flag.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+            print(f"\nThe 'current' symlink would be updated to point to '{args.release}'.")
+        sys.exit(0)
 
     ### List the available releases or modules ###
     all_releases = get_releases(

--- a/download-data.py
+++ b/download-data.py
@@ -472,7 +472,7 @@ def main() -> None:
 
         if target == "current":
             # find the most recent local release to use as target
-            dated_releases = [x.name for x in args.data_dir.iterdir() if x.is_dir and re.match("\d{4}-\d{2}-\d{2}$", x.name)]
+            dated_releases = {x.name for x in args.data_dir.iterdir() if x.is_dir and re.match("\d{4}-\d{2}-\d{2}$", x.name)}
             most_recent = sorted(dated_releases)[-1]
             update_symlink(args.data_dir, most_recent, dryrun = args.dryrun)
         else:

--- a/download-data.py
+++ b/download-data.py
@@ -151,6 +151,23 @@ def add_parent_dirs(patterns: List[str], dirs: List[str]) -> List[str]:
     return parent_patterns
 
 
+def update_symlink(
+    release: str
+) -> None:
+    """
+    Update symlink when switching test and release data
+    """
+    ### Update current link to point to new or test data if required ###
+    # only do this if we are using test data or the specified release is "current" or "latest", not for specific dates
+    if update_current and not dryrun:
+        # update the current symlink
+        current_symlink = data_dir / "current"
+        current_symlink.unlink(missing_ok=True)
+        current_symlink.symlink_to(release)
+        print(f"Updated 'current' symlink to point to '{release}'.")
+
+
+
 def download_release_data(
     bucket: str,
     release: str,
@@ -244,12 +261,12 @@ def download_release_data(
 
     ### Update current link to point to new or test data if required ###
     # only do this if we are using test data or the specified release is "current" or "latest", not for specific dates
-    if update_current and not dryrun:
-        # update the current symlink
-        current_symlink = data_dir / "current"
-        current_symlink.unlink(missing_ok=True)
-        current_symlink.symlink_to(release)
-        print(f"Updated 'current' symlink to point to '{release}'.")
+    if update_current:
+        if not dryrun:
+            update_symlink(release)
+        else:
+            print(f"\nIf this were not a dry run, the 'current' symlink would be updated to point to '{release}'.")
+
 
 
 def main() -> None:

--- a/download-data.py
+++ b/download-data.py
@@ -381,6 +381,7 @@ def main() -> None:
         help="Whether to update the 'current' symlink to direct to a different data release."
         " By default, the symlink will be updated to direct to the latest local release."
         " Provide the --release flag to specify a different release."
+        " To update the symlink to direct to test data, use the --test-data flag."
         " No data will be downloaded if this flag is used."
     )
     args = parser.parse_args()

--- a/download-data.py
+++ b/download-data.py
@@ -364,7 +364,7 @@ def main() -> None:
         "--update-symlink",
         type=str,
         default="",
-        help="The release to update the 'current' symlink to direct to. Data will not be re-downloaded data if it is already present."
+        help="The release version to update the 'current' symlink to direct to. Release directory must be present. Data will not be re-downloaded if it is already present."
     )
     args = parser.parse_args()
 

--- a/download-data.py
+++ b/download-data.py
@@ -262,7 +262,7 @@ def download_release_data(
         if not dryrun:
             update_symlink(download_dir, release)
         else:
-            print(f"\nIf this were not a dry run, the 'current' symlink would be updated to point to '{release}'.")
+            print(f"\nThe 'current' symlink would be updated to point to '{release}'.")
 
 
 
@@ -364,7 +364,7 @@ def main() -> None:
         "--update-symlink",
         type=str,
         default="",
-        help="The release version to update the 'current' symlink to direct to. Release directory must be present. Data will not be re-downloaded if it is already present."
+        help="The release version to update the 'current' symlink to direct to. Release directory must be present. No data will be downloaded."
     )
     args = parser.parse_args()
 

--- a/download-data.py
+++ b/download-data.py
@@ -491,6 +491,7 @@ def main() -> None:
                 update_symlink(args.data_dir, target, dryrun = args.dryrun)
             sys.exit(0)
 
+
     ### List the available releases or modules ###
     all_releases = get_releases(
         bucket=bucket, profile=args.profile, test_data=args.test_data

--- a/download-data.py
+++ b/download-data.py
@@ -378,9 +378,10 @@ def main() -> None:
     parser.add_argument(
         "--update-symlink",
         action="store_true",
-        help="Whether the 'current' symlink should be updated."
-        " By default, the symlink will be updated to direct to the most recent release."
-        " Provide the --release flag to specify a different release. No data will be downloaded if this flag is used."
+        help="Whether to update the 'current' symlink to direct to a different data release."
+        " By default, the symlink will be updated to direct to the latest local release."
+        " Provide the --release flag to specify a different release."
+        " No data will be downloaded if this flag is used."
     )
     args = parser.parse_args()
 
@@ -508,7 +509,7 @@ def main() -> None:
     # get the release to use or exit if it is not available
     if args.test_data:
         release = "test"
-    elif args.release.lower() in ["current", "latest"]:
+    elif args.release.casefold() in {"current", "latest"}:
         release = current_releases[0]
     elif args.release in all_releases:  # allow downloads from the future
         release = args.release
@@ -538,7 +539,7 @@ def main() -> None:
         samples=args.samples.split(",") if args.samples else [],
         dryrun=args.dryrun,
         profile=args.profile,
-        update_current=args.test_data or args.release.lower() in ["current", "latest"],
+        update_current=args.test_data or args.release.casefold() in {"current", "latest"},
     )
 
 


### PR DESCRIPTION
Closes #530

This PR adds the `--update-symlink` argument to the `data-download.py` script, and it's working as expected on my end 👍 . I added a function `update_symlink()` which is called in two spots:
  - After downloading a data release (where the code originally was before I ported it into a function)
    - I also added a sentence here to print out how the symlink _would_ change if `--dryrun` is used 
  - Before any creds get used (to list releases), I include an `if args.update_symlink:` to update the symlink as desired. This is only done if the specified directory exists, and errors out otherwise with a message that you should download the data instead. I also use `sys.exit(0)` to exit out after changing the symlink, since we don't want to be doing any downloads with this flag.

Let me know if there are other behaviors we'd like to see for this flag. Also, I'm not convinced my help string for this argument is as clear as it could be, what do you think?