### PR TITLE
Fix monthly docker check failures

### DIFF
--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -13,12 +13,16 @@ on:
   schedule:
     # run monthly on the 1st
     - cron: "0 0 1 * *"
+  push:
+    # build and push all on tagged release
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       push-ecr:
         description: "Push to AWS ECR"
         type: boolean
-        required: false
+        required: true
 
 jobs:
   build-docker-modules:
@@ -34,7 +38,8 @@ jobs:
     uses: ./.github/workflows/build-push-docker-module.yml
     with:
       module: ${{ matrix.module }}
-      push-ecr: ${{ inputs.push-ecr }}
+      # push if the workflow was triggered for scheduled build or push, or if the user requested it
+      push-ecr: ${{ github.event_name == 'schedule'|| github.event_name == 'push' || inputs.push-ecr }}
 
   check-jobs:
     name: Check Job Status

--- a/.github/workflows/docker_doublet-detection.yml
+++ b/.github/workflows/docker_doublet-detection.yml
@@ -27,7 +27,7 @@ on:
       push-ecr:
         description: "Push to AWS ECR"
         type: boolean
-        required: false
+        required: true
 
 jobs:
   test-build:

--- a/.github/workflows/docker_hello-R.yml
+++ b/.github/workflows/docker_hello-R.yml
@@ -29,7 +29,7 @@ on:
       push-ecr:
         description: "Push to AWS ECR"
         type: boolean
-        required: false
+        required: true
   workflow_call:
     inputs:
       push-ecr:

--- a/.github/workflows/docker_hello-python.yml
+++ b/.github/workflows/docker_hello-python.yml
@@ -29,7 +29,7 @@ on:
       push-ecr:
         description: "Push to AWS ECR"
         type: boolean
-        required: false
+        required: true
   workflow_call:
     inputs:
       push-ecr:

--- a/.github/workflows/docker_simulate-sce.yml
+++ b/.github/workflows/docker_simulate-sce.yml
@@ -29,7 +29,7 @@ on:
       push-ecr:
         description: "Push to AWS ECR"
         type: boolean
-        required: false
+        required: true
   workflow_call:
     inputs:
       push-ecr:

--- a/templates/workflows/docker_module.yml
+++ b/templates/workflows/docker_module.yml
@@ -26,7 +26,7 @@ on:
       push-ecr:
         description: "Push to AWS ECR"
         type: boolean
-        required: false
+        required: true
 
 jobs:
   test-build:


### PR DESCRIPTION
Closes https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/552

The "build all" action failed because the `input` variables are not defined except in a `workflow_dispatch` context. I had previously partially fixed this in another branch, so changing this one so we always push images for scheduled runs was pretty quick. The only question is if this is actually the behavior we want? I could imagine we might not want to push images for the monthly test builds, but I can see arguments either way. 