### PR TITLE
Update Dockerfile and docs to use CMD instead of ENTRYPOINT

### DIFF
--- a/analyses/cell-type-ewings/Dockerfile
+++ b/analyses/cell-type-ewings/Dockerfile
@@ -65,5 +65,5 @@ RUN Rscript -e 'renv::restore()' && \
   rm -rf /tmp/downloaded_packages && \
   rm -rf /tmp/Rtmp*
 
-# Set entrypoint to bash to activate the environment for any commands
-ENTRYPOINT ["/bin/bash"]
+# Set CMD to bash to activate the environment for any commands
+CMD ["/bin/bash"]

--- a/analyses/doublet-detection/Dockerfile
+++ b/analyses/doublet-detection/Dockerfile
@@ -62,4 +62,5 @@ RUN Rscript -e 'renv::restore()' \
 # Activate conda environment on bash launch
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
 
+# Set CMD to bash to activate the environment when launching
 CMD ["/bin/bash"]

--- a/analyses/hello-python/Dockerfile
+++ b/analyses/hello-python/Dockerfile
@@ -25,5 +25,5 @@ RUN conda-lock install -n ${ENV_NAME} && \
 # Activate conda environment on bash launch
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
 
-# Set entrypoint to bash to activate the environment for any commands
-ENTRYPOINT ["bash", "-l"]
+# Set CMD to bash to activate the environment when launching
+CMD ["/bin/bash"]

--- a/docs/ensuring-repro/docker/docker-images.md
+++ b/docs/ensuring-repro/docker/docker-images.md
@@ -103,7 +103,7 @@ In the Dockerfile, you will want include the following steps:
 - Install `conda-lock`.
 - Copy the `conda-lock.yml` file from the host environment to the image.
 - Use `conda-lock install` to create an environment from the `conda-lock.yml` file.
-- Make sure the environment is activated when the container is launched by modifying the `.bashrc` file and setting the `ENTRYPOINT` to `bash -l -c`.
+- Make sure the environment is activated when the container is launched by modifying the `.bashrc` file and setting the `CMD` to `/bin/bash`.
 
 A simple `Dockerfile` for a conda-based analysis module that uses `conda-lock` for its environment might look like this:
 

--- a/docs/ensuring-repro/docker/docker-images.md
+++ b/docs/ensuring-repro/docker/docker-images.md
@@ -127,8 +127,8 @@ RUN conda-lock install -n ${ENV_NAME} \
 # Activate conda environment on bash launch
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
 
-# Set entrypoint to bash to activate the environment for any commands
-ENTRYPOINT ["bash", "-l", "-c"]
+# Set CMD to bash to activate the environment when launching
+CMD ["/bin/bash"]
 ```
 
 
@@ -188,8 +188,8 @@ RUN Rscript -e 'renv::restore()' \
 # Activate conda environment on bash launch
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
 
-# Set entrypoint to bash to activate the environment for any commands
-ENTRYPOINT ["bash", "-l", "-c"]
+# Set CMD to bash to activate the environment when launching
+CMD ["/bin/bash"]
 ```
 
 !!! tip


### PR DESCRIPTION
Here I am applying the changes in from #626 in `analyses/doublet-detection/Dockerfile` to all of the Dockerfiles, replacing `ENTRYPOINT` with `CMD`. This seems to solve the problems we were having with proper launching and activation of conda environments in `openscpca-nf`.

I also updated the docs to reflect the same suggestions.