### PR TITLE
Add workflow for running AUCell across all samples in SCPCP000015

### DIFF
--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -42,7 +42,7 @@ jobs:
           ./aws/install
 
       - name: Download test data
-        run: ./download-data.py --test-data --format "sce,anndata" --samples SCPCS000490,SCPCS000491
+        run: ./download-data.py --test-data --format "sce,anndata" --project SCPCP000015
 
       - name: Run analysis
         run: |

--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -42,10 +42,11 @@ jobs:
           ./aws/install
 
       - name: Download test data
-        run: ./download-data.py --test-data --format "sce,anndata" --samples SCPCS000490
+        run: ./download-data.py --test-data --format "sce,anndata" --samples SCPCS000490,SCPCS000491
 
       - name: Run analysis
         run: |
           conda activate openscpca-cell-type-ewings
           cd $MODULE_PATH
           bash cnv-annotation.sh
+          bash aucell-annotation.sh

--- a/analyses/cell-type-ewings/aucell-annotation.sh
+++ b/analyses/cell-type-ewings/aucell-annotation.sh
@@ -43,7 +43,8 @@ auc_threshold=$(Rscript $scripts_dir/01-run-aucell.R \
     --return_auc)
 
 # now run AUCell, gene set scores, and generate AUCell report for each sample that is not the ref sample
-for sample_id in $(basename ${data_dir}/SCPCS*); do
+sample_ids=$(basename -a ${data_dir}/SCPCS*)
+for sample_id in $sample_ids; do
 
     # make sure sample results directory exists
     sample_results_dir="${results_dir}/${sample_id}"

--- a/analyses/cell-type-ewings/aucell-annotation.sh
+++ b/analyses/cell-type-ewings/aucell-annotation.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# This script identfies tumor cells using AUCell for all samples in SCPCP000015
+# Usage: ./aucell-annotation.sh
+
+set -euo pipefail
+
+# navigate to where script lives
+cd $(dirname "$0")
+module_dir=$(pwd)
+
+# use 4 CPUs
+threads=4
+
+# set up input and output file paths
+# make sure full paths are provided for notebook rendering
+data_dir="${module_dir}/../../data/current/SCPCP000015"
+results_dir="${module_dir}/results/aucell_annotation"
+mkdir -p ${results_dir}
+
+# define path to marker genes file
+marker_genes_file="${module_dir}/references/tumor-marker-genes.tsv"
+
+# define scripts and notebook directories
+scripts_dir="scripts/auc-workflow"
+notebook_dir="template_notebooks/auc-workflow"
+
+# define reference sample
+ref_sample="SCPCS000490"
+ref_library="SCPCL000822"
+ref_sce="${data_dir}/${ref_sample}/${ref_library}_processed.rds"
+ref_auc_results="${results_dir}/${ref_sample}/${ref_library}_auc-classifications.tsv"
+
+echo "Running AUCell for reference sample: $ref_sample and library: $ref_library"
+# first run AUCell on reference sample
+auc_threshold=$(Rscript $scripts_dir/01-run-aucell.R \
+    --sce_file $ref_sce \
+    --output_file $ref_auc_results \
+    --return_auc)
+
+# now run AUCell, gene set scores, and generate AUCell report for each sample that is not the ref sample
+for sample_id in $(basename ${data_dir}/SCPCS*); do
+
+    # make sure sample results directory exists
+    sample_results_dir="${results_dir}/${sample_id}"
+    mkdir -p $sample_results_dir
+
+    for sce_file in $data_dir/$sample_id/*_processed.rds; do
+
+        # define library ID
+        library_id=$(basename $sce_file | sed 's/_processed.rds$//')
+
+        # define output files
+        auc_results="${sample_results_dir}/${library_id}_auc-classifications.tsv"
+        geneset_results="${sample_results_dir}/${library_id}_gene-set-scores.tsv"
+
+        # only run AUCell if sample is NOT the ref sample
+        if [[ ($sample_id != $ref_sample) && ($library_id != $ref_library)]]; then
+
+            echo "Running AUCell for sample: $sample_id and library: $library_id"
+
+            # run AUCell
+            Rscript $scripts_dir/01-run-aucell.R \
+                --sce_file $sce_file \
+                --auc_threshold $auc_threshold \
+                --output_file $auc_results \
+                --threads $threads
+
+        fi
+
+        # generate gene set scores
+        Rscript $scripts_dir/02-calculate-gene-set-scores.R \
+          --sce_file $sce_file \
+          --output_file $geneset_results
+
+        # render notebook
+        Rscript -e "rmarkdown::render('$notebook_dir/01-auc-results.Rmd', \
+          clean = TRUE, \
+          output_dir = '$sample_results_dir', \
+          output_file = '${library_id}_aucell-report.html', \
+          params = list(library_id = '$library_id', \
+                        sce_file = '$sce_file', \
+                        aucell_results_file = '$auc_results', \
+                        ref_auc_results = '$ref_auc_results', \
+                        geneset_scores_file = '$geneset_results', \
+                        marker_genes_file = '$marker_genes_file', \
+                        auc_threshold = $auc_threshold), \
+          envir = new.env()) \
+        "
+    done
+done

--- a/analyses/cell-type-ewings/aucell-annotation.sh
+++ b/analyses/cell-type-ewings/aucell-annotation.sh
@@ -25,10 +25,14 @@ marker_genes_file="${module_dir}/references/tumor-marker-genes.tsv"
 scripts_dir="scripts/auc-workflow"
 notebook_dir="template_notebooks/auc-workflow"
 
-# define reference sample
+# define reference sample inputs and outputs
 ref_sample="SCPCS000490"
 ref_library="SCPCL000822"
 ref_sce="${data_dir}/${ref_sample}/${ref_library}_processed.rds"
+
+ref_results_dir="${results_dir}/${ref_sample}"
+mkdir -p $ref_results_dir
+
 ref_auc_results="${results_dir}/${ref_sample}/${ref_library}_auc-classifications.tsv"
 
 echo "Running AUCell for reference sample: $ref_sample and library: $ref_library"

--- a/analyses/cell-type-ewings/aucell-annotation.sh
+++ b/analyses/cell-type-ewings/aucell-annotation.sh
@@ -59,7 +59,7 @@ for sample_id in $(basename ${data_dir}/SCPCS*); do
         geneset_results="${sample_results_dir}/${library_id}_gene-set-scores.tsv"
 
         # only run AUCell if sample is NOT the ref sample
-        if [[ ($sample_id != $ref_sample) && ($library_id != $ref_library)]]; then
+        if [[ ($sample_id != $ref_sample) && ($library_id != $ref_library) ]]; then
 
             echo "Running AUCell for sample: $sample_id and library: $library_id"
 

--- a/analyses/cell-type-ewings/scripts/README.md
+++ b/analyses/cell-type-ewings/scripts/README.md
@@ -187,7 +187,7 @@ To run this script use the following command:
 ```sh
 Rscript 02-calculate-gene-set-scores.R \
   --sce_file <path to processed sce file> \
-  --results_dir <full path to folder to save results>
+  --output_file <full path to TSV file to save results>
 ```
 
 ## Utils

--- a/analyses/cell-type-ewings/template_notebooks/auc-workflow/01-auc-results.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/auc-workflow/01-auc-results.Rmd
@@ -8,13 +8,13 @@ output:
     toc_depth: 3
     code_folding: "hide"
 params:
-  library_id: SCPCS000490
-  sce_file: "../../../../data/current/SCPCP000015/SCPCS000490/SCPCL000822_processed.rds"
-  aucell_results_file: "../../results/aucell_annotation_test/SCPCS000490/SCPCL000822_auc-classifications.tsv"
-  ref_auc_results: "../../results/aucell_annotation_test/SCPCS000490/SCPCL000822_auc-classifications.tsv"
-  geneset_scores_file: "../../results/aucell_annotation_test/SCPCS000490/SCPCL000822_gene-set-scores.tsv"
-  marker_genes_file: "../../references/tumor-marker-genes.tsv"
-  auc_threshold: 0.009131468
+  library_id: NULL
+  sce_file: NULL
+  aucell_results_file: NULL
+  ref_auc_results: NULL
+  geneset_scores_file: NULL
+  marker_genes_file: NULL
+  auc_threshold: NULL
 ---
 
 This report summarizes the classification of `r params$library_id` using [`AUCell`](https://www.bioconductor.org/packages/release/bioc/html/AUCell.html). 

--- a/analyses/cell-type-ewings/template_notebooks/auc-workflow/01-auc-results.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/auc-workflow/01-auc-results.Rmd
@@ -8,13 +8,13 @@ output:
     toc_depth: 3
     code_folding: "hide"
 params:
-  library_id: NULL
-  sce_file: NULL
-  aucell_results_file: NULL
-  ref_auc_results: NULL
-  geneset_scores_file: NULL
-  marker_genes_file: NULL
-  auc_threshold: NULL
+  library_id: SCPCS000490
+  sce_file: "../../../../data/current/SCPCP000015/SCPCS000490/SCPCL000822_processed.rds"
+  aucell_results_file: "../../results/aucell_annotation_test/SCPCS000490/SCPCL000822_auc-classifications.tsv"
+  ref_auc_results: "../../results/aucell_annotation_test/SCPCS000490/SCPCL000822_auc-classifications.tsv"
+  geneset_scores_file: "../../results/aucell_annotation_test/SCPCS000490/SCPCL000822_gene-set-scores.tsv"
+  marker_genes_file: "../../references/tumor-marker-genes.tsv"
+  auc_threshold: 0.009131468
 ---
 
 This report summarizes the classification of `r params$library_id` using [`AUCell`](https://www.bioconductor.org/packages/release/bioc/html/AUCell.html). 
@@ -103,6 +103,14 @@ markers_df <- create_marker_gene_df(
   classification_df, 
   params$marker_genes_file
 )
+
+# test if _any_ marker genes have expression
+if(sum(markers_df$gene_expression) == 0){
+  has_marker_gene_exp <- FALSE
+  message("No marker gene expression detected, so all plots of marker genes will be skipped.")
+} else {
+  has_marker_gene_exp <- TRUE
+}
 ```
 
 ## AUCell classification UMAP
@@ -150,7 +158,7 @@ The below plots summarize marker gene expression in tumor and normal cells as cl
 The `logcounts` for each gene in the marker gene list is summed for each cell and shown on the x-axis.
 We would expect tumor cells to have higher expression of marker genes than normal cells. 
 
-```{r}
+```{r, eval=has_marker_gene_exp}
 # create a density plot showing the distribution of marker gene expression across classification methods 
 markers_df |> 
   dplyr::select(barcodes, sum_raw_exp, auc_classification) |> 
@@ -185,7 +193,7 @@ annotation <- ComplexHeatmap::columnAnnotation(
 )
 ```
 
-```{r}
+```{r, eval=has_marker_gene_exp}
 # plot heatmap of marker genes 
 plot_gene_heatmap(marker_gene_matrix, 
                   row_title = "Marker gene symbol",

--- a/analyses/cell-type-ewings/template_notebooks/auc-workflow/01-auc-results.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/auc-workflow/01-auc-results.Rmd
@@ -56,11 +56,8 @@ plot_colors <- c("Tumor" = "#00274C", "Normal" = "#FFCB05")
 
 
 ```{r base paths}
-# The base path for the OpenScPCA repository, found by its (hidden) .git directory
-repository_base <- rprojroot::find_root(rprojroot::is_git_root)
-
 # The path to this module
-module_base <- file.path(repository_base, "analyses", "cell-type-ewings")
+module_base <- rprojroot::find_root(rprojroot::is_renv_project)
 
 # source in helper functions: plot_gene_heatmap() and plot_cnv_heatmap() 
 # create_classification_df() and create_marker_gene_df()


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Closes #566 

#### What is the goal of this pull request?

Here I am adding a shell script to run AUCell and render the summary report for every sample in SCPCP000015. 

#### Briefly describe the general approach you took to achieve this goal.

The shell script is pretty simple and the way I have it set up right now I don't have any command line arguments and define all variables within the script. In the script, I define the reference sample/library as SCPCS000490/SCPCL000822. I didn't think we needed a variable for this at this time since that's the only sample we have validated to be useful as a reference. AUCell is first run on this reference sample with the `--return_auc` flag. The AUC value is saved to a variable to use in the next steps. 

For every SCE file in the project: 

1. AUCell is run using the specified AUC threshold. The reference sample will skip this step. 
2. Gene set scores are calculated. 
3. The template notebook is rendered to summarize the AUC results. 

I updated the documentation in the main README to include instructions on using this workflow. I also added it to GHA and now download the whole project. This means the workflow will be run on every single sample for testing, is that what we want? 

During testing with the test samples, I had to account for the case where we don't have any marker gene expression as we did with the other workflow, so I made a small adjustment to the notebook to account for this. 

#### If known, do you anticipate filing additional pull requests to complete this analysis module?

Yes 

### Results

#### What is the name of your results bucket on S3?

`s3://researcher-211125375652-us-east-2/cell-type-ewings/results/aucell_annotation`

#### What types of results does your code produce (e.g., table, figure)?

This creates TSV files with annotations and gene set scores and a single html report for each library that has been processed. 

#### What is your summary of the results?

I did run this through locally with all of the samples in SCPCP000015 and glanced at a few reports, but I will provide a full summary and post comments on #567. 


### Provide directions for reviewers

#### What are the software and computational requirements needed to be able to run the code in this PR?

Just noting that I added the ability to run `AUCell` with multiple threads in the `01-run-aucell.R` script. I set the number of threads to use for running the workflow to 4, should I make this a command line argument instead? 

#### Is there anything that you want to discuss further?

Do we want to commit the html files to the repo like we did with the output of the CNV annotation workflow? If so, I can add them here or in a separate PR but I wanted to check before I added them. 


### Author checklists

_Check all those that apply._
_Note that you may find it easier to check off these items after the pull request is actually filed._


#### Analysis module and review

- [ ] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [x] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [x] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [x] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
