### PR TITLE
Add ensembldb to lock file and Docker

### DIFF
--- a/analyses/cell-type-ewings/components/dependencies.R
+++ b/analyses/cell-type-ewings/components/dependencies.R
@@ -1,2 +1,3 @@
 # R dependencies not captured by `renv`
 # library("missing_package")
+library(ensembldb)

--- a/analyses/cell-type-ewings/components/dependencies.R
+++ b/analyses/cell-type-ewings/components/dependencies.R
@@ -1,3 +1,2 @@
 # R dependencies not captured by `renv`
-# library("missing_package")
 library(ensembldb)

--- a/analyses/cell-type-ewings/renv.lock
+++ b/analyses/cell-type-ewings/renv.lock
@@ -75,6 +75,20 @@
       ],
       "Hash": "b7df9c597fb5533fc8248d73b8c703ac"
     },
+    "AnnotationFilter": {
+      "Package": "AnnotationFilter",
+      "Version": "1.28.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "GenomicRanges",
+        "R",
+        "lazyeval",
+        "methods",
+        "utils"
+      ],
+      "Hash": "24e809470aef6d81b25003d775b2fb56"
+    },
     "AnnotationHub": {
       "Package": "AnnotationHub",
       "Version": "3.12.0",
@@ -481,6 +495,29 @@
       ],
       "Hash": "e539709764587c581b31e446dc84d7b8"
     },
+    "GenomicFeatures": {
+      "Package": "GenomicFeatures",
+      "Version": "1.56.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "AnnotationDbi",
+        "BiocGenerics",
+        "Biostrings",
+        "DBI",
+        "GenomeInfoDb",
+        "GenomicRanges",
+        "IRanges",
+        "R",
+        "S4Vectors",
+        "XVector",
+        "methods",
+        "rtracklayer",
+        "stats",
+        "utils"
+      ],
+      "Hash": "0d19619d13b06b9dea85993ce7f09c52"
+    },
     "GenomicRanges": {
       "Package": "GenomicRanges",
       "Version": "1.56.1",
@@ -684,6 +721,16 @@
         "data.table"
       ],
       "Hash": "40a55bd0b44719941d103291ac5e9d74"
+    },
+    "ProtGenerics": {
+      "Package": "ProtGenerics",
+      "Version": "1.36.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "methods"
+      ],
+      "Hash": "a3737c10efc865abfa9d204ca8735b74"
     },
     "R.methodsS3": {
       "Package": "R.methodsS3",
@@ -2113,6 +2160,33 @@
         "rlang"
       ],
       "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
+    },
+    "ensembldb": {
+      "Package": "ensembldb",
+      "Version": "2.28.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "AnnotationDbi",
+        "AnnotationFilter",
+        "Biobase",
+        "BiocGenerics",
+        "Biostrings",
+        "DBI",
+        "GenomeInfoDb",
+        "GenomicFeatures",
+        "GenomicRanges",
+        "IRanges",
+        "ProtGenerics",
+        "R",
+        "RSQLite",
+        "Rsamtools",
+        "S4Vectors",
+        "curl",
+        "methods",
+        "rtracklayer"
+      ],
+      "Hash": "f9a5e52468ec832a839c012e15c41c15"
     },
     "evaluate": {
       "Package": "evaluate",


### PR DESCRIPTION
It looks like the failure in https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/runs/10084373932/job/27883026469 is because we are missing `ensembldb` in the docker image. I think that is a dependency of `celldex` since we are setting `ensembl=TRUE` and it doesn't appear to get automatically captured. I added it to the `dependencies.R` sheet and then updated the lock file here. 