### PR TITLE
Add pandoc to Dockerfile

### DIFF
--- a/analyses/doublet-detection/Dockerfile
+++ b/analyses/doublet-detection/Dockerfile
@@ -52,6 +52,13 @@ RUN Rscript -e 'renv::restore()' \
   && rm -rf /tmp/downloaded_packages \
   && rm -rf /tmp/Rtmp*
 
+# Install pandoc dependency
+RUN apt-get -y update &&  \
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends -y \
+  pandoc \
+  && rm -rf /var/lib/apt/lists/*
+
 # Activate conda environment on bash launch
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
 

--- a/analyses/doublet-detection/Dockerfile
+++ b/analyses/doublet-detection/Dockerfile
@@ -27,6 +27,13 @@ RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.s
 # Install conda-lock
 RUN conda install --channel=conda-forge --name=base conda-lock
 
+# Install pandoc dependency
+RUN apt-get -y update &&  \
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends -y \
+  pandoc \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install renv
 RUN Rscript -e "install.packages('renv')"
 
@@ -51,13 +58,6 @@ RUN Rscript -e 'renv::restore()' \
   && rm -rf ~/.cache/R/renv \
   && rm -rf /tmp/downloaded_packages \
   && rm -rf /tmp/Rtmp*
-
-# Install pandoc dependency
-RUN apt-get -y update &&  \
-  DEBIAN_FRONTEND=noninteractive \
-  apt-get install --no-install-recommends -y \
-  pandoc \
-  && rm -rf /var/lib/apt/lists/*
 
 # Activate conda environment on bash launch
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc


### PR DESCRIPTION
Related to #637 
Now that the benchmarking notebooks are being run in the doublets GHA, it has become [apparent that the Docker image needs `pandoc`](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/runs/10047296868/job/27768675342#step:5:516). I've added it here to the Dockerfile, so once this image makes it to the registry hopefully #637 will pass.
