### PR TITLE
Fix docker action repository naming

### DIFF
--- a/.github/workflows/build-push-docker-module.yml
+++ b/.github/workflows/build-push-docker-module.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Create ECR repository if needed
         id: create-ecr
         run: |
-          aws ecr-public describe-repositories --repository-names ${{ inputs.module }} \
-          || aws ecr-public create-repository --repository-name ${{ inputs.module }}
+          module=echo "${{ inputs.module }}" | tr '[:upper:]' '[:lower:]'
+          aws ecr-public describe-repositories --repository-names $module
+          || aws ecr-public create-repository --repository-name $module
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker_cell-type-ewings.yaml
+++ b/.github/workflows/docker_cell-type-ewings.yaml
@@ -15,8 +15,6 @@ on:
       - analyses/cell-type-ewings/renv.lock
       - analyses/cell-type-ewings/conda-lock.yml
   push:
-    tags:
-      - "v*.*.*"
     branches:
       - main
     paths:

--- a/.github/workflows/docker_hello-R.yml
+++ b/.github/workflows/docker_hello-R.yml
@@ -15,8 +15,6 @@ on:
       - analyses/hello-R/renv.lock
       - analyses/hello-R/conda-lock.yml
   push:
-    tags:
-      - "v*.*.*"
     branches:
       - main
     paths:

--- a/.github/workflows/docker_hello-python.yml
+++ b/.github/workflows/docker_hello-python.yml
@@ -15,8 +15,6 @@ on:
       - analyses/hello-python/renv.lock
       - analyses/hello-python/conda-lock.yml
   push:
-    tags:
-      - "v*.*.*"
     branches:
       - main
     paths:


### PR DESCRIPTION
Here I am removing a couple of legacy triggers for tagged versions from docker actions, and fixing the error that came up when trying to make a new repo for the `hello-R` module. 

closes #655

The error there was that `hello-R` has a capital letter in it, which is not allowed in a docker tag. So I added a step to convert that before checking for the presence of the tag in AWS ECR. 

The docker metadata action itself already [sanitizes image tag](https://github.com/docker/metadata-action/tree/v5/?tab=readme-ov-file#image-name-and-tag-sanitization), so I believe that I only have to change the AWS portion of the action.

I considered pulling out the sanitized version from the metadata action, but that actually seems like it will be a fair bit more complex. So there is still a risk of module names that include unallowed characters, but that seems like a low risk, and one that may be best addressed by changing the module names. 