### PR TITLE
Set Renv not to activate in docker images

### DIFF
--- a/analyses/cell-type-ewings/.Rprofile
+++ b/analyses/cell-type-ewings/.Rprofile
@@ -1,1 +1,4 @@
-source("renv/activate.R")
+# Don't activate renv in an OpenScPCA docker image
+if(Sys.getenv('OPENSCPCA_DOCKER') != 'TRUE'){
+  source('renv/activate.R')
+}

--- a/analyses/cell-type-ewings/Dockerfile
+++ b/analyses/cell-type-ewings/Dockerfile
@@ -8,6 +8,9 @@ LABEL org.opencontainers.image.description="Docker image for the OpenScPCA analy
 LABEL org.opencontainers.image.authors="OpenScPCA scpca@ccdatalab.org"
 LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-ewings"
 
+# Set an environment variable to allow checking if we are in an OpenScPCA container
+ENV OPENSCPCA_DOCKER TRUE
+
 # Disable the renv cache to install packages directly into the R library
 ENV RENV_CONFIG_CACHE_ENABLED FALSE
 # set a name for the conda environment
@@ -18,11 +21,11 @@ ENV PATH="/opt/conda/bin:${PATH}"
 
 # Install dependencies for renv library
 RUN apt-get -y update &&  \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install --no-install-recommends -y \
-    pandoc \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends -y \
+  pandoc \
+  wget \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install miniconda
 # adapted from https://github.com/ContinuumIO/docker-images/blob/main/miniconda3/debian/Dockerfile

--- a/analyses/doublet-detection/.Rprofile
+++ b/analyses/doublet-detection/.Rprofile
@@ -1,1 +1,4 @@
-source("renv/activate.R")
+# Don't activate renv in an OpenScPCA docker image
+if(Sys.getenv('OPENSCPCA_DOCKER') != 'TRUE'){
+  source('renv/activate.R')
+}

--- a/analyses/doublet-detection/Dockerfile
+++ b/analyses/doublet-detection/Dockerfile
@@ -8,6 +8,9 @@ LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/OpenScPC
 # set a name for the conda environment
 ARG ENV_NAME=openscpca-doublet-detection
 
+# Set an environment variable to allow checking if we are in an OpenScPCA container
+ENV OPENSCPCA_DOCKER TRUE
+
 # set environment variables to install miniconda
 ENV PATH="/opt/conda/bin:${PATH}"
 

--- a/analyses/hello-R/.Rprofile
+++ b/analyses/hello-R/.Rprofile
@@ -1,1 +1,3 @@
-source("renv/activate.R")
+if(Sys.getenv("OPENSCPCA_DOCKER") != "TRUE"){
+  source("renv/activate.R")
+}

--- a/analyses/hello-R/.Rprofile
+++ b/analyses/hello-R/.Rprofile
@@ -1,3 +1,4 @@
-if(Sys.getenv("OPENSCPCA_DOCKER") != "TRUE"){
-  source("renv/activate.R")
+# Don't activate renv in an OpenScPCA docker image
+if(Sys.getenv('OPENSCPCA_DOCKER') != 'TRUE'){
+  source('renv/activate.R')
 }

--- a/analyses/hello-R/Dockerfile
+++ b/analyses/hello-R/Dockerfile
@@ -6,6 +6,16 @@ FROM bioconductor/r-ver:3.19
 LABEL org.opencontainers.image.authors="OpenScPCA scpca@ccdatalab.org"
 LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/hello-R"
 
+# Set an environment variable to allow checking if we are in an OpenScPCA container
+ENV OPENSCPCA_DOCKER TRUE
+
+# Install additional system dependencies
+RUN apt-get -y update &&  \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install --no-install-recommends -y \
+    pandoc \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install renv to enable later package installation
 RUN Rscript -e "install.packages('renv')"
 

--- a/analyses/hello-python/Dockerfile
+++ b/analyses/hello-python/Dockerfile
@@ -6,6 +6,9 @@ FROM continuumio/miniconda3:24.1.2-0
 LABEL org.opencontainers.image.authors="OpenScPCA scpca@ccdatalab.org"
 LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/hello-python"
 
+# Set an environment variable to allow checking if we are in an OpenScPCA container
+ENV OPENSCPCA_DOCKER TRUE
+
 # set a name for the conda environment
 ARG ENV_NAME=openscpca-hello-python
 

--- a/analyses/simulate-sce/.Rprofile
+++ b/analyses/simulate-sce/.Rprofile
@@ -1,1 +1,4 @@
-source("renv/activate.R")
+# Don't activate renv in an OpenScPCA docker image
+if(Sys.getenv('OPENSCPCA_DOCKER') != 'TRUE'){
+  source('renv/activate.R')
+}

--- a/analyses/simulate-sce/Dockerfile
+++ b/analyses/simulate-sce/Dockerfile
@@ -8,6 +8,9 @@ LABEL org.opencontainers.image.description="Docker image for the OpenScPCA analy
 LABEL org.opencontainers.image.authors="OpenScPCA scpca@ccdatalab.org"
 LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/simulate-sce"
 
+# Set an environment variable to allow checking if we are in an OpenScPCA container
+ENV OPENSCPCA_DOCKER TRUE
+
 ENV RENV_CONFIG_CACHE_ENABLED FALSE
 RUN Rscript -e "install.packages(c('remotes', 'renv'))"
 

--- a/create-analysis-module.py
+++ b/create-analysis-module.py
@@ -215,6 +215,15 @@ def main() -> None:
             ["Rscript", "-e", renv_script],
             cwd=module_dir,
         )
+
+        # Set .Rprofile to not activate renv in an OpenScPCA Docker image
+        (module_dir / ".Rprofile").write_text(
+            "# Don't activate renv in an OpenScPCA docker image\n"
+            "if (Sys.getenv('OPENSCPCA_DOCKER') != 'TRUE') {\n"
+            "    source('renv/activate.R')\n"
+            "}\n"
+        )
+
         # make the components directory and add a dependencies.R file
         component_dir = module_dir / "components"
         component_dir.mkdir(exist_ok=True)

--- a/create-analysis-module.py
+++ b/create-analysis-module.py
@@ -220,7 +220,7 @@ def main() -> None:
         (module_dir / ".Rprofile").write_text(
             "# Don't activate renv in an OpenScPCA docker image\n"
             "if (Sys.getenv('OPENSCPCA_DOCKER') != 'TRUE') {\n"
-            "    source('renv/activate.R')\n"
+            "  source('renv/activate.R')\n"
             "}\n"
         )
 

--- a/templates/analysis-module/Dockerfile
+++ b/templates/analysis-module/Dockerfile
@@ -5,3 +5,6 @@ FROM ubuntu:22.04
 # For more information, see https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1
 LABEL org.opencontainers.image.authors="OpenScPCA scpca@ccdatalab.org"
 LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/templates/analysis-module"
+
+# Set an environment variable to allow checking if we are in an OpenScPCA container
+ENV OPENSCPCA_DOCKER TRUE


### PR DESCRIPTION
Closes #542

Here I added a bit of simple logic to avoid running `renv/activate.R` when we are in a Docker image.  To do this I added an ENV variable named `OPENSCPCA_DOCKER` to all docker images, and then only source the activate script if the value is not set to `TRUE`. 

The original issue isn't so much that related to caching in the docker images as that the files are being installed in the system library, so we don't want renv to be activated and looking for its own versions of the packages. If we were to do that, we would almost certainly run into path problems with files stored or not in the host filesystem.

I tested this in the hello-R image/script, but applied the same changes everywhere, including in the `create-analysis-module.py` script to cover future modules. I also included the ENV variable in the template, and in the hello-python module Dockerfile, even though it may not be needed there. Seemed a good place for just a bit of extra consistency.