### PR TITLE
Add push trigger to Wilms tumor cell typing Docker build/push workflow & proposed change to template

### DIFF
--- a/.github/workflows/docker_cell-type-wilms-tumor-06.yml
+++ b/.github/workflows/docker_cell-type-wilms-tumor-06.yml
@@ -21,6 +21,14 @@ on:
       - "analyses/cell-type-wilms-tumor-06/.dockerignore"
       - "analyses/cell-type-wilms-tumor-06/renv.lock"
       - "analyses/cell-type-wilms-tumor-06/conda-lock.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "analyses/cell-type-wilms-tumor-06/Dockerfile"
+      - "analyses/cell-type-wilms-tumor-06/.dockerignore"
+      - "analyses/cell-type-wilms-tumor-06/renv.lock"
+      - "analyses/cell-type-wilms-tumor-06/conda-lock.yml"
   workflow_dispatch:
     inputs:
       push-ecr:

--- a/templates/workflows/docker_module.yml
+++ b/templates/workflows/docker_module.yml
@@ -21,6 +21,14 @@ on:
   #     - "analyses/{{ openscpca_module }}/.dockerignore"
   #     - "analyses/{{ openscpca_module }}/renv.lock"
   #     - "analyses/{{ openscpca_module }}/conda-lock.yml"
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - "analyses/{{ openscpca_module }}/Dockerfile"
+  #     - "analyses/{{ openscpca_module }}/.dockerignore"
+  #     - "analyses/{{ openscpca_module }}/renv.lock"
+  #     - "analyses/{{ openscpca_module }}/conda-lock.yml"
   workflow_dispatch:
     inputs:
       push-ecr:


### PR DESCRIPTION
### Purpose/implementation Section

Here, I'm adding a GitHub Actions workflow trigger that will push the Docker images for the `cell-type-wilms-tumor-06` module to ECR upon merge to `main`.

I meant to accomplish this in https://github.com/maud-p/OpenScPCA-analysis/pull/3, but I was (arguably overly!) focused on aligning the changes with the template.

That made me wonder why these commented-out steps are not in the template, so I've added them. I could see an argument for not including them–we want to make sure something is sufficiently mature before pushing–but I don't know that the pull request trigger and push trigger need to be uncommented at the same time.

#### Please link to the GitHub issue that this pull request addresses.

N/A


### Provide directions for reviewers

What do you think of this change to the template? I admit there maybe should be docs changes as well, but I wanted to discuss this first!

