### PR TITLE
Add modules to run_all

### DIFF
--- a/.github/ISSUE_TEMPLATE/create-a-semantic-version-release.md
+++ b/.github/ISSUE_TEMPLATE/create-a-semantic-version-release.md
@@ -11,7 +11,8 @@ If issues must be resolved before creating a release, mark them as blockers in Z
 
 - [ ] Any mentions of the release tag in the repository have been updated
 - [ ] All maintenance workflows are passing
-  - [ ] [Run all analysis modules](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/workflows/run_all-modules.yml) (trigger manually if needed)
+  - [ ] [Run all analysis modules](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/workflows/run_all-modules.yml) (trigger manually if needed)<br>
+  Check that all analysis modules are present in the workflow before running, and file a PR updating the workflow if necessary.
   - [ ] [Spellcheck](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/workflows/spellcheck.yml) (trigger manually if needed)
   - [ ] [Code styling](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/workflows/code-styling.yml) (optional, trigger manually)
 - [ ] All blocking issues have been resolved

--- a/.github/workflows/run_all-modules.yml
+++ b/.github/workflows/run_all-modules.yml
@@ -19,12 +19,20 @@ jobs:
   hello-python:
     uses: ./.github/workflows/run_hello-python.yml
 
+  doublet-detection:
+    uses: ./.github/workflows/run_doublet-detection.yml
+
+  cell-type-ewings:
+    uses: ./.github/workflows/run_cell-type-ewings.yml
+
   ## Add additional modules above this comment, and to the needs list below
   check-jobs:
     if: ${{ always() }}
     needs:
       - hello-R
       - hello-python
+      - doublet-detection
+      - cell-type-ewings
     runs-on: ubuntu-latest
     steps:
       - name: Checkout template file


### PR DESCRIPTION
Here I am adding `detect-doublets` and `cell-type-ewings` to the `run_all` workflow.

I also added some instructions to be sure this workflow is up to date before completing a versioned release. 

I wasn't totally sure we needed to add `cell-type-ewings` yet, but I figured it wouldn't hurt. 