### PR TITLE
Docs for updating docker images

### DIFF
--- a/docs/ensuring-repro/docker/updating-images.md
+++ b/docs/ensuring-repro/docker/updating-images.md
@@ -12,7 +12,7 @@ Changing the software environment means that module-specific Docker image also n
     If these conditions are not met, you do not need to take any specific steps to update Docker images when you update a module's software environment.
 
 
-## Context (header help????)
+## Context (header help???)
 
 Docker images in OpenScPCA are used in two primary circumstances:
 

--- a/docs/ensuring-repro/docker/updating-images.md
+++ b/docs/ensuring-repro/docker/updating-images.md
@@ -4,16 +4,6 @@ Over the course of module development, new dependencies and packages may get add
 For example, your environment will change if you add a new R or Python package to perform additional analyses.
 Changing the software environment means that the module-specific Docker image also needs to be updated to incorporate those changes.
 
-!!! note
-    These instructions assume that the Data Lab has already activated both of the [GitHub Action (GHA) workflows](../../contributing-to-analyses/analysis-modules/creating-a-module.md#module-workflows) that were created when the module was established, including the [module-testing GHA](../workflows/run-module-gha.md) and the [Docker-building GHA](#STUB_LINK../workflows/docker-build-gha.md).
-
-    In addition, the module-testing GHA should have already been updated to build its runtime environment from the module's Docker image, not from other environment files (e.g. `renv.lock` or `conda-lock.yml`.)
-
-    If these conditions are not met, you do not need to take any specific steps to update Docker images when you update a module's software environment.
-
-
-## Context (header help???)
-
 Docker images in OpenScPCA are used in two primary circumstances:
 
 1. When generating module results as part of the `OpenScPCA-nf` workflow <!-- STUB_LINK -->
@@ -22,6 +12,13 @@ Docker images in OpenScPCA are used in two primary circumstances:
 
 The module-testing GHA will fail if any module dependencies are missing from the Docker image it pulls down.
 Therefore, for this GHA to pass, any environment changes must have already been incorporated into the module's Docker image and pushed to the Docker registry.
+
+!!! note
+    These instructions assume that the Data Lab has already activated both of the [GitHub Action (GHA) workflows](../../contributing-to-analyses/analysis-modules/creating-a-module.md#module-workflows) that were created when the module was established, including the [module-testing GHA](../workflows/run-module-gha.md) and the [Docker-building GHA](#STUB_LINK../workflows/docker-build-gha.md).
+
+    In addition, the module-testing GHA should have already been updated to build its runtime environment from the module's Docker image, not from other environment files (e.g. `renv.lock` or `conda-lock.yml`.)
+
+    If these conditions are not met, you do not need to take any specific steps to update Docker images when you update a module's software environment.
 
 ## Steps to update a Docker image
 

--- a/docs/ensuring-repro/docker/updating-images.md
+++ b/docs/ensuring-repro/docker/updating-images.md
@@ -2,7 +2,7 @@
 
 Over the course of module development, new dependencies and packages may get added or removed, thereby changing the [module's software environment](../managing-software/index.md).
 For example, your environment will change if you add a new R or Python package to perform additional analyses.
-Changing the software environment means that module-specific Docker image also needs to be updated to incorporate those changes.
+Changing the software environment means that the module-specific Docker image also needs to be updated to incorporate those changes.
 
 !!! note
     These instructions assume that the Data Lab has already activated both of the [GitHub Action (GHA) workflows](../../contributing-to-analyses/analysis-modules/creating-a-module.md#module-workflows) that were created when the module was established, including the [module-testing GHA](../workflows/run-module-gha.md) and the [Docker-building GHA](#STUB_LINK../workflows/docker-build-gha.md).
@@ -28,7 +28,7 @@ Therefore, for this GHA to pass, any environment changes must have already been 
 Whenever you add or remove a new package or dependency to your module's software environment, you will generally need to take a two-step process to add new code that uses those new dependencies:
 
 1. First, file a PR that _only contains_ your updated environment files, e.g. `renv.lock` and/or `conda-lock.yml`.
-_This PR should not any additional code changes that need this updated environment._
+_This PR should not include any additional code changes that require this updated environment._
     - Once this PR is merged, the module's Docker image will be [rebuilt and pushed to the OpenScPCA Docker Registry](#STUB_LINK../workflows/docker-build-gha.md)
 1. Then, you can file one or more PRs with code changes that use the update software environment.
     - By ensuring the updated Docker image was pushed to the registry _before_ filing this PR, the [module testing GHA](../workflows/run-module-gha.md) will be able to use the most up-to-date Docker image and avoid dependency errors

--- a/docs/ensuring-repro/docker/updating-images.md
+++ b/docs/ensuring-repro/docker/updating-images.md
@@ -1,21 +1,34 @@
 # Updating Docker images
 
-Over the course of module development, new dependencies may get added or removed, thereby changing the [module's software environment](../managing-software/index.md).
-As modules progress to maturity, there are important considerations to bear in mind when updating the module's software environment.
+Over the course of module development, new dependencies and packages may get added or removed, thereby changing the [module's software environment](../managing-software/index.md).
+For example, your environment will change if you add a new R or Python package to perform additional analyses.
+Changing the software environment means that module-specific Docker image also needs to be updated to incorporate those changes.
 
-In particular, over the course of module development, the Data Lab will activate two [GitHub Action (GHA) workflows](../workflows/index.md) to ensure module reproducibility:
+!!! note
+    These instructions assume that the Data Lab has already activated both of the [GitHub Action (GHA) workflows](../../contributing-to-analyses/analysis-modules/creating-a-module.md#module-workflows) that were created when the module was established, including the [module-testing GHA](../workflows/run-module-gha.md) and the [Docker-building GHA](#STUB_LINK../workflows/docker-build-gha.md).
 
-- A GHA workflow to [build and push the module's Docker image](#STUB_LINK../workflows/docker-build-gha.md) to the OpenScPCA Docker Registry
-    - This GHA automatically runs when pull requests (PRs) that modify a module's environment are merged into `main`
-- A GHA workflow to [run the module using test data](../workflows/run-module-gha.md)
-    - This GHA automatically runs on PRs that modify any module code
-    - Once the module's Docker image has been pushed to the OpenScPCA Docker Registry, this GHA will pull that Docker image to build a runtime environment.
-    Therefore, for this GHA to succeed, it must use the most up-to-date Docker image.
+    In addition, the module-testing GHA should have already been updated to build its runtime environment from the module's Docker image, not from other environment files (e.g. `renv.lock` or `conda-lock.yml`.)
 
-Once both of these workflows have been activated, you will need to file two PRs every time you write code that takes advantage of changes to the module software environment:
+    If these conditions are not met, you do not need to take any specific steps to update Docker images when you update a module's software environment.
 
-1. First, file a PR that contains _only_ changes to your module's environment files, e.g. `renv.lock` and/or `conda.lock`.
-This PR should not include additional code changes that require the updated environment.
-    - Once this PR is merged, the module's Docker image will be rebuilt and pushed to the OpenScPCA Docker Registry
-1. Second, file a PR that includes the code changes which use the update software environment
-    - By ensuring the updated Docker image is pushed to the registry _before_ filing this PR, the [module testing GHA](../workflows/run-module-gha.md) will be able to use the most up-to-date Docker image and avoid dependency errors
+
+## Context (header help????)
+
+Docker images in OpenScPCA are used in two primary circumstances:
+
+1. When generating module results as part of the `OpenScPCA-nf` workflow <!-- STUB_LINK -->
+2. When the [module-testing GitHub Action (GHA) workflow](../workflows/run-module-gha.md) is run on pull requests (PRs) that modify module code
+    - This GHA pulls the module-specific Docker image from the [OpenScPCA Docker registry](https://gallery.ecr.aws/openscpca/) to create a reproducible runtime environment with all module dependencies
+
+The module-testing GHA will fail if any module dependencies are missing from the Docker image it pulls down.
+Therefore, for this GHA to pass, any environment changes must have already been incorporated into the module's Docker image and pushed to the Docker registry.
+
+## Steps to update a Docker image
+
+Whenever you add or remove a new package or dependency to your module's software environment, you will generally need to take a two-step process to add new code that uses those new dependencies:
+
+1. First, file a PR that _only contains_ your updated environment files, e.g. `renv.lock` and/or `conda-lock.yml`.
+_This PR should not any additional code changes that need this updated environment._
+    - Once this PR is merged, the module's Docker image will be [rebuilt and pushed to the OpenScPCA Docker Registry](#STUB_LINK../workflows/docker-build-gha.md)
+1. Then, you can file one or more PRs with code changes that use the update software environment.
+    - By ensuring the updated Docker image was pushed to the registry _before_ filing this PR, the [module testing GHA](../workflows/run-module-gha.md) will be able to use the most up-to-date Docker image and avoid dependency errors

--- a/docs/ensuring-repro/docker/updating-images.md
+++ b/docs/ensuring-repro/docker/updating-images.md
@@ -18,4 +18,4 @@ Once both of these workflows have been activated, you will need to file two PRs 
 This PR should not include additional code changes that require the updated environment.
     - Once this PR is merged, the module's Docker image will be rebuilt and pushed to the OpenScPCA Docker Registry
 1. Second, file a PR that includes the code changes which use the update software environment
-    - By ensuring the updated Docker image is pushed to the registry _before_ filing this PR, the [module testing GHA](../workflows/run-module-gha.md) will be able to use most up-to-date Docker image and avoid dependency errors
+    - By ensuring the updated Docker image is pushed to the registry _before_ filing this PR, the [module testing GHA](../workflows/run-module-gha.md) will be able to use the most up-to-date Docker image and avoid dependency errors

--- a/docs/ensuring-repro/docker/updating-images.md
+++ b/docs/ensuring-repro/docker/updating-images.md
@@ -1,0 +1,21 @@
+# Updating Docker images
+
+Over the course of module development, new dependencies may get added or removed, thereby changing the [module's software environment](../managing-software/index.md).
+As modules progress to maturity, there are important considerations to bear in mind when updating the module's software environment.
+
+In particular, over the course of module development, the Data Lab will activate two [GitHub Action (GHA) workflows](../workflows/index.md) to ensure module reproducibility:
+
+- A GHA workflow to [build and push the module's Docker image](#STUB_LINK../workflows/docker-build-gha.md) to the OpenScPCA Docker Registry
+    - This GHA automatically runs when pull requests (PRs) that modify a module's environment are merged into `main`
+- A GHA workflow to [run the module using test data](../workflows/run-module-gha.md)
+    - This GHA automatically runs on PRs that modify any module code
+    - Once the module's Docker image has been pushed to the OpenScPCA Docker Registry, this GHA will pull that Docker image to build a runtime environment.
+    Therefore, for this GHA to succeed, it must use the most up-to-date Docker image.
+
+Once both of these workflows have been activated, you will need to file two PRs every time you write code that takes advantage of changes to the module software environment:
+
+1. First, file a PR that contains _only_ changes to your module's environment files, e.g. `renv.lock` and/or `conda.lock`.
+This PR should not include additional code changes that require the updated environment.
+    - Once this PR is merged, the module's Docker image will be rebuilt and pushed to the OpenScPCA Docker Registry
+1. Second, file a PR that includes the code changes which use the update software environment
+    - By ensuring the updated Docker image is pushed to the registry _before_ filing this PR, the [module testing GHA](../workflows/run-module-gha.md) will be able to use most up-to-date Docker image and avoid dependency errors

--- a/docs/ensuring-repro/managing-software/index.md
+++ b/docs/ensuring-repro/managing-software/index.md
@@ -16,3 +16,13 @@ We specifically recommend these two package managers to specify module-specific 
 Conda can also be used to manage standalone software packages that do not depend on a specific language.
 
 When you [create a module with `create-analysis-module.py`](../../contributing-to-analyses/analysis-modules/creating-a-module.md), you can use one (or more!) of several [flags](../../contributing-to-analyses/analysis-modules/creating-a-module.md#module-creation-script-flags) to establish your module with an initialized software environment.
+
+## Updating software environments
+
+As analysis modules mature, the Data Lab will activate several [GitHub Action workflows](../workflows/index.md) that ensure module reproducibility.
+Once these workflows are activated, you will need to file _two PRs_ every time you wish to update your software environment:
+
+1. First, file a PR that updates your software environment, e.g. `renv.lock`, `conda.lock`, or `Dockerfile` files
+1. After that first PR is been merged, you can then file a second PR that contains your code changes that use the updated environment
+
+For more details on this process, please refer to our [documentation on updating Docker images](../docker/updating-images.md).

--- a/docs/ensuring-repro/managing-software/index.md
+++ b/docs/ensuring-repro/managing-software/index.md
@@ -20,7 +20,7 @@ When you [create a module with `create-analysis-module.py`](../../contributing-t
 ## Updating software environments
 
 As analysis modules mature, the Data Lab will activate several [GitHub Action workflows](../workflows/index.md) that ensure module reproducibility.
-Once these workflows are activated, you will need to file _two PRs_ every time you wish to update your software environment:
+Once these workflows are activated, you will need to file _two PRs_ every time you wish to update your software environment, including adding or updating a package used in R or Python: 
 
 1. First, file a PR that updates your software environment, e.g. `renv.lock`, `conda.lock`, or `Dockerfile` files
 1. After that first PR is been merged, you can then file a second PR that contains your code changes that use the updated environment

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
       - ensuring-repro/docker/index.md
       - ensuring-repro/docker/docker-images.md
       - ensuring-repro/docker/using-images.md
+      - ensuring-repro/docker/updating-images.md
   - Cloud storage and compute:  # AWS
     - aws/index.md
     - aws/joining-aws.md


### PR DESCRIPTION
Closes #497 

This PR adds docs that describe why you need to file 2 PRs to update a docker image, once all the GHAs have been turned on. Note that it contains one `#STUB_LINK` which can be completed once #533 goes in. 

Instructions for reviewers:
1. I am not at all sure if I have presented this information clearly, so please let me know whether there is a different logical flow of information which would make this easier to understand! Any comments about clarity and presentation are appreciated!
2. Are there any additional details to communicate besides that they need 2 PRs?
3. Are there any more spots in the docs that would benefit from linking to this page?