### PR TITLE
Download data after environment setup in module GHAs

### DIFF
--- a/.github/workflows/run_doublet-detection.yml
+++ b/.github/workflows/run_doublet-detection.yml
@@ -55,7 +55,6 @@ jobs:
             lzma-dev \
             libglpk-dev
 
-
       - name: Set up pandoc
         uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/run_doublet-detection.yml
+++ b/.github/workflows/run_doublet-detection.yml
@@ -9,7 +9,7 @@
 name: Run doublet-detection analysis module
 env:
   MODULE_PATH: analyses/doublet-detection
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-2
 
 concurrency:
   # only one run per branch at a time

--- a/.github/workflows/run_hello-R.yml
+++ b/.github/workflows/run_hello-R.yml
@@ -7,7 +7,7 @@
 name: Run hello-R analysis module
 env:
   MODULE_PATH: analyses/hello-R
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-2
 
 concurrency:
   # only one run per branch at a time

--- a/.github/workflows/run_hello-R.yml
+++ b/.github/workflows/run_hello-R.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Download test data
-        run: ./download-data.py --test-data --format SCE
-
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -46,6 +43,9 @@ jobs:
         uses: r-lib/actions/setup-renv@v2
         with:
           working-directory: ${{ env.MODULE_PATH }}
+
+      - name: Download test data
+        run: ./download-data.py --test-data --format SCE
 
       - name: Run analysis
         run: |

--- a/.github/workflows/run_hello-python.yml
+++ b/.github/workflows/run_hello-python.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Download test data
-        run: ./download-data.py --test-data --format AnnData
-
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v3
 
@@ -44,6 +41,9 @@ jobs:
         run: |
           conda install conda-lock
           conda-lock install --name test ${MODULE_PATH}/conda-lock.yml
+
+      - name: Download test data
+        run: ./download-data.py --test-data --format AnnData
 
       - name: Run analysis
         run: |

--- a/.github/workflows/run_hello-python.yml
+++ b/.github/workflows/run_hello-python.yml
@@ -7,7 +7,7 @@
 name: Run hello-python analysis module
 env:
   MODULE_PATH: analyses/hello-python
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-2
 
 concurrency:
   # only one run per branch at a time

--- a/docs/ensuring-repro/workflows/run-module-gha.md
+++ b/docs/ensuring-repro/workflows/run-module-gha.md
@@ -37,11 +37,11 @@ As an analysis module matures, the Data Lab staff will activate this GHA file so
 Each module testing GHA is initially created with these steps, which should be updated to reflect the given module's needs:
 
 - Checkout the repository
+- Set up the module environment
+    - Depending on [the flags used when creating your module](../../contributing-to-analyses/analysis-modules/creating-a-module.md#module-creation-script-flags), these steps will install the [`renv` and/or conda environment](../managing-software/index.md) from existing environment files (`renv.lock` and/or `conda-lock.yml`, respectively).
 - Download test data
     - Use the [`download-data.py`](../../getting-started/accessing-resources/getting-access-to-data.md#using-the-download-data-script) and/or [`download-results.py`](../../getting-started/accessing-resources/getting-access-to-data.md#accessing-scpca-module-results) scripts to specify the set of input files you need, with the `--test-data` flag to specify downloading the test data.
     - After this step, the `data/current` directory will point to the test data, ensuring the module GHA runs using the test data.
-- Set up the module environment
-    - Depending on [the flags used when creating your module](../../contributing-to-analyses/analysis-modules/creating-a-module.md#module-creation-script-flags), these steps will install the [`renv` and/or conda environment](../managing-software/index.md) from existing environment files (`renv.lock` and/or `conda-lock.yml`, respectively).
 - Run the analysis module
     - Generally, this will involve calling the [module's run script](../../contributing-to-analyses/analysis-modules/running-a-module.md).
 

--- a/templates/workflows/run_conda-module.yml
+++ b/templates/workflows/run_conda-module.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up conda
+        # Note that this creates and activates an environment named 'test' by default
         uses: conda-incubator/setup-miniconda@v3
 
       - name: Install and activate locked conda environment

--- a/templates/workflows/run_conda-module.yml
+++ b/templates/workflows/run_conda-module.yml
@@ -10,7 +10,7 @@
 name: Run {{ openscpca_module }} analysis module
 env:
   MODULE_PATH: analyses/{{ openscpca_module }}
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-2
 
 concurrency:
   # only one run per branch at a time

--- a/templates/workflows/run_conda-module.yml
+++ b/templates/workflows/run_conda-module.yml
@@ -37,10 +37,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # Update this step as needed to download the desired data
-      - name: Download test data
-        run: ./download-data.py --test-data --format AnnData
-
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v3
 
@@ -49,7 +45,11 @@ jobs:
           conda install conda-lock
           conda-lock install --name test ${MODULE_PATH}/conda-lock.yml
 
+      # Update this step as needed to download the desired data
+      - name: Download test data
+        run: ./download-data.py --test-data --format AnnData
+
       - name: Run analysis module
         run: |
           cd ${MODULE_PATH}
-          # run module script here
+          # run module script(s) here

--- a/templates/workflows/run_renv-module.yml
+++ b/templates/workflows/run_renv-module.yml
@@ -34,10 +34,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # Update this step as needed to download the desired data
-      - name: Download test data
-        run: ./download-data.py --test-data --format SCE
-
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -52,7 +48,11 @@ jobs:
         with:
           working-directory: ${{ env.MODULE_PATH }}
 
+      # Update this step as needed to download the desired data
+      - name: Download test data
+        run: ./download-data.py --test-data --format SCE
+
       - name: Run analysis module
         run: |
           cd ${MODULE_PATH}
-          # run module script here
+          # run module script(s) here

--- a/templates/workflows/run_renv-module.yml
+++ b/templates/workflows/run_renv-module.yml
@@ -10,7 +10,7 @@
 name: Run {{ openscpca_module }} analysis module
 env:
   MODULE_PATH: analyses/{{ openscpca_module }}
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-2
 
 concurrency:
   # only one run per branch at a time


### PR DESCRIPTION
Closes #529 

This PR updates workflows and associated docs (which currently live only in the `reproducibility-docs` branch, hence that is the target branch here) to download data after environment setup. I also updated a couple small spots in workflows, both existing workflows and templates, based on the reviews in #556. 

Any other spots to update that I missed here? 

(Incidentally, I noticed we also don't have a GHA to run the `simulate-sce` module. Did we want one?)