### PR TITLE
Don't run hello-R test GHA in forks

### DIFF
--- a/.github/workflows/run_hello-R.yml
+++ b/.github/workflows/run_hello-R.yml
@@ -24,7 +24,7 @@ on:
       - analyses/hello-R/**
 jobs:
   run-module:
-    if: github.repository_owner == "AlexsLemonade"
+    if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run_hello-R.yml
+++ b/.github/workflows/run_hello-R.yml
@@ -23,8 +23,8 @@ on:
     paths:
       - analyses/hello-R/**
 jobs:
-  if: github.repository_owner == "AlexsLemonade"
   run-module:
+    if: github.repository_owner == "AlexsLemonade"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run_hello-R.yml
+++ b/.github/workflows/run_hello-R.yml
@@ -23,6 +23,7 @@ on:
     paths:
       - analyses/hello-R/**
 jobs:
+  if: github.repository_owner == "AlexsLemonade"
   run-module:
     runs-on: ubuntu-latest
 

--- a/analyses/hello-R/README.md
+++ b/analyses/hello-R/README.md
@@ -10,7 +10,7 @@ This analysis counts the number of cells in each processed SCE file in the curre
 
 To run the analysis, run the following command from this analysis directory:
 
-```bash
+```sh
 bash run_hello-R.sh
 ```
 


### PR DESCRIPTION
Based on https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/574#issuecomment-2218200567, this PR updates the `hello-R` workflow so we can whether it runs in forks on merge/sync. I made a small change to ensure the GHA is triggered upon merge. If this works, I'll make these changes more broadly, including to the GHA templates.

Note that we could also try `github.repository = "AlexsLemonade/OpenScPCA-analysis` (or other options, scroll through https://docs.github.com/en/actions/learn-github-actions/contexts#github-context for more), but it should be equivalent in practice, so `github.repository_owner == "AlexsLemonade"` seems fine.