### PR TITLE
Remove AWS install from ewings action

### DIFF
--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -33,12 +33,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download test data
-        run: |
-          conda activate openscpca-cell-type-ewings
-          ./download-data.py --test-data --format "sce,anndata" --samples SCPCS000490
+        run: ./download-data.py --test-data --format "sce,anndata" --samples SCPCS000490
 
       - name: Run analysis
         run: |
-          conda activate openscpca-cell-type-ewings
           cd $MODULE_PATH
           bash cnv-annotation.sh

--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -31,7 +31,6 @@ jobs:
       run:
         shell: bash -el {0}
 
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -33,9 +33,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download test data
-        run: ./download-data.py --test-data --format "sce,anndata" --samples SCPCS000490
+        run: |
+          conda activate openscpca-cell-type-ewings
+          ./download-data.py --test-data --format "sce,anndata" --samples SCPCS000490
 
       - name: Run analysis
         run: |
+          conda activate openscpca-cell-type-ewings
           cd $MODULE_PATH
           bash cnv-annotation.sh

--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -27,22 +27,15 @@ jobs:
     if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
     container: public.ecr.aws/openscpca/cell-type-ewings:latest
-    defaults:
-      run:
-        shell: bash -el {0}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install awscli
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          ./aws/install
-
       - name: Download test data
-        run: ./download-data.py --test-data --format "sce,anndata" --samples SCPCS000490
+        run: |
+          conda activate openscpca-cell-type-ewings
+          ./download-data.py --test-data --format "sce,anndata" --samples SCPCS000490
 
       - name: Run analysis
         run: |

--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -27,10 +27,6 @@ jobs:
     if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
     container: public.ecr.aws/openscpca/cell-type-ewings:latest
-    defaults:
-      run:
-        shell: bash -el {0}
-
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -27,6 +27,10 @@ jobs:
     if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
     container: public.ecr.aws/openscpca/cell-type-ewings:latest
+    defaults:
+      run:
+        shell: bash -el {0}
+
 
     steps:
       - name: Checkout repo

--- a/analyses/cell-type-ewings/README.md
+++ b/analyses/cell-type-ewings/README.md
@@ -153,11 +153,13 @@ Use `threads=1` when running the workflow to specify this.
 To increase the speed of the workflow, we recommend running on a computer with at least 12 CPUs.
 If this is the case, you may run the workflow using the default settings of 4 threads.
 
+
 ## Exploratory analyses
 
 Any notebooks or scripts used specifically for exploratory analyses can be found in the `exploratory_analysis` folder.
 The `exploratory_analysis/annotation_notebooks` folder contains notebooks used to generate and save cell type annotations for samples in `SCPCP000015`.
 For more information on how these were generated, see the [README.md](./exploratory_notebooks/annotation_notebooks/README.md).
+
 
 ## Software requirements
 

--- a/download-data.py
+++ b/download-data.py
@@ -469,7 +469,7 @@ def main() -> None:
                 x.name
                 for x in args.data_dir.iterdir()
                 if x.is_dir()
-                and re.match("\d{4}-\d{2}-\d{2}$", x.name)
+                and re.match(r"\d{4}-\d{2}-\d{2}$", x.name)
                 and x.name <= datetime.date.today().isoformat()
             )
             most_recent = max(dated_releases)


### PR DESCRIPTION
I realized while reviewing another PR that the Ewings module already does have `aws` installed, just in the conda environment. So here I am eliminating the install step and substituting activation.

I may do some additional testing, because the Docker image _should_ auto-activate, but github may be overriding that somehow.