### PR TITLE
Bump mkdocs version and fix some link anchors

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -29,7 +29,7 @@ jobs:
 
           # Capture all the bad links (don't let grep exit -1 if no match)
           grep "relative link" build-log.txt > bad_links.txt || true
-          grep "no such anchor" build-log.txt > bad_links.txt || true
+          grep "no such anchor" build-log.txt >> bad_links.txt || true
 
           # Save the number of bad links to github output
           echo "n_bad_links=$(wc -l < bad_links.txt)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -29,6 +29,7 @@ jobs:
 
           # Capture all the bad links (don't let grep exit -1 if no match)
           grep "relative link" build-log.txt > bad_links.txt || true
+          grep "no such anchor" build-log.txt > bad_links.txt || true
 
           # Save the number of bad links to github output
           echo "n_bad_links=$(wc -l < bad_links.txt)" >> "$GITHUB_OUTPUT"

--- a/docs/aws/index.md
+++ b/docs/aws/index.md
@@ -18,7 +18,7 @@ All contributors will have a designated [researcher bucket](working-with-s3-buck
 Please refer to these pages about working with S3:
 
 - [Configuring and logging into AWS from the command line](../technical-setup/environment-setup/configure-aws-cli.md)
-- [Accessing project data from S3](../getting-started/accessing-resources/getting-access-to-data.md#accessing-data-on-s3)
+- [Accessing project data from S3](../getting-started/accessing-resources/getting-access-to-data.md#accessing-data-from-s3)
 - [Using your researcher bucket](working-with-s3-buckets.md)
 
 ## Lightsail for Research: Virtual computing with AWS

--- a/docs/contributing-to-analyses/analysis-modules/notebook-structure.md
+++ b/docs/contributing-to-analyses/analysis-modules/notebook-structure.md
@@ -12,7 +12,7 @@ We have found that following some common patterns can enhance sharing and reprod
     - Use headings and subheadings to break up the analysis into logical sections.
 - **Session info**: Print out the versions of all packages used in the analysis.
 
-Below we provide more detail about each of these sections for [R Markdown](#r-markdown-notebooks) and [Jupyter](#python-notebooks) notebooks.
+Below we provide more detail about each of these sections for [R Markdown](#r-markdown-notebooks) and [Jupyter](#jupyter-notebooks) notebooks.
 
 ## R Markdown notebooks
 

--- a/docs/ensuring-repro/managing-software/using-conda.md
+++ b/docs/ensuring-repro/managing-software/using-conda.md
@@ -51,7 +51,7 @@ You should perform this step before [filing a pull request](../../contributing-t
     If the `conda-lock` command fails, it may be because a package is not available for one of the platforms listed in the `environment.yml` file.
     Usually this will be a package that is not available for the `osx-arm64` (Apple Silicon) platform.
 
-    If this happens, see the [Software not available on a specific platform](#software-not-available-on-a-specific-platform) section below for instructions on how to handle this situation.
+    If this happens, see the [Software not available on a specific platform](#adding-dependencies-not-available-on-a-specific-platform) section below for instructions on how to handle this situation.
 
 ## Adding packages to the environment
 

--- a/docs/getting-started/project-tools/using-the-terminal.md
+++ b/docs/getting-started/project-tools/using-the-terminal.md
@@ -2,6 +2,7 @@
 
 This page provides some background information on working with the terminal, also known as the command line prompt.
 
+This sentence tests a bad [anchor link](#does-not-exist).
 
 ## What is the terminal?
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==9.5.10
-mkdocs==1.5.3
+mkdocs-material==9.5.27
+mkdocs==1.6.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==9.5.27
-mkdocs==1.6.0
+mkdocs-material==9.5.10
+mkdocs==1.5.3

--- a/docs/technical-setup/install-wsl-2.md
+++ b/docs/technical-setup/install-wsl-2.md
@@ -44,7 +44,7 @@ Open it by clicking "Run as administrator".
     You will need to use your password when installing software for Ubuntu, and if you choose to use [RStudio](environment-setup/install-r-rstudio.md#using-the-rstudio-server), you will need your username and password.
     - Note that when you type your password, no symbols will appear - this is expected!
 
-1. Open an [Ubuntu terminal window](../getting-started/project-tools/using-the-terminal.md#accessing-the-terminal-on-wsl2-on-windows).
+1. Open an [Ubuntu terminal window](../getting-started/project-tools/using-the-terminal.md#accessing-the-terminal-on-wsl-2-on-windows).
 
     - Run the following command in Ubuntu to ensure that the package index for `apt`, the native Ubuntu package manager, and all its pre-installed packages are up to date.
     - Ubuntu will prompt you for your newly-created password when you run this command; you can expect to be prompted for a password any time you run a command as [`sudo`](https://www.pluralsight.com/resources/blog/cloud/linux-commands-for-beginners-sudo).


### PR DESCRIPTION
I recently updated my local version of `material-mkdocs`, and found that in the current version I have locally, serving the docs found several bad anchor links which had not been flagged previously.

This PR fixes those anchor links and also bumps the `mkdocs` versions in the `docs/requirements.txt` file that we use when running the GHA to check links (though maybe I was a bit too prescriptive with the patch version here...). To test if the GHA now flags bad anchor links, I added an intentionally bad one so hopefully the links action fails 🤞 