### PR TITLE
Only run GHAs on forks

### DIFF
--- a/.github/workflows/build-push-docker-module.yml
+++ b/.github/workflows/build-push-docker-module.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build-push:
     name: Build and Push Docker Image
-    if: inputs.push-ecr
+    if: inputs.push-ecr && github.repository_owner == 'AlexsLemonade'
     environment: prod
     runs-on: ubuntu-latest
 
@@ -43,7 +43,7 @@ jobs:
         run: |
           aws ecr-public describe-repositories --repository-names ${{ inputs.module }} \
           || aws ecr-public create-repository --repository-name ${{ inputs.module }}
-          
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-docs-links:
+    if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
     name: Check links
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build:
     name: Build Docker Image
+    if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
     environment: 'prod'
 

--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -36,7 +36,9 @@ jobs:
           - hello-python
           - simulate-sce
           - cell-type-ewings
+          - doublet-detection
     uses: ./.github/workflows/build-push-docker-module.yml
+    if: github.repository_owner == 'AlexsLemonade'
     with:
       module: ${{ matrix.module }}
       # push if the workflow was triggered for scheduled build or push, or if the user requested it

--- a/.github/workflows/file_periodic_release_issue.yml
+++ b/.github/workflows/file_periodic_release_issue.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   post_issue:
+    if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
+
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/run_all-modules.yml
+++ b/.github/workflows/run_all-modules.yml
@@ -44,6 +44,7 @@ jobs:
           labels: |
             OpenScPCA admin
             ci
+
       - name: Check for failures or cancelled jobs
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: echo "Job failed" && exit 1

--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -24,7 +24,9 @@ on:
       - analyses/cell-type-ewings/**
 jobs:
   run-module:
+    if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
+
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/run_doublet-detection.yml
+++ b/.github/workflows/run_doublet-detection.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   run-module:
+    if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/run_hello-python.yml
+++ b/.github/workflows/run_hello-python.yml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   run-module:
+    if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   spellcheck:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'AlexsLemonade'
     name: Spell check files
     permissions:
       contents: read

--- a/templates/workflows/docker_module.yml
+++ b/templates/workflows/docker_module.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   test-build:
     name: Test Build Docker Image
-    if: github.event_name == 'pull_request' || (contains(github.event_name, 'workflow_') && !inputs.push-ecr)
+    if: github.repository_owner == 'AlexsLemonade' && (github.event_name == 'pull_request' || (contains(github.event_name, 'workflow_') && !inputs.push-ecr))
     runs-on: ubuntu-latest
 
     steps:

--- a/templates/workflows/run_conda-module.yml
+++ b/templates/workflows/run_conda-module.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   run-module:
+    if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/templates/workflows/run_conda-renv-module.yml
+++ b/templates/workflows/run_conda-renv-module.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   run-module:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'AlexsLemonade'
     defaults:
       run:
         shell: bash -el {0}

--- a/templates/workflows/run_renv-module.yml
+++ b/templates/workflows/run_renv-module.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   run-module:
+    if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Closes #577 

This PR updates GHAs to add a conditional statement so they won't run on forks.
Opening this as a draft, since there will be much testing and probably some syntax I need to fix, and then add a few more conditionals once I check some of said syntax.

I did not add the conditional to `create_periodic_release.yml` since this was only a manual trigger, but I can still do it if we want?  I also did not touch any of the jobs with an `always()` conditional, since it seemed to me that those jobs all had (unless I missed one!) `needs:` statements with jobs that I _did_ add the repo conditional to.