### PR TITLE
Fix failed GHA for building and pushing docker images 

### DIFF
--- a/.github/workflows/build-push-docker-module.yml
+++ b/.github/workflows/build-push-docker-module.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create ECR repository if needed
         id: create-ecr
         run: |
-          module=echo "${{ inputs.module }}" | tr '[:upper:]' '[:lower:]'
+          module=$(echo "${{ inputs.module }}" | tr '[:upper:]' '[:lower:]')
           aws ecr-public describe-repositories --repository-names $module
           || aws ecr-public create-repository --repository-name $module
 


### PR DESCRIPTION
I was seeing an error in the action to build and push the docker images after merging and it looks like we might just be missing the `$()` around the call to actually assign the module variable. 

This is from the failed ewings build on the PR I just merged, but it looks like some other builds failed after merging yesterday too. 

<img width="561" alt="Screenshot 2024-07-25 at 10 34 17 AM" src="https://github.com/user-attachments/assets/8909e780-ea4d-4136-8489-ded66ccba59a">
