### PR TITLE
Handle some stub links

### DIFF
--- a/docs/contributing-to-analyses/creating-pull-requests/index.md
+++ b/docs/contributing-to-analyses/creating-pull-requests/index.md
@@ -6,7 +6,7 @@ A pull request (PR) is used to propose merging new changes saved in one branch i
 In other words, you file a PR to _request_ that your code be _pulled_ into another branch.
 In most cases, PRs are used to merge in changes from a [feature branch](../working-with-git/working-with-branches.md) into the `main` branch of the repository.
 
-You can file PRs on GitHub and [request review](../pr-review-and-merge/index.md) to ultimately be able to merge your code.  <!-- STUB_LINK: Update to request review link, if needed -->
+You can file PRs on GitHub and [request review](../pr-review-and-merge/index.md) to ultimately be able to merge your code.
 The following components will be present in each PR:
 
 - A summary of line-by-line differences between the feature branch and the main branch, created by GitHub.
@@ -28,17 +28,16 @@ Once you have created a [feature branch](../working-with-git/working-with-branch
     See [scoping a pull request](scoping-pull-requests.md).
 - Each PR includes a description of the changes made.
     - We provide a [pull request template](pull-request-template.md) to guide you on what to include in your pull request description.
-- All PRs are [reviewed](../pr-review-and-merge/index.md) by at least one Data Lab staff member before they can be approved. <!-- STUB_LINK: Update to review link-->
+- All PRs are [reviewed](../pr-review-and-merge/index.md) by at least one Data Lab staff member before they can be approved.
 Once approved, a Data Lab staff member will merge your feature branch into the `main` branch of `AlexsLemonade/OpenScPCA-analysis`.
 
 ## The pull request review process
-
 
 <figure markdown="span">
     ![The PR review process](../../img/pr-review-cycle.png){width="700"}
 </figure>
 
-We require that [at least one Data Lab staff member review](../pr-review-and-merge/index.md) the content of all PRs. <!-- STUB_LINK: Update to request review link -->
+We require that [at least one Data Lab staff member review](../pr-review-and-merge/index.md) the content of all PRs.
 We will review your code contribution by:
 
 - Checking for correctness, clarity, and reproducibility in the code

--- a/docs/contributing-to-analyses/creating-pull-requests/scoping-pull-requests.md
+++ b/docs/contributing-to-analyses/creating-pull-requests/scoping-pull-requests.md
@@ -19,7 +19,7 @@ All changes in a given PR should be focused with a set of related changes.
 For most cases, each PR should contain changes that address one [issue filed in the repository](../../communications-tools/github-issues/index.md).
 There may be occasions where one issue requires multiple PRs, but _do not_ file PRs that address multiple issues at once.
 
-Ensuring your PRs are focused on one task helps combat reviewer fatigue and keeps the [review process](../pr-review-and-merge/index.md) short. <!--STUB_LINK: Replace with review process link -->
+Ensuring your PRs are focused on one task helps combat reviewer fatigue and keeps the [review process](../pr-review-and-merge/respond-to-review.md) short.
 
 - Longer PRs are harder and more time-consuming to review, and reviewers are more likely to miss catching unwanted bugs in the code.
 - The smaller the PR, the faster and more thorough the review!


### PR DESCRIPTION
Closes #504 

We're getting to the end of the reproducibility docs epic, so I went ahead and checked out the remaining stub links. Turns out we had already gotten all the reproducibility ones along the way, but there were a few pre-existing ones that I figured could be addressed now. I filled in one stub link, and removed several stub link comments which are almost certainly not needed. Let me know if you think these decisions were reasonable!