### PR TITLE
Add update-symlink to data download docs

### DIFF
--- a/docs/aws/index.md
+++ b/docs/aws/index.md
@@ -11,7 +11,7 @@ We use Amazon Web Services (AWS) to grant contributors access to data and Linux 
 
 ## S3: Data and results storage with AWS
 
-We use [AWS S3](https://aws.amazon.com/s3/) to store project data and results from mature analysis modules in folders referred to in S3 as "buckets."
+We use [AWS S3](https://aws.amazon.com/s3/) to store project data and results from mature analysis modules in locations referred to in S3 as "buckets."
 We also use S3 as central location for you to share your result files with us before [filing a pull request](../contributing-to-analyses/creating-pull-requests/index.md).
 All contributors will have a designated [researcher bucket](working-with-s3-buckets.md) where results can be synced and shared as part of [code review](../contributing-to-analyses/pr-review-and-merge/index.md).
 

--- a/docs/aws/index.md
+++ b/docs/aws/index.md
@@ -9,16 +9,16 @@ We use Amazon Web Services (AWS) to grant contributors access to data and Linux 
 
     Note that your use of AWS services described in this section counts towards your [monthly budget](../getting-started/accessing-resources/getting-access-to-compute.md#monthly-budget).
 
-## S3: Data storage with AWS
+## S3: Data and results storage with AWS
 
-We use [AWS S3](https://aws.amazon.com/s3/) to store project data in folders referred to in S3 as "buckets."
+We use [AWS S3](https://aws.amazon.com/s3/) to store project data and results from mature analysis modules in folders referred to in S3 as "buckets."
 We also use S3 as central location for you to share your result files with us before [filing a pull request](../contributing-to-analyses/creating-pull-requests/index.md).
 All contributors will have a designated [researcher bucket](working-with-s3-buckets.md) where results can be synced and shared as part of [code review](../contributing-to-analyses/pr-review-and-merge/index.md).
 
 Please refer to these pages about working with S3:
 
 - [Configuring and logging into AWS from the command line](../technical-setup/environment-setup/configure-aws-cli.md)
-- [Accessing project data from S3](../getting-started/accessing-resources/getting-access-to-data.md#accessing-data-from-s3)
+- [Accessing project data and results from S3](../getting-started/accessing-resources/getting-access-to-data.md#accessing-data-as-an-openscpca-contributor)
 - [Using your researcher bucket](working-with-s3-buckets.md)
 
 ## Lightsail for Research: Virtual computing with AWS

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -354,17 +354,3 @@ data
 │          └── single_cell_metadata.tsv
 └── current -> portal-downloads
 ```
-
-For example, if you downloaded `SingleCellExperiment`-formatted files for the sample `SCPCS000001` from the project `SCPCP000001`, your files should be organized as:
-
-```sh
-data
-├── portal-downloads
-│       └── SCPCP000001
-│          └── SCPCS000001
-│          │     ├── SCPCL000001_filtered.rds
-│          │     ├── SCPCL000001_processed.rds
-│          │     └── SCPCL000001_unfiltered.rds
-│          └── single_cell_metadata.tsv
-└── current -> portal-downloads
-```

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -7,12 +7,12 @@ Broadly speaking, there are three kinds of ScPCA data you might wish to work wit
 
 1. Data from the ScPCA Portal
     - You can find out more about the contents of files and how they were processed from the ScPCA documentation: <https://scpca.readthedocs.io>.
-    - OpenScPCA project contributors [with an Amazon Web Services (AWS) acccount](./index.md#getting-access-to-aws) can access data using the provided `download-data.py` script, [as described below](#using-the-download-data-script).
+    - OpenScPCA project contributors [with an Amazon Web Services (AWS) account](./index.md#getting-access-to-aws) can access data using the provided `download-data.py` script, [as described below](#using-the-download-data-script).
         - If you have not yet been onboarded to OpenScPCA, you will need to access data [directly from the ScPCA Portal](#accessing-data-from-the-scpca-portal).
 1. Results from other OpenScPCA modules
-    - OpenScPCA project contributors with an AWS acccount can obtain results from modules that have been added to the `OpenScPCA-nf` workflow by [following the instructions below](#accessing-scpca-module-results).
+    - OpenScPCA project contributors with an AWS account can obtain results from completed modules using the provided `download-results.py` script, [as described below](#accessing-scpca-module-results).
     - To use results from an in-progress module from the `OpenScPCA-analysis` repository, you may need to run the module yourself to generate its result files.
-1. Test datasets
+2. Test datasets
     - We provide reduced-size test files with simulated and/or permuted versions of both ScPCA Portal data and results from completed modules.
     - These data are used for automated testing, but you can also use them while developing your module if smaller files helps make development more efficient.
     - You do not need an AWS account to download the test files, so you can use this data before you are granted full access to ScPCA data.
@@ -21,9 +21,9 @@ Broadly speaking, there are three kinds of ScPCA data you might wish to work wit
 ## Accessing data as an OpenScPCA contributor
 
 Because we expect that contributors may want to work with many samples or analyze data on remote systems, contributors can access to ScPCA data and results from AWS S3.
-We also provide a download script to make accessing these data more convenient.
+We provide a download script to make accessing these data more convenient.
 
-Before you can access data in this manner, the Data Lab team needs to create an AWS account for you; these data are not publicly accessible.
+Before you can access data in this manner, the Data Lab team needs to create an AWS account for you, as these data are not publicly accessible.
 See our documentation [getting access to AWS](index.md#getting-access-to-aws) for more information.
 
 !!! info Review additional restrictions
@@ -118,15 +118,9 @@ If you had already downloaded the most recent data or results, this will not rep
     ./download-data.py --projects SCPCPXXXXXX --dryrun
     ```
 
-- To update the `data/current` symlink, for example if you have downloaded multiple releases and/or [test data](#accessing-test-data), use the `--update-symlink` flag in one of the following ways.
-  - Note that no data will be downloaded if you use this flag.
-    ```sh
-    # update data/current to direct to most recent local release
-    ./download-data.py --update-symlink
+The `download-data.py` script will always update the `data/current` symlink to point to the specified release directory.
+You can use the [`--update-symlink` flag described below](#updating-the-current-symlink) to update which release directory the `data/current` symlink directs to.
 
-    # update data/current to direct to specific release version
-    ./download-data.py --update-symlink --release 2024-05-01
-    ```
 
 ### Download data file structure
 
@@ -289,33 +283,44 @@ You do not need an AWS account set up to download the test data or results.
 
 Running either of the above commands will update the `data/current` symlink to point to the `data/test` directory.
 This means any real ScPCA data or results you had previously downloaded will no longer be in the `data/current` path.
+You can use the `--update-symlink` flag, as described below, to update which release directory the `data/current` symlink directs to.
 
-- To switch this symlink path back to the real ScPCA data or results, run the _data download_ script with the flag `--update-symlink` as follows:
+### Updating the `current` symlink
+
+As described above, the `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recently-downloaded release directory.
+You can update this symlink to point to a different data release directory (or to the test data directory) in one of two ways:
+
+1. When you download a new data or results release, `current` will automatically be updated to direct to the newly-downloaded release directory.
+    - Both the `download-data.py` and `download-results.py` scripts will print a message telling you where `current` directs to.
+1. You can use the `download-data.py` script with the `--update-symlink` flag to redirect the `current` symlink to a release of your choice.
+Note that no data will be downloaded if you use this flag.
+Below are some common use cases for this flag:
+
     ```sh
-    # update the data/current symlink to direct to the most recent release
+    # By default, this flag will update the current symlink to direct to the
+    #  most recent release that is present on your computer
     ./download-data.py --update-symlink
-    ```
 
-- Conversely, you can also use the `--update-symlink` and `--test-data` flags together to direct the `data/current` symlink to instead point to any present test data as follows:
-    ```sh
-    # update the data/current symlink to direct to the test data
+    # Use the --release option to specify which release to direct the symlink to
+    ./download-data.py --update-symlink --release 2025-05-01
+
+    # Use the --test-data flag to direct the symlink to the test data
     ./download-data.py --update-symlink --test-data
     ```
 
 
 ## Accessing data from the ScPCA Portal
 
-ScPCA data are readily available from the ScPCA Portal that the Data Lab maintains: <https://scpca.alexslemonade.org/>.
-If you have not formally joined the OpenScPCA project, you will need to obtain data directly from the Portal.
+If you have not formally joined the OpenScPCA project, you will need to obtain data directly from ScPCA Portal that the Data Lab maintains: <https://scpca.alexslemonade.org/>.
 
 You can select the project(s) or sample(s) you are interested in analyzing and download them from the Portal.
 
-We recommend creating a `portal_downloads` subdirectory in the local copy of the `data` directory, which can be accomplished by running the following command from the root of the repository on Linux or macOS:
+We recommend creating a `portal-downloads` subdirectory in the local copy of the `data` directory, which can be accomplished by running the following command from the root of the repository on Linux or macOS:
 
 ```sh
-mkdir -p data/portal_downloads
+mkdir -p data/portal-downloads
 ```
 
 You can then develop your analysis using these paths.
 
-However, before filing a pull request, you should change your paths to reflect the directory established by the download script (`data/current`) described in the next section.
+However, before filing a pull request, you should change your paths to use `data/current` directory [established by the data download script](#download-data-file-structure).

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -16,6 +16,24 @@ Broadly speaking, there are three kinds of ScPCA data you might wish to work wit
     - These data are used for automated testing, but you can also use them while developing your module if smaller files helps make development more efficient.
     - You do not need an AWS account to download the test files, so you can use this data before you are granted full access to ScPCA data.
 
+
+!!! tip "Log into AWS CLI before running the download scripts"
+    Below, we describe how to use both the `data-download.py` and `results-download.py` script to download ScPCA data and result files, respectively.
+    Before running either of these scripts locally (e.g., not from a [virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    To do this, run the following commands in terminal before running the script, and follow instructions to log in.
+
+    ```sh
+    # replace `openscpca` with your AWS CLI profile name if it differs
+    export AWS_PROFILE=openscpca
+    aws sso login
+    ```
+
+    The command `export AWS_PROFILE=openscpca` will define your AWS profile name as `openscpca` for the duration of your terminal session.
+    Defining this variable is helpful because the download scripts also need your profile name to download files from S3.
+
+    Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
+
+
 ## Accessing ScPCA data
 
 ### Accessing data on the ScPCA Portal
@@ -55,21 +73,6 @@ See our documentation [getting access to AWS](index.md#getting-access-to-aws) fo
     - [Configured the AWS CLI and logged in](../../technical-setup/environment-setup/configure-aws-cli.md) OR are [using Lightsail for Research](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws) (which doesn't require logging in via the AWS CLI)
 
 The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-data.py) is designed to download files from whatever release you specify to a folder in `data` named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`.
-
-!!! tip "Log into AWS CLI before running the script"
-    Before running this script locally, you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
-    To do this, run the following commands in terminal before running the `data-download.py` script, and follow instructions to log in.
-
-    ```sh
-    # replace `openscpca` with your AWS CLI profile name if it differs
-    export AWS_PROFILE=openscpca
-    aws sso login
-    ```
-
-    The command `export AWS_PROFILE=openscpca` will define your AWS profile name as `openscpca` for the duration of your terminal session.
-    Defining this environment variable is helpful because the `download-data.py` script also needs your profile name to download data from S3.
-
-    Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
 
 We briefly cover some of this script's most common use cases below, but we encourage you to review all the options available to you.
 
@@ -169,20 +172,6 @@ You can list all the options for `download-results.py` by running the following 
 ./download-results.py --help
 ```
 
-!!! tip "Log into AWS CLI before running the script"
-    Before running this script locally, you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
-    To do this, run the following commands in terminal before running the `results-download.py` script, and follow instructions to log in.
-
-    ```sh
-    # replace `openscpca` with your AWS CLI profile name if it differs
-    export AWS_PROFILE=openscpca
-    aws sso login
-    ```
-
-    The command `export AWS_PROFILE=openscpca` will define your AWS profile name as `openscpca` for the duration of your terminal session.
-    Defining this variable is helpful because the `download-data.py` script also needs your profile name to download data from S3.
-
-    Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
 
 To download results for one or more modules, use the `--modules` option as follows:
 

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -59,7 +59,7 @@ The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analy
 We briefly cover some of this script's most common use cases below, but we encourage you to review all the options available to you.
 
 !!! tip "Log into AWS CLI before running the script"
-    Before running this script locally, you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    Before running this script locally (i.e., not from an ALSF-provided [virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
     To do this, run the following commands in terminal before running the `download-data.py` script, and follow instructions to log in.
 
     ```sh
@@ -186,7 +186,7 @@ We have provided a [`download-results.py` script](https://github.com/AlexsLemona
 We briefly cover some of the most common use cases below, but we encourage you to review all the options available to you.
 
 !!! tip "Log into AWS CLI before running the script"
-    Before running this script locally, you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    Before running this script locally (i.e., not from an ALSF-provided [virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
     To do this, run the following commands in terminal before running the `download-results.py` script, and follow instructions to log in.
 
     ```sh

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -290,7 +290,7 @@ Similarly, you use the [download result script](#accessing-scpca-module-results)
 
 Running either of the above commands will update the `data/current` symlink to point to the `data/test` directory.
 This means any real ScPCA data or results you had previously downloaded will no longer be in the `data/current` path.
-You can use the `--update-symlink` flag, as described below, to update which release directory the `data/current` symlink directs to.
+You can use the `download-data.py` script with the `--update-symlink` flag, as described below, to update which release directory the `data/current` symlink directs to.
 
 ## Updating the `current` symlink
 

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -335,7 +335,7 @@ You can accomplish this with the following:
 mkdir -p data/portal-downloads
 
 # set up a symlink from data/current to data/portal-downloads
-ln -s data/portal-downloads
+ln -s data/portal-downloads data/current
 ```
 
 You can then develop your analysis specifying the `data/current` path when reading in data.

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -113,14 +113,7 @@ If you had already downloaded the most recent data or results, this will not rep
 
 -->
 
-- To review what samples would be downloaded without performing the download yet, you can use the `--dryrun` option as follows.
-    - We strongly recommend using the `--dryrun` flag the first time you run the script for a new data download to ensure the downloaded files are as expected.
-
-    ```sh
-    ./download-data.py --dryrun
-    ```
-
-- If you're only working with a subset of the data, you can use the `--projects` or `--samples` to download select projects or samples, respectively (note that these options are mutually exclusive):
+- If you're only working with a subset of the data, you can use the `--projects` or `--samples` option to download select projects or samples, respectively (note that these options are mutually exclusive):
 
     ```sh
     # use the --projects option
@@ -128,6 +121,16 @@ If you had already downloaded the most recent data or results, this will not rep
 
     # use the --samples option
     ./download-data.py --samples SCPCSXXXXXX,SCPCSXXXXXY
+    ```
+
+- To review the files would be downloaded without performing the download yet, you can use the `--dryrun` option as follows.
+    - We strongly recommend using the `--dryrun` flag the first time you run the script for a new data download to ensure the downloaded files are as expected.
+
+    ```sh
+    ./download-data.py --dryrun
+
+    # show what would be downloaded when the --projects option is used, for example
+    ./download-data.py --projects SCPCPXXXXXX --dryrun
     ```
 
 - To update the `data/current` symlink, for example if you have downloaded multiple releases and/or [test data](#accessing-test-data), use the `--update-symlink` flag in one of the following ways.

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -202,7 +202,7 @@ We briefly cover some of the most common use cases below, but we encourage you t
     ./download-results.py --help
     ```
 
-- To download results for one or more modules, use the `--modules` option as follows:
+- To download results for one or more modules, use the `--modules` option with the module directory name(s) as a comma separated list:
     ```sh
     # Get results from a single module
     ./download-results.py --modules module-name
@@ -297,7 +297,7 @@ You do not need an AWS account set up to download the test data or results.
     ```
 
 
-Running either of the above commands will update the `data/current` symlink to point to the `data/test` directory, rather than a given data release directory.
+Running either of the above commands will update the `data/current` symlink to point to the `data/test` directory.
 This means any real ScPCA data or results you had previously downloaded will no longer be in the `data/current` path.
 
 - To switch this symlink path back to the real ScPCA data or results, run the _data download_ script with the flag `--update-symlink` as follows:

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -332,4 +332,4 @@ ln -s data/portal-downloads data/current
 
 You can then develop your analysis using these paths.
 
-However, before filing a pull request, you should change your paths to use `data/current` directory [established by the data download script](#download-data-file-structure).
+However, before filing a pull request, you should change your paths to use `data/current` directory [established by the data download script](#downloaded-data-file-structure).

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -97,6 +97,25 @@ We briefly cover some of this script's most common use cases below, but we encou
     ./download-data.py --format AnnData
     ```
 
+- To download a specific release, you can use the `--release` flag as follows:
+
+
+
+<!--
+
+TODO: This section needs to be reworked to avoid unexpected downloads. We should recommend --use-release instead.
+
+These commands will download either test data or results, respectively, and will
+
+```sh
+./download-data.py --release current
+
+./download-results.py --release current
+```
+If you had already downloaded the most recent data or results, this will not repeat downloading the files you already have.
+
+-->
+
 - To review what samples would be downloaded without performing the download yet, you can use the `--dryrun` option as follows.
     - We strongly recommend using the `--dryrun` flag the first time you run the script for a new data download to ensure the downloaded files are as expected.
 
@@ -104,7 +123,7 @@ We briefly cover some of this script's most common use cases below, but we encou
     ./download-data.py --dryrun
     ```
 
-- If you're only working with a subset of the data, you can use the `--projects` or `--samples` to download select samples (note: these options are mutually exclusive):
+- If you're only working with a subset of the data, you can use the `--projects` or `--samples` to download select projects or samples, respectively (note that these options are mutually exclusive):
 
     ```sh
     # use the --projects option
@@ -166,46 +185,41 @@ We have provided a [`download-results.py` script](https://github.com/AlexsLemona
 
 We briefly cover some of the most common use cases below, but we encourage you to review all the options available to you.
 
-You can list all the options for `download-results.py` by running the following from the root directory of the repository:
+- You can list all the options for `download-results.py` by running the following from the root directory of the repository:
+    ```sh
+    ./download-results.py --help
+    ```
 
-```sh
-./download-results.py --help
-```
+- To download results for one or more modules, use the `--modules` option as follows:
+    ```sh
+    # Get results from a single module
+    ./download-results.py --modules module-name
 
+    # Get results from several modules
+    ./download-results.py --modules first-module,second-module
+    ```
 
-To download results for one or more modules, use the `--modules` option as follows:
-
-```sh
-# Get results from a single module
-./download-results.py --modules module-name
-
-# Get results from several modules
-./download-results.py --modules first-module,second-module
-```
-
-To list all available modules for which you can download results, you can use the `--list-modules` option as follows.
+- To list all available modules for which you can download results, you can use the `--list-modules` option as follows.
 This will list all modules available in, by default, the current release:
+    ```sh
+    ./download-results.py --list-modules
+    ```
 
-```sh
-./download-results.py --list-modules
-```
+- To see the result files that would be downloaded without performing the download yet, you can use the `--dryrun` option as follows:
+    - We strongly recommend using the `--dryrun` flag the first time you run the script for a new data download to ensure the downloaded files are as expected.
+    ```sh
+    ./download-results.py --modules module-name --dryrun
+    ```
 
-To see the result files that would be downloaded without performing the download yet, you can use the `--dryrun` option as follows:
+- While the structure of results files varies by module, some modules' results will be organized by project and/or sample.
+For those modules, you can use either the `--projects` or `--samples` flag (noting that these options are mutually exclusive) to download results specific to one or more projects or samples, respectively:
+    ```sh
+    # use the --projects option
+    ./download-results.py --modules module-name --dryrun --projects SCPCPXXXXXX
 
-```sh
-./download-results.py --modules module-name --dryrun
-```
-
-While the structure of results files varies by module, some modules' results will be organized by project and/or sample.
-For those modules, you can use either the `--projects` or `--samples` flag (noting that these options are mutually exclusive) to download results specific to one or more projects or samples:
-
-```sh
-# use the --projects option
-./download-results.py --modules module-name --dryrun --projects SCPCPXXXXXX
-
-# use the --samples option
-./download-results.py --modules module-name --dryrun --samples SCPCSXXXXXX,SCPCSXXXXXY
-```
+    # use the --samples option
+    ./download-results.py --modules module-name --dryrun --samples SCPCSXXXXXX,SCPCSXXXXXY
+    ```
 
 
 #### Download result data structure
@@ -246,8 +260,7 @@ To list all available releases, you can use the following command from the root 
 ./download-results.py --list-releases
 ```
 
-The `data/current` directory is symlinked to the current release directory
-.
+The `data/current` directory is symlinked to the current release directory.
 This is generally the path you should use in your code.
 
 
@@ -261,31 +274,28 @@ Similarly, you use the [download result script](#accessing-scpca-module-results)
 
 You do not need an AWS account set up to download the test data or results.
 
-To download test data with all other options set at default, run the following from the root of the repository:
+- To download test data with all other options set at default, run the following from the root of the repository:
+    ```sh
+    ./download-data.py --test-data
+    ```
 
-```sh
-./download-data.py --test-data
-```
+- To download a given module's results as generated with the test data, run the following from the root of the repository:
+    ```sh
+    ./download-results.py --modules module-name --test-data
+    ```
 
-To download a given module's results as generated with the test data, run the following from the root of the repository:
 
-```sh
-./download-results.py --modules module-name --test-data
-```
-
-<!--
-
-TODO: This section needs to be reworked to avoid unexpected downloads. We should recommend --use-release instead.
-
-These commands will download either test data or results, respectively, and will update the `data/current` symlink to instead point to the `data/test` directory.
+Running either of the above commands will update the `data/current` symlink to point to the `data/test` directory, rather than a given data release directory.
 This means any real ScPCA data or results you had previously downloaded will no longer be in the `data/current` path.
-To switch this symlink path back to ScPCA data or results, rerun either script with the `--release current` option:
 
-```sh
-./download-data.py --release current
+- To switch this symlink path back to the real ScPCA data or results, run the _data download_ script with the flag `--update-symlink` as follows:
+    ```sh
+    # update the data/current symlink to direct to the most recent release
+    ./download-data.py --update-symlink
+    ```
 
-./download-results.py --release current
-```
-If you had already downloaded the most recent data or results, this will not repeat downloading the files you already have.
-
--->
+- Conversely, you can also use the `--update-symlink` and `--test-data` flags together to direct the `data/current` symlink to instead point to any present test data as follows:
+    ```sh
+    # update the data/current symlink to direct to the test data
+    ./download-data.py --update-symlink --test-data
+    ```

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -8,7 +8,7 @@ Broadly speaking, there are three kinds of ScPCA data you might wish to work wit
 1. Data from the ScPCA Portal
     - You can find out more about the contents of files and how they were processed from the ScPCA documentation: <https://scpca.readthedocs.io>.
     - OpenScPCA project contributors [with an Amazon Web Services (AWS) account](./index.md#getting-access-to-aws) can access data using the provided `download-data.py` script, [as described below](#using-the-download-data-script).
-    - All data is also available [directly from the ScPCA Portal](#accessing-data-from-the-scpca-portal) for users who have not yet fully joined the OpenSCPCA project.
+    - All data is also available [directly from the ScPCA Portal](#accessing-data-from-the-scpca-portal) for users who have not yet fully joined the OpenScPCA project.
 2. Results from other OpenScPCA modules
     - OpenScPCA project contributors with an AWS account can obtain results from completed modules using the provided `download-results.py` script, [as described below](#accessing-scpca-module-results).
     - To use results from an in-progress module from the `OpenScPCA-analysis` repository, you may need to run the module yourself to generate its result files.
@@ -45,7 +45,7 @@ We briefly cover some of this script's most common use cases below, but we encou
 All examples below assume you are running the script from the root of the repository.
 
 !!! tip "Log into AWS CLI before running the script"
-    Before running this script locally (i.e., not using Lightsail for Research](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    Before running this script locally (i.e., not using [Lightsail for Research](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
     To do this, run the following commands in terminal before running the `download-data.py` script, and follow instructions to log in.
 
     ```sh

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -165,7 +165,7 @@ We briefly cover some of the most common use cases below, but we encourage you t
 All examples below assume you are running the script from the root of the repository.
 
 !!! tip "Log into AWS CLI before running the script"
-    Before running this script locally (i.e., not from an [ALSF-provided virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    Before running this script locally (i.e., not using [Lightsail for Research](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
     To do this, run the following commands in terminal before running the `download-results.py` script, and follow instructions to log in.
 
     ```sh
@@ -318,10 +318,10 @@ Below are some common use cases for this flag:
 
 ## Accessing data from the ScPCA Portal
 
-If you have not yet been [granted access to ScPCA data via AWS](./index.md#getting-access-to-aws), you will need to obtain data directly from [the ScPCA Portal that the Data Lab maintains](https://scpca.alexslemonade.org).
+If you have not yet been [granted access to OpenScPCA AWS resources](./index.md#getting-access-to-aws), you will need to obtain data directly from [the ScPCA Portal](https://scpca.alexslemonade.org).
 You can download the project(s) or sample(s) you are interested in analyzing from the ScPCA Portal.
 
-Note that you can also access the [OpenScPCA test data](#accessing-test-data) before getting AWS access as well.
+Note that you can download the [OpenScPCA test data](#accessing-test-data) before getting AWS access as well.
 
 
 ### Organizing data files
@@ -341,7 +341,7 @@ ln -s data/portal-downloads data/current
 You can then develop your analysis specifying the `data/current` path when reading in data.
 This way, your directory names will be compatible with the file structure established by the [OpenScPCA data download script](#using-the-download-data-script).
 
-Within `data/portal-downloads`, we further recommend organizing your files in the same manner [as the official OpenScPCA data download script does](#downloaded-data-file-structure), as in:
+Within `data/portal-downloads`, we further recommend organizing your files in the same manner [as the OpenScPCA data download script does](#downloaded-data-file-structure), as in:
 
 ```sh
 data

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -368,21 +368,3 @@ data
 │          └── single_cell_metadata.tsv
 └── current -> portal-downloads
 ```
-
-
-
-
-
-We recommend creating a `portal-downloads` subdirectory in the local copy of the `data` directory, and then creating a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) at `data/current` to direct to `data/portal-downloads`.
-Within `data/portal-downloads`, we further recommend organizing your files in the same manner [as the official OpenScPCA data download script does](#downloaded-data-file-structure), fo
-
-You can accomplish this with the following:
-
-```sh
-# create the data/portal-downloads directory
-mkdir -p data/portal-downloads
-
-# set up a symlink from data/current to data/portal-downloads
-ln -s data/portal-downloads data/current
-```
-

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -16,24 +16,6 @@ Broadly speaking, there are three kinds of ScPCA data you might wish to work wit
     - These data are used for automated testing, but you can also use them while developing your module if smaller files helps make development more efficient.
     - You do not need an AWS account to download the test files, so you can use this data before you are granted full access to ScPCA data.
 
-
-!!! tip "Log into AWS CLI before running the download scripts"
-    Below, we describe how to use both the `data-download.py` and `results-download.py` script to download ScPCA data and result files, respectively.
-    Before running either of these scripts locally (e.g., not from a [virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
-    To do this, run the following commands in terminal before running the script, and follow instructions to log in.
-
-    ```sh
-    # replace `openscpca` with your AWS CLI profile name if it differs
-    export AWS_PROFILE=openscpca
-    aws sso login
-    ```
-
-    The command `export AWS_PROFILE=openscpca` will define your AWS profile name as `openscpca` for the duration of your terminal session.
-    Defining this variable is helpful because the download scripts also need your profile name to download files from S3.
-
-    Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
-
-
 ## Accessing ScPCA data
 
 ### Accessing data on the ScPCA Portal
@@ -75,6 +57,21 @@ See our documentation [getting access to AWS](index.md#getting-access-to-aws) fo
 The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-data.py) is designed to download files from whatever release you specify to a folder in `data` named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`.
 
 We briefly cover some of this script's most common use cases below, but we encourage you to review all the options available to you.
+
+!!! tip "Log into AWS CLI before running the script"
+    Before running this script locally, you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    To do this, run the following commands in terminal before running the `download-data.py` script, and follow instructions to log in.
+
+    ```sh
+    # replace `openscpca` with your AWS CLI profile name if it differs
+    export AWS_PROFILE=openscpca
+    aws sso login
+    ```
+
+    The command `export AWS_PROFILE=openscpca` will define your AWS profile name as `openscpca` for the duration of your terminal session.
+    Defining this environment variable is helpful because the `download-data.py` script also needs your profile name to download data from S3.
+
+    Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
 
 - You can list all the options for the download data script by running the following from the root directory of the repository:
     ```sh
@@ -184,6 +181,21 @@ If you wish to use output from an `OpenScPCA-nf` analysis module in your module,
 We have provided a [`download-results.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-results.py) that you can use to download results from a module that has been run in `OpenScPCA-nf`.
 
 We briefly cover some of the most common use cases below, but we encourage you to review all the options available to you.
+
+!!! tip "Log into AWS CLI before running the script"
+    Before running this script locally, you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    To do this, run the following commands in terminal before running the `download-results.py` script, and follow instructions to log in.
+
+    ```sh
+    # replace `openscpca` with your AWS CLI profile name if it differs
+    export AWS_PROFILE=openscpca
+    aws sso login
+    ```
+
+    The command `export AWS_PROFILE=openscpca` will define your AWS profile name as `openscpca` for the duration of your terminal session.
+    Defining this variable is helpful because the `download-data.py` script also needs your profile name to download data from S3.
+
+    Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
 
 - You can list all the options for `download-results.py` by running the following from the root directory of the repository:
     ```sh

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -42,6 +42,7 @@ TODO DURING REVIEW: Do we still need this admonition note?
 The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-data.py) is designed to download files from whatever release you specify to a directory in `data` named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`.
 
 We briefly cover some of this script's most common use cases below, but we encourage you to review all the options available to you.
+All examples below assume you are running the script from the root of the repository.
 
 !!! tip "Log into AWS CLI before running the script"
     Before running this script locally (i.e., not from an [ALSF-provided virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
@@ -58,7 +59,8 @@ We briefly cover some of this script's most common use cases below, but we encou
 
     Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
 
-- You can list all the options for the download data script by running the following from the root directory of the repository:
+- You can list all possible arguments and their usage for the download data script with the following:
+
     ```sh
     ./download-data.py --help
     ```
@@ -79,24 +81,21 @@ We briefly cover some of this script's most common use cases below, but we encou
     ./download-data.py --format AnnData
     ```
 
-- To download a specific release, you can use the `--release` flag as follows:
+- To download a specific release other than the most recent release, you can use the `--release` option as follows.
+Again, please download full data releases with caution, as they are quite large!
+    - First, you may wish to use the `--list-releases` flag to see all available releases, which are named in `YYYY-MM-DD` format based on their release date.
 
+    ```sh
+    # First, see which releases are available for download
+    ./download-data.py --list-releases
 
+    # Download SingleCellExperiment format files for a specific release
+    # For example, this downloads the 2024-05-01 release
+    ./download-data.py --release 2024-05-01
 
-<!--
-
-TODO: This section needs to be reworked to avoid unexpected downloads. We should recommend --use-release instead.
-
-These commands will download either test data or results, respectively, and will
-
-```sh
-./download-data.py --release current
-
-./download-results.py --release current
-```
-If you had already downloaded the most recent data or results, this will not repeat downloading the files you already have.
-
--->
+    # Download AnnData format files for a specific release, for example
+    ./download-data.py --release 2024-05-01 --format AnnData
+    ```
 
 - If you're only working with a subset of the data, you can use the `--projects` or `--samples` option to download select projects or samples, respectively (note that these options are mutually exclusive):
 
@@ -164,6 +163,7 @@ If you wish to use output from an `OpenScPCA-nf` analysis module in your module,
 We have provided a [`download-results.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-results.py) that you can use to download results from a module that has been run in `OpenScPCA-nf`.
 
 We briefly cover some of the most common use cases below, but we encourage you to review all the options available to you.
+All examples below assume you are running the script from the root of the repository.
 
 !!! tip "Log into AWS CLI before running the script"
     Before running this script locally (i.e., not from an [ALSF-provided virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
@@ -180,12 +180,14 @@ We briefly cover some of the most common use cases below, but we encourage you t
 
     Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
 
-- You can list all the options for `download-results.py` by running the following from the root directory of the repository:
+- You can list all possible arguments and their usage for the results download script with the following:
+
     ```sh
     ./download-results.py --help
     ```
 
 - To download results for one or more modules, use the `--modules` option with the module directory name(s) as a comma separated list:
+
     ```sh
     # Get results from a single module
     ./download-results.py --modules module-name
@@ -194,20 +196,23 @@ We briefly cover some of the most common use cases below, but we encourage you t
     ./download-results.py --modules first-module,second-module
     ```
 
-- To list all available modules for which you can download results, you can use the `--list-modules` option as follows.
+- To list all available modules for which you can download results, you can use the `--list-modules` flag as follows.
 This will list all modules available in, by default, the current release:
+
     ```sh
     ./download-results.py --list-modules
     ```
 
-- To see the result files that would be downloaded without performing the download yet, you can use the `--dryrun` option as follows:
+- To see the result files that would be downloaded without performing the download yet, you can use the `--dryrun` flag as follows:
     - We strongly recommend using the `--dryrun` flag the first time you run the script for a new data download to ensure the downloaded files are as expected.
+
     ```sh
     ./download-results.py --modules module-name --dryrun
     ```
 
 - While the structure of results files varies by module, some modules' results will be organized by project and/or sample.
 For those modules, you can use either the `--projects` or `--samples` flag (noting that these options are mutually exclusive) to download results specific to one or more projects or samples, respectively:
+
     ```sh
     # use the --projects option
     ./download-results.py --modules module-name --dryrun --projects SCPCPXXXXXX
@@ -265,17 +270,19 @@ To list all available releases, you can use the following command from the root 
 The test data are simulated or permuted data files with the same structure as the real project data, and are generally much smaller than the original data (learn more at the [`simulate-sce`](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/simulate-sce) module).
 These files are also used during automated testing of analysis modules. <!-- STUB_LINK for module GHAs -->
 
-You can use the [download data script](#using-the-download-data-script) to download the test data for the project by using the `--test-data` option.
-Similarly, you use the [download result script](#accessing-scpca-module-results) to download ScPCA results from running completed modules on the test data by using the `--test-data` option.
+You can use the [download data script](#using-the-download-data-script) to download the test data for the project by using the `--test-data` flag.
+Similarly, you use the [download result script](#accessing-scpca-module-results) to download ScPCA results from running completed modules on the test data by using the `--test-data` flag.
 
 You do not need an AWS account set up to download the test data or results.
 
 - To download test data with all other options set at default, run the following from the root of the repository:
+
     ```sh
     ./download-data.py --test-data
     ```
 
 - To download a given module's results as generated with the test data, run the following from the root of the repository:
+
     ```sh
     ./download-results.py --modules module-name --test-data
     ```
@@ -285,14 +292,14 @@ Running either of the above commands will update the `data/current` symlink to p
 This means any real ScPCA data or results you had previously downloaded will no longer be in the `data/current` path.
 You can use the `--update-symlink` flag, as described below, to update which release directory the `data/current` symlink directs to.
 
-### Updating the `current` symlink
+## Updating the `current` symlink
 
 As described above, the `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recently-downloaded release directory.
 You can update this symlink to point to a different data release directory (or to the test data directory) in one of two ways:
 
-1. When you download a new data or results release, `current` will automatically be updated to direct to the newly-downloaded release directory.
+1. When you download a new data or results release, `data/current` will automatically be updated to direct to the newly-downloaded release directory.
     - Both the `download-data.py` and `download-results.py` scripts will print a message telling you where `current` directs to.
-1. You can use the `download-data.py` script with the `--update-symlink` flag to redirect the `current` symlink to a release of your choice.
+1. You can use the `download-data.py` script with the `--update-symlink` flag to redirect the `data/current` symlink to a release of your choice.
 Note that no data will be downloaded if you use this flag.
 Below are some common use cases for this flag:
 

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -5,38 +5,22 @@ Here, we describe several ways to access data.
 
 Broadly speaking, there are three kinds of ScPCA data you might wish to work with:
 
-
-- Data from the ScPCA Portal
-    - You can find out more about the contents of files and how they were processed from the ScPCA documentation: <https://scpca.readthedocs.io>
-- Results from other OpenScPCA modules
-    - You can obtain results from modules that have been added to the `OpenScPCA-nf` workflow by [following the instructions below](#accessing-scpca-module-results).
+1. Data from the ScPCA Portal
+    - You can find out more about the contents of files and how they were processed from the ScPCA documentation: <https://scpca.readthedocs.io>.
+    - OpenScPCA project contributors [with an Amazon Web Services (AWS) acccount](./index.md#getting-access-to-aws) can access data using the provided `download-data.py` script, [as described below](#using-the-download-data-script).
+        - If you have not yet been onboarded to OpenScPCA, you will need to access data [directly from the ScPCA Portal](#accessing-data-from-the-scpca-portal).
+1. Results from other OpenScPCA modules
+    - OpenScPCA project contributors with an AWS acccount can obtain results from modules that have been added to the `OpenScPCA-nf` workflow by [following the instructions below](#accessing-scpca-module-results).
     - To use results from an in-progress module from the `OpenScPCA-analysis` repository, you may need to run the module yourself to generate its result files.
-- Test datasets
+1. Test datasets
     - We provide reduced-size test files with simulated and/or permuted versions of both ScPCA Portal data and results from completed modules.
     - These data are used for automated testing, but you can also use them while developing your module if smaller files helps make development more efficient.
     - You do not need an AWS account to download the test files, so you can use this data before you are granted full access to ScPCA data.
 
-## Accessing ScPCA data
 
-### Accessing data on the ScPCA Portal
+## Accessing data as an OpenScPCA contributor
 
-ScPCA data are readily available from the ScPCA Portal that the Data Lab maintains: <https://scpca.alexslemonade.org/>.
-
-You can select the project(s) or sample(s) you are interested in analyzing and download them from the Portal.
-
-We recommend creating a `portal_downloads` subdirectory in the local copy of the `data` directory, which can be accomplished by running the following command from the root of the repository on Linux or macOS:
-
-```sh
-mkdir -p data/portal_downloads
-```
-
-You can then develop your analysis using these paths temporarily.
-
-Before filing a pull request, you should change your paths to reflect the directory established by the download script (`data/current`) described in the next section.
-
-### Accessing data from S3
-
-Because we expect that contributors may want to work with many samples or analyze data on remote systems, access to ScPCA data on AWS S3 is also available to contributors.
+Because we expect that contributors may want to work with many samples or analyze data on remote systems, contributors can access to ScPCA data and results from AWS S3.
 We also provide a download script to make accessing these data more convenient.
 
 Before you can access data in this manner, the Data Lab team needs to create an AWS account for you; these data are not publicly accessible.
@@ -45,8 +29,9 @@ See our documentation [getting access to AWS](index.md#getting-access-to-aws) fo
 !!! info Review additional restrictions
     Please review the `DATA_USAGE.md` file included in all downloads for any additional restrictions on data usage (see [Policies](../../policies/index.md)).
 
-#### Using the download data script
+### Using the download data script
 
+TODO DURING REVIEW: Do we still need this admonition note?
 !!! note
     These instructions assume you have taken the following steps:
 
@@ -54,12 +39,12 @@ See our documentation [getting access to AWS](index.md#getting-access-to-aws) fo
     - [Set up conda](../../technical-setup/environment-setup/setup-conda.md) (note that conda is pre-installed, but not yet set up, on [Lightsail for Research](../../aws/lsfr/starting-development-on-lsfr.md#create-and-activate-a-conda-environment) instances)
     - [Configured the AWS CLI and logged in](../../technical-setup/environment-setup/configure-aws-cli.md) OR are [using Lightsail for Research](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws) (which doesn't require logging in via the AWS CLI)
 
-The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-data.py) is designed to download files from whatever release you specify to a folder in `data` named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`.
+The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-data.py) is designed to download files from whatever release you specify to a directory in `data` named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`.
 
 We briefly cover some of this script's most common use cases below, but we encourage you to review all the options available to you.
 
 !!! tip "Log into AWS CLI before running the script"
-    Before running this script locally (i.e., not from an ALSF-provided [virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    Before running this script locally (i.e., not from an [ALSF-provided virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
     To do this, run the following commands in terminal before running the `download-data.py` script, and follow instructions to log in.
 
     ```sh
@@ -143,9 +128,9 @@ If you had already downloaded the most recent data or results, this will not rep
     ./download-data.py --update-symlink --release 2024-05-01
     ```
 
-#### Download data structure
+### Download data file structure
 
-Downloads via the download script will generally have the following structure:
+Downloads via the download script will generally have the following structure.
 
 ```sh
 data
@@ -159,6 +144,11 @@ data
 └── current -> {Release}
 ```
 
+!!! tip "The `data/current` directory"
+    The `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recently-downloaded data release.
+    You should therefore use the `data/current` path in your analysis code when reading in data, rather than a specific release directory.
+
+
 See the ScPCA documentation for [more information about individual files](https://scpca.readthedocs.io/en/latest/sce_file_contents.html).
 
 Data releases are dated using the following format: `YYYY-MM-DD`.
@@ -169,10 +159,6 @@ To list all available releases, you can use the following command from the root 
 ```sh
 ./download-data.py --list-releases
 ```
-
-The release directory is symlinked to `data/current`.
-This is generally the path you should use in your code.
-
 
 ## Accessing ScPCA module results
 
@@ -186,7 +172,7 @@ We have provided a [`download-results.py` script](https://github.com/AlexsLemona
 We briefly cover some of the most common use cases below, but we encourage you to review all the options available to you.
 
 !!! tip "Log into AWS CLI before running the script"
-    Before running this script locally (i.e., not from an ALSF-provided [virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    Before running this script locally (i.e., not from an [ALSF-provided virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
     To do this, run the following commands in terminal before running the `download-results.py` script, and follow instructions to log in.
 
     ```sh
@@ -237,7 +223,7 @@ For those modules, you can use either the `--projects` or `--samples` flag (noti
     ```
 
 
-#### Download result data structure
+### Download result file structure
 
 Results will download into the `data` directory in your local copy of the `OpenScPCA-analysis` repository.
 Result downloads will generally follow this structure:
@@ -250,6 +236,11 @@ data
 │              └── {Result files}
 └── current -> {Release}
 ```
+
+!!! tip "The `data/current` directory"
+    The `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recently-downloaded release directory.
+    You should therefore use the `data/current` path in your analysis code when reading in results, rather than a specific release directory.
+
 
 Both result files and ScPCA data files follow the same release schedule.
 Therefore, if you have downloaded both data and workflow results, all files will be present in the `data` directory with this overall structure:
@@ -274,10 +265,6 @@ To list all available releases, you can use the following command from the root 
 ```sh
 ./download-results.py --list-releases
 ```
-
-The `data/current` directory is symlinked to the current release directory.
-This is generally the path you should use in your code.
-
 
 ## Accessing test data
 
@@ -314,3 +301,21 @@ This means any real ScPCA data or results you had previously downloaded will no 
     # update the data/current symlink to direct to the test data
     ./download-data.py --update-symlink --test-data
     ```
+
+
+## Accessing data from the ScPCA Portal
+
+ScPCA data are readily available from the ScPCA Portal that the Data Lab maintains: <https://scpca.alexslemonade.org/>.
+If you have not formally joined the OpenScPCA project, you will need to obtain data directly from the Portal.
+
+You can select the project(s) or sample(s) you are interested in analyzing and download them from the Portal.
+
+We recommend creating a `portal_downloads` subdirectory in the local copy of the `data` directory, which can be accomplished by running the following command from the root of the repository on Linux or macOS:
+
+```sh
+mkdir -p data/portal_downloads
+```
+
+You can then develop your analysis using these paths.
+
+However, before filing a pull request, you should change your paths to reflect the directory established by the download script (`data/current`) described in the next section.

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -80,6 +80,16 @@ All examples below assume you are running the script from the root of the reposi
     ./download-data.py --format AnnData
     ```
 
+- If you're only working with a subset of the data, you can use the `--projects` or `--samples` option to download select projects or samples, respectively (note that these options are mutually exclusive):
+
+    ```sh
+    # use the --projects option
+    ./download-data.py --projects SCPCPXXXXXX
+
+    # use the --samples option
+    ./download-data.py --samples SCPCSXXXXXX,SCPCSXXXXXY
+    ```
+
 - To download a specific release other than the most recent release, you can use the `--release` option.
 Again, download full data releases with caution, as they are quite large!
     - You can use the `--list-releases` flag to see all available releases, which are named in `YYYY-MM-DD` format based on their release date.
@@ -94,16 +104,6 @@ Again, download full data releases with caution, as they are quite large!
 
     # Download AnnData format files for a specific release, for example
     ./download-data.py --release 2024-05-01 --format AnnData
-    ```
-
-- If you're only working with a subset of the data, you can use the `--projects` or `--samples` option to download select projects or samples, respectively (note that these options are mutually exclusive):
-
-    ```sh
-    # use the --projects option
-    ./download-data.py --projects SCPCPXXXXXX
-
-    # use the --samples option
-    ./download-data.py --samples SCPCSXXXXXX,SCPCSXXXXXY
     ```
 
 - To review the files would be downloaded without performing the download yet, you can use the `--dryrun` option as follows.

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -8,11 +8,11 @@ Broadly speaking, there are three kinds of ScPCA data you might wish to work wit
 1. Data from the ScPCA Portal
     - You can find out more about the contents of files and how they were processed from the ScPCA documentation: <https://scpca.readthedocs.io>.
     - OpenScPCA project contributors [with an Amazon Web Services (AWS) account](./index.md#getting-access-to-aws) can access data using the provided `download-data.py` script, [as described below](#using-the-download-data-script).
-        - If you have not yet been onboarded to OpenScPCA, you will need to access data [directly from the ScPCA Portal](#accessing-data-from-the-scpca-portal).
-1. Results from other OpenScPCA modules
+    - All data is also available [directly from the ScPCA Portal](#accessing-data-from-the-scpca-portal) for users who have not yet fully joined the OpenSCPCA project.
+2. Results from other OpenScPCA modules
     - OpenScPCA project contributors with an AWS account can obtain results from completed modules using the provided `download-results.py` script, [as described below](#accessing-scpca-module-results).
     - To use results from an in-progress module from the `OpenScPCA-analysis` repository, you may need to run the module yourself to generate its result files.
-2. Test datasets
+3. Test datasets and associated results
     - We provide reduced-size test files with simulated and/or permuted versions of both ScPCA Portal data and results from completed modules.
     - These data are used for automated testing, but you can also use them while developing your module if smaller files helps make development more efficient.
     - You do not need an AWS account to download the test files, so you can use this data before you are granted full access to ScPCA data.
@@ -45,7 +45,7 @@ We briefly cover some of this script's most common use cases below, but we encou
 All examples below assume you are running the script from the root of the repository.
 
 !!! tip "Log into AWS CLI before running the script"
-    Before running this script locally (i.e., not from an [ALSF-provided virtual computer](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
+    Before running this script locally (i.e., not using Lightsail for Research](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws)), you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
     To do this, run the following commands in terminal before running the `download-data.py` script, and follow instructions to log in.
 
     ```sh
@@ -59,7 +59,7 @@ All examples below assume you are running the script from the root of the reposi
 
     Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
 
-- You can list all possible arguments and their usage for the download data script with the following:
+- You can list all available arguments and their usage for the download data script with the following:
 
     ```sh
     ./download-data.py --help
@@ -81,9 +81,9 @@ All examples below assume you are running the script from the root of the reposi
     ./download-data.py --format AnnData
     ```
 
-- To download a specific release other than the most recent release, you can use the `--release` option as follows.
-Again, please download full data releases with caution, as they are quite large!
-    - First, you may wish to use the `--list-releases` flag to see all available releases, which are named in `YYYY-MM-DD` format based on their release date.
+- To download a specific release other than the most recent release, you can use the `--release` option.
+Again, download full data releases with caution, as they are quite large!
+    - You can use the `--list-releases` flag to see all available releases, which are named in `YYYY-MM-DD` format based on their release date.
 
     ```sh
     # First, see which releases are available for download
@@ -117,11 +117,11 @@ Again, please download full data releases with caution, as they are quite large!
     ./download-data.py --projects SCPCPXXXXXX --dryrun
     ```
 
-The `download-data.py` script will always update the `data/current` symlink to point to the specified release directory.
-You can use the [`--update-symlink` flag described below](#updating-the-current-symlink) to update which release directory the `data/current` symlink directs to.
+The `download-data.py` script will update the `data/current` symlink to point to the current release directory when run without a `--release` option or to the test data directory when run with `--test-data`.
+If you want to instead point to a specific release, you can use the [`--update-symlink` flag described below](#updating-the-current-symlink) to update which release directory the `data/current` symlink directs to.
 
 
-### Download data file structure
+### Downloaded data file structure
 
 Downloads via the download script will generally have the following structure.
 
@@ -138,7 +138,7 @@ data
 ```
 
 !!! tip "The `data/current` directory"
-    The `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recently-downloaded data release.
+    The `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recent data release.
     You should therefore use the `data/current` path in your analysis code when reading in data, rather than a specific release directory.
 
 
@@ -180,7 +180,7 @@ All examples below assume you are running the script from the root of the reposi
 
     Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
 
-- You can list all possible arguments and their usage for the results download script with the following:
+- You can list all available arguments and their usage for the results download script with the following:
 
     ```sh
     ./download-results.py --help
@@ -222,7 +222,7 @@ For those modules, you can use either the `--projects` or `--samples` flag (noti
     ```
 
 
-### Download result file structure
+### Downloaded results file structure
 
 Results will download into the `data` directory in your local copy of the `OpenScPCA-analysis` repository.
 Result downloads will generally follow this structure:
@@ -237,7 +237,7 @@ data
 ```
 
 !!! tip "The `data/current` directory"
-    The `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recently-downloaded release directory.
+    The `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recent release directory available locally.
     You should therefore use the `data/current` path in your analysis code when reading in results, rather than a specific release directory.
 
 
@@ -294,7 +294,7 @@ You can use the `--update-symlink` flag, as described below, to update which rel
 
 ## Updating the `current` symlink
 
-As described above, the `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recently-downloaded release directory.
+As described above, the `data/current` directory is a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to the most recent release directory.
 You can update this symlink to point to a different data release directory (or to the test data directory) in one of two ways:
 
 1. When you download a new data or results release, `data/current` will automatically be updated to direct to the newly-downloaded release directory.
@@ -326,6 +326,8 @@ We recommend creating a `portal-downloads` subdirectory in the local copy of the
 
 ```sh
 mkdir -p data/portal-downloads
+# set up a symlink
+ln -s data/portal-downloads data/current
 ```
 
 You can then develop your analysis using these paths.

--- a/docs/getting-started/accessing-resources/getting-access-to-data.md
+++ b/docs/getting-started/accessing-resources/getting-access-to-data.md
@@ -16,7 +16,7 @@ Broadly speaking, there are three kinds of ScPCA data you might wish to work wit
     - These data are used for automated testing, but you can also use them while developing your module if smaller files helps make development more efficient.
     - You do not need an AWS account to download the test files, so you can use this data before you are granted full access to ScPCA data.
 
-## Accessing ScPCA Data
+## Accessing ScPCA data
 
 ### Accessing data on the ScPCA Portal
 
@@ -54,7 +54,7 @@ See our documentation [getting access to AWS](index.md#getting-access-to-aws) fo
     - [Set up conda](../../technical-setup/environment-setup/setup-conda.md) (note that conda is pre-installed, but not yet set up, on [Lightsail for Research](../../aws/lsfr/starting-development-on-lsfr.md#create-and-activate-a-conda-environment) instances)
     - [Configured the AWS CLI and logged in](../../technical-setup/environment-setup/configure-aws-cli.md) OR are [using Lightsail for Research](../../aws/index.md#lightsail-for-research-virtual-computing-with-aws) (which doesn't require logging in via the AWS CLI)
 
-The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-data.py) is designed to download files from whatever release you specify to a folder named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`.
+The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/download-data.py) is designed to download files from whatever release you specify to a folder in `data` named for the date of that release and [symlink](https://en.wikipedia.org/wiki/Symbolic_link) it to `data/current`.
 
 !!! tip "Log into AWS CLI before running the script"
     Before running this script locally, you will need to be [logged into your AWS CLI profile](../../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session).
@@ -71,45 +71,55 @@ The [`download-data.py` script](https://github.com/AlexsLemonade/OpenScPCA-analy
 
     Note that you can also [add this profile definition to your shell profile file](../../technical-setup/environment-setup/configure-aws-cli.md#storing-your-aws-profile-name) so that it will always be defined in any terminal session.
 
-We briefly cover some of the most common use cases below, but we encourage you to review all the options available to you.
+We briefly cover some of this script's most common use cases below, but we encourage you to review all the options available to you.
 
-You can list all the options for the download data script by running the following from the root directory of the repository:
+- You can list all the options for the download data script by running the following from the root directory of the repository:
+    ```sh
+    ./download-data.py --help
+    ```
 
-```sh
-./download-data.py --help
-```
+- You can run the download script with all default options to download all processed samples from the most recent release in `SingleCellExperiment` format:
 
-You can run the download script with all default options to download all processed samples from the most recent release in `SingleCellExperiment` format:
+    !!! warning
+        **The full data release download is quite large: over 35 GB for `SingleCellExperiment` format, and over 100 GB for `AnnData` format.
+        Please download the full data release with caution!**
 
-!!! warning
-    **The full data release download is quite large: over 35 GB for `SingleCellExperiment` format, and over 100 GB for `AnnData` format.
-    Please download the full data release with caution!**
+    ```sh
+    ./download-data.py
+    ```
 
-```sh
-./download-data.py
-```
+- If you prefer to work with `AnnData` files, use the `--format` option as follows:
 
-If you prefer to work with `AnnData` files, use the `--format` option as follows:
+    ```sh
+    ./download-data.py --format AnnData
+    ```
 
-```sh
-./download-data.py --format AnnData
-```
+- To review what samples would be downloaded without performing the download yet, you can use the `--dryrun` option as follows.
+    - We strongly recommend using the `--dryrun` flag the first time you run the script for a new data download to ensure the downloaded files are as expected.
 
-To review what samples would be downloaded without performing the download yet, you can use the `--dryrun` option as follows:
+    ```sh
+    ./download-data.py --dryrun
+    ```
 
-```sh
-./download-data.py --dryrun
-```
+- If you're only working with a subset of the data, you can use the `--projects` or `--samples` to download select samples (note: these options are mutually exclusive):
 
-If you're only working with a subset of the data, you can use the `--projects` or `--samples` to download select samples (note: these options are mutually exclusive):
+    ```sh
+    # use the --projects option
+    ./download-data.py --projects SCPCPXXXXXX
 
-```sh
-# use the --projects option
-./download-data.py --projects SCPCPXXXXXX
+    # use the --samples option
+    ./download-data.py --samples SCPCSXXXXXX,SCPCSXXXXXY
+    ```
 
-# use the --samples option
-./download-data.py --samples SCPCSXXXXXX,SCPCSXXXXXY
-```
+- To update the `data/current` symlink, for example if you have downloaded multiple releases and/or [test data](#accessing-test-data), use the `--update-symlink` flag in one of the following ways.
+  - Note that no data will be downloaded if you use this flag.
+    ```sh
+    # update data/current to direct to most recent local release
+    ./download-data.py --update-symlink
+
+    # update data/current to direct to specific release version
+    ./download-data.py --update-symlink --release 2024-05-01
+    ```
 
 #### Download data structure
 

--- a/docs/getting-started/explore-analysis.md
+++ b/docs/getting-started/explore-analysis.md
@@ -39,5 +39,5 @@ Additionally, you can use the [`simulate-sce`](https://github.com/AlexsLemonade/
 - The module requires either `SingleCellExperiment` or `AnnData` objects from the ScPCA Portal as input.
 
 In some cases, an analysis module's input data will be the results/output from a different module.
-These results are stored in an [S3 bucket on Amazon Web Services](../aws/index.md#s3-data-storage-with-aws), and are available to contributors.
+These results are stored in an [S3 bucket on Amazon Web Services](../aws/index.md#s3-data-and-results-storage-with-aws), and are available to contributors.
 Read more about [getting access to data](accessing-resources/getting-access-to-data.md).

--- a/docs/technical-setup/environment-setup/setup-conda.md
+++ b/docs/technical-setup/environment-setup/setup-conda.md
@@ -72,7 +72,7 @@ These commands will set the [recommended channels](https://docs.conda.io/project
 The last step is to create an `openscpca` conda environment and install the packages needed for OpenScPCA development.
 These are specified in the `environment.yml` in the root of the repository, and include:
 
-- The [`awscli` package](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) will allow you to interact with [data stored in the Amazon Web Services (AWS) S3 bucket](../../aws/index.md#s3-data-storage-with-aws)
+- The [`awscli` package](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) will allow you to interact with [data stored in the Amazon Web Services (AWS) S3 bucket](../../aws/index.md#s3-data-and-results-storage-with-aws)
 - The [`conda-lock` package](https://conda.github.io/conda-lock/) is used to create fully reproducible, cross-platform [conda environments for analysis modules](../../ensuring-repro/managing-software/using-conda.md#conda-and-conda-lock)
 - The [`jq` package](https://jqlang.github.io/jq/) provides JSON parsing capabilities
 - The [`pre-commit` package](https://pre-commit.com) will allow you to use [pre-commit hooks when contributing to analysis modules](../../contributing-to-analyses/working-with-git/making-commits.md#pre-commit-checks)

--- a/docs/troubleshooting-faq/faq.md
+++ b/docs/troubleshooting-faq/faq.md
@@ -27,7 +27,7 @@ Data files in each release are organized on S3 as:
 
 
 1. First, find the names of all the data releases, which are named based on their release date in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601).
-You can use the [`download-data.py`](../getting-started/accessing-resources/getting-access-to-data.md#download-data-file-structure) script with the `--list-releases` flag to do this.
+You can use the [`download-data.py`](../getting-started/accessing-resources/getting-access-to-data.md#downloaded-data-file-structure) script with the `--list-releases` flag to do this.
 Don't forget to [log into your AWS `openscpca` profile first](../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session)!
 
     ```bash

--- a/docs/troubleshooting-faq/faq.md
+++ b/docs/troubleshooting-faq/faq.md
@@ -27,7 +27,7 @@ Data files in each release are organized on S3 as:
 
 
 1. First, find the names of all the data releases, which are named based on their release date in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601).
-You can use the [`download-data.py`](../getting-started/accessing-resources/getting-access-to-data.md#download-data-structure) script with the `--list-releases` flag to do this.
+You can use the [`download-data.py`](../getting-started/accessing-resources/getting-access-to-data.md#download-data-file-structure) script with the `--list-releases` flag to do this.
 Don't forget to [log into your AWS `openscpca` profile first](../technical-setup/environment-setup/configure-aws-cli.md#logging-in-to-a-new-session)!
 
     ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,10 +73,10 @@ copyright: Copyright &copy; 2024 OpenScPCA Project Maintainers & Contributors | 
 # Note that the overall website landing page is in `docs/index.md`.
 #  When you locally serve, mkdocs will complain that it isn't in the nav below - this is expected. It should not be in the nav below.
 nav:
-  - Getting Started:      # welcome, familiarizing yourself with the project
+  - Getting started:      # welcome, familiarizing yourself with the project
     - getting-started/making-your-first-analysis-contribution.md
     - getting-started/explore-analysis.md
-    - Getting Access to Resources:
+    - Getting access to resources:
       - getting-started/accessing-resources/index.md
       - getting-started/accessing-resources/getting-access-to-data.md
       - getting-started/accessing-resources/getting-access-to-compute.md
@@ -97,7 +97,7 @@ nav:
       - technical-setup/environment-setup/install-r-rstudio.md
   - Tools for communication:   # Slack, issues, discussions
     - communications-tools/index.md
-    - GitHub Issues:
+    - GitHub issues:
       - communications-tools/github-issues/index.md
       - communications-tools/github-issues/writing-issues.md
       - communications-tools/github-issues/what-makes-a-good-issue.md


### PR DESCRIPTION
Closes #523

This PR updates the documentation for the data download script to also cover the `--update-symlink` flag (note https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/523#issuecomment-2217798972 about why the target branch here is not `main`). 

I added docs for `--update-symlink` in areas where I thought it made sense, and I also bullet-ified some of the instructions for improved legibility while I was here. I have two questions for reviewers:
- Any other spots to add `--update-symlink` to?
- I'm wondering if we actually don't want to keep the docs changes as I've written here, but instead add a section just to describe the symlink situation more explicitly, both in terms of how the scripts behave and in terms of using this new flag. At first I wanted to go in that direction, but then couldn't exactly decide where that section should go. Very curious to hear high-level thoughts about doc organization!
  - That said, this might be good enough for now, and we could reorganize later if contributors frequently have questions or trouble with this behavior.