### PR TITLE
Remove reproducibility-docs branch from GHAs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - main
-      - reproducibility-docs
       - feature/*
     paths:
       - docs/**

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - main
-      - reproducibility-docs
       - feature/*
     paths:
       - docs/**


### PR DESCRIPTION
All that's left of the #487 reproducibility doc epic is to merge changes into `main` (next PR)! Before we do that, I'm removing this branch from the GHAs; in the future, we will name feature branches as `feature/<informative branch name>` so these GHAs will work fine moving forward in similar circumstances.