### PR TITLE
Provide output TSV to doublets

### DIFF
--- a/analyses/doublet-detection/README.md
+++ b/analyses/doublet-detection/README.md
@@ -109,3 +109,6 @@ A Dockerfile is also provided.
 ## Computational resources
 
 This module does not require compute beyond what is generally available on a laptop.
+By default, `scDblFinder` is run with 4 cores.
+To modify this, you can update _line 7_ in `run_doublet-detection-benchmark.sh` and/or `run_doublet-detection-scpca.sh` defining the `CORES` variable to a value of your choice.
+

--- a/analyses/doublet-detection/run_doublet-detection-benchmark.sh
+++ b/analyses/doublet-detection/run_doublet-detection-benchmark.sh
@@ -42,10 +42,14 @@ for dataset in "${bench_datasets[@]}"; do
     ./scripts/00_format-benchmark-data.R --dataset ${dataset} --input_dir ${DATA_DIR}/raw --output_dir ${DATASET_DIR}
 
     # Infer doublets with scDblFinder
-    ./scripts/01a_run-scdblfinder.R --input_sce_file ${DATASET_DIR}/${dataset}.rds --results_dir ${RESULTS_DIR} --benchmark
+    SCDBLFINDER_TSV=${RESULTS_DIR}/${dataset}_scdblfinder.tsv
+    ./scripts/01a_run-scdblfinder.R --input_sce_file ${DATASET_DIR}/${dataset}.rds --output_tsv_file ${SCDBLFINDER_TSV} --benchmark
 
     # Infer doublets with scrublet
-    ./scripts/01b_run-scrublet.py --input_anndata_file ${DATASET_DIR}/${dataset}.h5ad --results_dir ${RESULTS_DIR}
+    SCRUBLET_TSV=${RESULTS_DIR}/${dataset}_scrublet.tsv
+    ./scripts/01b_run-scrublet.py --input_anndata_file ${DATASET_DIR}/${dataset}.h5ad --output_tsv_file ${SCRUBLET_TSV}
+
+    exit 0
 
     # Explore each individual set of doublet results
     Rscript -e "rmarkdown::render('${TEMPLATE_NB_DIR}/02_explore-benchmark-results.Rmd',

--- a/analyses/doublet-detection/run_doublet-detection-benchmark.sh
+++ b/analyses/doublet-detection/run_doublet-detection-benchmark.sh
@@ -49,8 +49,6 @@ for dataset in "${bench_datasets[@]}"; do
     SCRUBLET_TSV=${RESULTS_DIR}/${dataset}_scrublet.tsv
     ./scripts/01b_run-scrublet.py --input_anndata_file ${DATASET_DIR}/${dataset}.h5ad --output_tsv_file ${SCRUBLET_TSV}
 
-    exit 0
-
     # Explore each individual set of doublet results
     Rscript -e "rmarkdown::render('${TEMPLATE_NB_DIR}/02_explore-benchmark-results.Rmd',
             output_dir = '${RESULTS_NB_DIR}',

--- a/analyses/doublet-detection/run_doublet-detection-benchmark.sh
+++ b/analyses/doublet-detection/run_doublet-detection-benchmark.sh
@@ -42,11 +42,11 @@ for dataset in "${bench_datasets[@]}"; do
 
     # Infer doublets with scDblFinder
     SCDBLFINDER_TSV=${RESULTS_DIR}/${dataset}_scdblfinder.tsv
-    ./scripts/01a_run-scdblfinder.R --input_sce_file ${DATASET_DIR}/${dataset}.rds --output_tsv_file ${SCDBLFINDER_TSV} --cores $CORES --benchmark
+    ./scripts/01a_run-scdblfinder.R --input_sce_file ${DATASET_DIR}/${dataset}.rds --output_file ${SCDBLFINDER_TSV} --cores $CORES --benchmark
 
     # Infer doublets with scrublet
     SCRUBLET_TSV=${RESULTS_DIR}/${dataset}_scrublet.tsv
-    ./scripts/01b_run-scrublet.py --input_anndata_file ${DATASET_DIR}/${dataset}.h5ad --output_tsv_file ${SCRUBLET_TSV}
+    ./scripts/01b_run-scrublet.py --input_anndata_file ${DATASET_DIR}/${dataset}.h5ad --output_file ${SCRUBLET_TSV}
 
     # Explore each individual set of doublet results
     Rscript -e "rmarkdown::render('${TEMPLATE_NB_DIR}/02_explore-benchmark-results.Rmd',

--- a/analyses/doublet-detection/run_doublet-detection-benchmark.sh
+++ b/analyses/doublet-detection/run_doublet-detection-benchmark.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 # This script runs the benchmarking portion of the `doublet-detection` module
+# Usage: ./run_doublet-detection-benchmark.sh
 
 set -euo pipefail
-
-
-# Set up --------------
+CORES=4
 
 # Ensure script is being run from its directory
 MODULE_DIR=$(dirname "${BASH_SOURCE[0]}")
@@ -43,7 +42,7 @@ for dataset in "${bench_datasets[@]}"; do
 
     # Infer doublets with scDblFinder
     SCDBLFINDER_TSV=${RESULTS_DIR}/${dataset}_scdblfinder.tsv
-    ./scripts/01a_run-scdblfinder.R --input_sce_file ${DATASET_DIR}/${dataset}.rds --output_tsv_file ${SCDBLFINDER_TSV} --benchmark
+    ./scripts/01a_run-scdblfinder.R --input_sce_file ${DATASET_DIR}/${dataset}.rds --output_tsv_file ${SCDBLFINDER_TSV} --cores $CORES --benchmark
 
     # Infer doublets with scrublet
     SCRUBLET_TSV=${RESULTS_DIR}/${dataset}_scrublet.tsv

--- a/analyses/doublet-detection/run_doublet-detection-scpca.sh
+++ b/analyses/doublet-detection/run_doublet-detection-scpca.sh
@@ -4,7 +4,7 @@
 # Usage: ./run_doublet-detection-scpca.sh {scpca project id}
 
 set -euo pipefail
-
+CORES=4
 
 # Ensure script is being run from its directory
 MODULE_DIR=$(dirname "${BASH_SOURCE[0]}")
@@ -29,6 +29,7 @@ for SAMPLE_DIR in ${DATA_DIR}/${PROJECT_ID}/SCPCS*; do
         TSV_FILE=$(basename "${SCE_FILE%.rds}_scdblfinder.tsv")
         Rscript scripts/01a_run-scdblfinder.R \
             --input_sce_file ${SCE_FILE} \
-            --output_tsv_file ${SAMPLE_RESULTS_DIR}/${TSV_FILE}
+            --output_tsv_file ${SAMPLE_RESULTS_DIR}/${TSV_FILE} \
+            --cores $CORES
     done
 done

--- a/analyses/doublet-detection/run_doublet-detection-scpca.sh
+++ b/analyses/doublet-detection/run_doublet-detection-scpca.sh
@@ -26,7 +26,7 @@ for SAMPLE_DIR in ${DATA_DIR}/${PROJECT_ID}/SCPCS*; do
     mkdir -p ${SAMPLE_RESULTS_DIR}
 
     for SCE_FILE in ${SAMPLE_DIR}/*_processed.rds; do
-        TSV_FILE=`sed 's/.rds/_scdblfinder.tsv/' <<<"$(basename $SCE_FILE)"`
+        TSV_FILE=$(basename "${SCE_FILE%.rds}_scdblfinder.tsv")
         Rscript scripts/01a_run-scdblfinder.R \
             --input_sce_file ${SCE_FILE} \
             --output_tsv_file ${SAMPLE_RESULTS_DIR}/${TSV_FILE}

--- a/analyses/doublet-detection/run_doublet-detection-scpca.sh
+++ b/analyses/doublet-detection/run_doublet-detection-scpca.sh
@@ -29,7 +29,7 @@ for SAMPLE_DIR in ${DATA_DIR}/${PROJECT_ID}/SCPCS*; do
         TSV_FILE=$(basename "${SCE_FILE%.rds}_scdblfinder.tsv")
         Rscript scripts/01a_run-scdblfinder.R \
             --input_sce_file ${SCE_FILE} \
-            --output_tsv_file ${SAMPLE_RESULTS_DIR}/${TSV_FILE} \
+            --output_file ${SAMPLE_RESULTS_DIR}/${TSV_FILE} \
             --cores $CORES
     done
 done

--- a/analyses/doublet-detection/run_doublet-detection-scpca.sh
+++ b/analyses/doublet-detection/run_doublet-detection-scpca.sh
@@ -26,8 +26,9 @@ for SAMPLE_DIR in ${DATA_DIR}/${PROJECT_ID}/SCPCS*; do
     mkdir -p ${SAMPLE_RESULTS_DIR}
 
     for SCE_FILE in ${SAMPLE_DIR}/*_processed.rds; do
+        TSV_FILE=`sed 's/.rds/_scdblfinder.tsv/' <<<"$(basename $SCE_FILE)"`
         Rscript scripts/01a_run-scdblfinder.R \
             --input_sce_file ${SCE_FILE} \
-            --results_dir ${SAMPLE_RESULTS_DIR}
+            --output_tsv_file ${SAMPLE_RESULTS_DIR}/${TSV_FILE}
     done
 done

--- a/analyses/doublet-detection/scripts/01a_run-scdblfinder.R
+++ b/analyses/doublet-detection/scripts/01a_run-scdblfinder.R
@@ -82,6 +82,7 @@ option_list <- list(
   make_option(
     "--output_file",
     type = "character",
+    default = "scdblfinder_results.tsv",
     help = "Path to output TSV file with doublet inferences."
   ),
   make_option(
@@ -114,11 +115,11 @@ opts <- parse_args(OptionParser(option_list = option_list))
 if (!file.exists(opts$input_sce_file)) {
     glue::glue("Could not find input SCE file, expected at: `{opts$input_sce_file}`.")
 }
-if (!stringr::str_ends(opts$output_tsv_file, ".tsv")) {
+if (!stringr::str_ends(opts$output_file, ".tsv")) {
   stop("The output TSV file must end in .tsv.")
 }
 
-fs::dir_create( dirname(opts$output_tsv_file) ) # create output directory as needed
+fs::dir_create( dirname(opts$output_file) ) # create output directory as needed
 set.seed(opts$random_seed)
 
 # Detect doublets and export TSV file with inferences -----
@@ -144,7 +145,7 @@ if (ncells < cell_threshold) {
   if (opts$benchmark) {
     na_df$cxds_score <- NA
   }
-  readr::write_tsv(na_df, opts$output_tsv_file)
+  readr::write_tsv(na_df, opts$output_file)
 
 } else {
 
@@ -165,5 +166,5 @@ if (ncells < cell_threshold) {
     random_seed = opts$random_seed,
     columns_to_keep = keep_columns
   ) |>
-  readr::write_tsv(opts$output_tsv_file)
+  readr::write_tsv(opts$output_file)
 }

--- a/analyses/doublet-detection/scripts/01a_run-scdblfinder.R
+++ b/analyses/doublet-detection/scripts/01a_run-scdblfinder.R
@@ -80,9 +80,9 @@ option_list <- list(
     help = "Path to input SCE file in RDS format."
   ),
   make_option(
-    "--results_dir",
+    "--output_tsv_file",
     type = "character",
-    help = "The directory to export TSV file with doublet inferences."
+    help = "Path to output TSV file with doublet inferences."
   ),
   make_option(
     "--cores",
@@ -94,7 +94,7 @@ option_list <- list(
     "--benchmark",
     action = "store_true",
     default = FALSE,
-    help = "Whether the script is being run as part of the doublet benchmarking analysis. If this flag is invoked, the `cxds_score` column will be included in the output TSV along with the `barcodes`, `score`, and `class` columns that are always included." 
+    help = "Whether the script is being run as part of the doublet benchmarking analysis. If this flag is invoked, the `cxds_score` column will be included in the output TSV along with the `barcodes`, `score`, and `class` columns that are always included."
   ),
   make_option(
     "--sample_var",
@@ -114,20 +114,11 @@ opts <- parse_args(OptionParser(option_list = option_list))
 if (!file.exists(opts$input_sce_file)) {
     glue::glue("Could not find input SCE file, expected at: `{opts$input_sce_file}`.")
 }
-if (is.null(opts$results_dir)) {
-  stop("Must provide an output path for results with --results_dir.")
+if (!stringr::str_ends(opts$output_tsv_file, ".tsv")) {
+  stop("The output TSV file must end in .tsv.")
 }
 
-output_tsv_file <- file.path(
-  opts$results_dir,
-  stringr::str_replace(
-    basename(opts$input_sce_file),
-    ".rds",
-    "_scdblfinder.tsv"
-  )
-)
-
-fs::dir_create(opts$results_dir)
+fs::dir_create( dirname(opts$output_tsv_file) ) # create output directory as needed
 set.seed(opts$random_seed)
 
 # Detect doublets and export TSV file with inferences -----
@@ -153,7 +144,7 @@ if (ncells < cell_threshold) {
   if (opts$benchmark) {
     na_df$cxds_score <- NA
   }
-  readr::write_tsv(na_df, output_tsv_file)
+  readr::write_tsv(na_df, opts$output_tsv_file)
 
 } else {
 
@@ -174,5 +165,5 @@ if (ncells < cell_threshold) {
     random_seed = opts$random_seed,
     columns_to_keep = keep_columns
   ) |>
-  readr::write_tsv(output_tsv_file)
+  readr::write_tsv(opts$output_tsv_file)
 }

--- a/analyses/doublet-detection/scripts/01a_run-scdblfinder.R
+++ b/analyses/doublet-detection/scripts/01a_run-scdblfinder.R
@@ -80,7 +80,7 @@ option_list <- list(
     help = "Path to input SCE file in RDS format."
   ),
   make_option(
-    "--output_tsv_file",
+    "--output_file",
     type = "character",
     help = "Path to output TSV file with doublet inferences."
   ),

--- a/analyses/doublet-detection/scripts/01a_run-scdblfinder.R
+++ b/analyses/doublet-detection/scripts/01a_run-scdblfinder.R
@@ -88,7 +88,7 @@ option_list <- list(
     "--cores",
     type = "integer",
     default = 4,
-    help = "Number of cores to use during scDblFinder inference. Only used when there are multiple samples in the SCE."
+    help = "Number of cores to use during scDblFinder inference."
   ),
   make_option(
     "--benchmark",

--- a/analyses/doublet-detection/scripts/01b_run-scrublet.py
+++ b/analyses/doublet-detection/scripts/01b_run-scrublet.py
@@ -39,15 +39,15 @@ def main() -> None:
     )
     parser.add_argument(
         "--input_anndata_file",
-        type=str,
+        type=Path,
         required=True,
         help="Path to the input AnnData file to process."
     )
     parser.add_argument(
-        "--results_dir",
+        "--output_tsv_file",
         type=Path,
         required=True,
-        help="The directory to export TSV file with doublet inferences."
+        help="Path to output TSV file with doublet inferences."
     )
     parser.add_argument(
         "--random_seed",
@@ -58,23 +58,27 @@ def main() -> None:
     args = parser.parse_args()
 
     # Define and check files, directories
-    args.results_dir.mkdir(parents = True, exist_ok = True)
-
-    input_anndata_file = Path(args.input_anndata_file)
-    if not input_anndata_file.exists():
+    if not args.input_anndata_file.exists():
         print(
             "The input AnnData file could not be found at:",
             args.input_anndata_file,
             file=sys.stderr
         )
         sys.exit(1)
-    result_tsv = args.results_dir / (input_anndata_file.name.replace(".h5ad", "_scrublet.tsv"))
+
+    if not args.output_tsv_file.name.endswith(".tsv"):
+        print(
+            "The output TSV file must end in `.tsv`.",
+            file=sys.stderr
+        )
+        sys.exit(1)
+    args.output_tsv_file.parent.mkdir(parents = True, exist_ok = True)
 
 
     # Run scrublet and export the results
-    adata = anndata.read_h5ad(input_anndata_file)
+    adata = anndata.read_h5ad(args.input_anndata_file)
     scrub_results = run_scrublet(adata, args.random_seed)
-    scrub_results.to_csv(result_tsv, sep="\t", index=False )
+    scrub_results.to_csv(args.output_tsv_file, sep="\t", index=False )
 
 if __name__ == "__main__":
     main()

--- a/analyses/doublet-detection/scripts/01b_run-scrublet.py
+++ b/analyses/doublet-detection/scripts/01b_run-scrublet.py
@@ -58,19 +58,25 @@ def main() -> None:
     args = parser.parse_args()
 
     # Define and check files, directories
+    arg_error=False
     if not args.input_anndata_file.exists():
         print(
             f"The input AnnData file could not be found at: {args.input_anndata_file}.",
             file=sys.stderr
         )
-        sys.exit(1)
+        arg_error=True
 
     if not args.output_file.name.endswith(".tsv"):
         print(
             "The output TSV file must end in `.tsv`.",
             file=sys.stderr
         )
+        arg_error=True
+
+    if arg_error:
         sys.exit(1)
+
+    # make output directory as needed
     args.output_file.parent.mkdir(parents = True, exist_ok = True)
 
 

--- a/analyses/doublet-detection/scripts/01b_run-scrublet.py
+++ b/analyses/doublet-detection/scripts/01b_run-scrublet.py
@@ -60,8 +60,7 @@ def main() -> None:
     # Define and check files, directories
     if not args.input_anndata_file.exists():
         print(
-            "The input AnnData file could not be found at:",
-            args.input_anndata_file,
+            f"The input AnnData file could not be found at: {args.input_anndata_file}.",
             file=sys.stderr
         )
         sys.exit(1)

--- a/analyses/doublet-detection/scripts/01b_run-scrublet.py
+++ b/analyses/doublet-detection/scripts/01b_run-scrublet.py
@@ -44,7 +44,7 @@ def main() -> None:
         help="Path to the input AnnData file to process."
     )
     parser.add_argument(
-        "--output_tsv_file",
+        "--output_file",
         type=Path,
         required=True,
         help="Path to output TSV file with doublet inferences."
@@ -65,19 +65,19 @@ def main() -> None:
         )
         sys.exit(1)
 
-    if not args.output_tsv_file.name.endswith(".tsv"):
+    if not args.output_file.name.endswith(".tsv"):
         print(
             "The output TSV file must end in `.tsv`.",
             file=sys.stderr
         )
         sys.exit(1)
-    args.output_tsv_file.parent.mkdir(parents = True, exist_ok = True)
+    args.output_file.parent.mkdir(parents = True, exist_ok = True)
 
 
     # Run scrublet and export the results
     adata = anndata.read_h5ad(args.input_anndata_file)
     scrub_results = run_scrublet(adata, args.random_seed)
-    scrub_results.to_csv(args.output_tsv_file, sep="\t", index=False )
+    scrub_results.to_csv(args.output_file, sep="\t", index=False )
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Closes #613

This PR updates the doublet scripts (both R and python; I did the latter for module consistency) to accept an input arg `output_tsv_file` instead of `results_dir`. This will make porting the analysis to `OpenScPCA-nf` more straightforward. Note that I'm requesting @jashapiro for review in case there's anything else that might jump out at you that might benefit from a change before heading over to `nf`. The rest looks ok to me, but let me know what you think (and if you have thoughts about my bash `sed` line too!). 