### PR TITLE
Add docker workflows for hello modules

### DIFF
--- a/.github/workflows/docker_hello-R.yml
+++ b/.github/workflows/docker_hello-R.yml
@@ -1,0 +1,63 @@
+name: Build Docker image for hello-R
+
+concurrency:
+  # only one run per branch at a time
+  group: "hello-R-${{ github.ref }}"
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - analyses/hello-R/Dockerfile
+      - analyses/hello-R/.dockerignore
+      - analyses/hello-R/renv.lock
+      - analyses/hello-R/conda-lock.yml
+  push:
+    tags:
+      - "v*.*.*"
+    branches:
+      - main
+    paths:
+      - analyses/hello-R/Dockerfile
+      - analyses/hello-R/.dockerignore
+      - analyses/hello-R/renv.lock
+      - analyses/hello-R/conda-lock.yml
+  workflow_dispatch:
+    inputs:
+      push-ecr:
+        description: "Push to AWS ECR"
+        type: boolean
+        required: false
+  workflow_call:
+    inputs:
+      push-ecr:
+        description: "Push to AWS ECR"
+        type: boolean
+
+jobs:
+  test-build:
+    name: Test Build Docker Image
+    if: github.event_name == 'pull_request' || (contains(github.event_name, 'workflow_') && !inputs.push-ecr)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:analyses/hello-R"
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-push:
+    name: Build and Push Docker Image
+    if: github.event_name == 'push' || inputs.push-ecr
+    uses: ./.github/workflows/build-push-docker-module.yml
+    with:
+      module: hello-R
+      push-ecr: true

--- a/.github/workflows/docker_hello-python.yml
+++ b/.github/workflows/docker_hello-python.yml
@@ -1,0 +1,63 @@
+name: Build Docker image for hello-python
+
+concurrency:
+  # only one run per branch at a time
+  group: "hello-python-${{ github.ref }}"
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - analyses/hello-python/Dockerfile
+      - analyses/hello-python/.dockerignore
+      - analyses/hello-python/renv.lock
+      - analyses/hello-python/conda-lock.yml
+  push:
+    tags:
+      - "v*.*.*"
+    branches:
+      - main
+    paths:
+      - analyses/hello-python/Dockerfile
+      - analyses/hello-python/.dockerignore
+      - analyses/hello-python/renv.lock
+      - analyses/hello-python/conda-lock.yml
+  workflow_dispatch:
+    inputs:
+      push-ecr:
+        description: "Push to AWS ECR"
+        type: boolean
+        required: false
+  workflow_call:
+    inputs:
+      push-ecr:
+        description: "Push to AWS ECR"
+        type: boolean
+
+jobs:
+  test-build:
+    name: Test Build Docker Image
+    if: github.event_name == 'pull_request' || (contains(github.event_name, 'workflow_') && !inputs.push-ecr)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:analyses/hello-python"
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-push:
+    name: Build and Push Docker Image
+    if: github.event_name == 'push' || inputs.push-ecr
+    uses: ./.github/workflows/build-push-docker-module.yml
+    with:
+      module: hello-python
+      push-ecr: true


### PR DESCRIPTION
While we have the "hello" modules in the `docker_all-modules.yml` action, they don't currently have their own actions to test and build Docker changes in those modules themselves, so I thought we should make sure we have that as well. 

I meant to put this as part of #542, but it slipped my mind until after merging!