### PR TITLE
handle explicit "all" options for download scripts

### DIFF
--- a/download-data.py
+++ b/download-data.py
@@ -436,6 +436,11 @@ def main() -> None:
     if validation_error:
         sys.exit(1)
 
+    # convert "all" to empty string for later processing
+    if args.projects.casefold() == "all":
+        args.projects = ""
+    if args.samples.casefold() == "all":
+        args.samples = ""
     # check project and sample names
     projects = {p.strip() for p in args.projects.split(",")} if args.projects else {}
     samples = {s.strip() for s in args.samples.split(",")} if args.samples else {}

--- a/download-results.py
+++ b/download-results.py
@@ -226,6 +226,11 @@ def main() -> None:
             file=sys.stderr,
         )
 
+    # convert "all" to empty string for later processing
+    if args.projects.casefold() == "all":
+        args.projects = ""
+    if args.samples.casefold() == "all":
+        args.samples = ""
     # check project and sample names
     projects = {p.strip() for p in args.projects.split(",")} if args.projects else {}
     samples = {s.strip() for s in args.samples.split(",")} if args.samples else {}


### PR DESCRIPTION
In https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/runs/10066556460 there was an error because the download script does not actually handle "all" as an option for samples or projects, expecting instead a blank string if the option was set. Because blank strings are hard to deal with at the command line, I added a step to explicitly parse "all" as an option in both the data and results scripts. 