### PR TITLE
Add Rosetta to Docker installation instructions

### DIFF
--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -32,6 +32,7 @@ CNVs
 codebase
 conda
 config
+containerd
 CopyKAT
 CRediT
 Crompton

--- a/docs/ensuring-repro/docker/index.md
+++ b/docs/ensuring-repro/docker/index.md
@@ -34,15 +34,15 @@ We will also use Docker images to run the analysis modules in the `OpenScPCA-nf`
 
 Follow the instructions to [Install Docker Desktop on Mac](https://docs.docker.com/desktop/install/mac-install/) on the Docker website.
 
-#### Apple silicon (M1-3) Mac users
+#### Apple silicon (M-series) Mac users
 
 After installing Docker, we recommend that Apple silicon Mac users follow these additional steps:
 
 1. Install Rosetta 2 [as described in the "System Requirements" section in the "Mac with Apple Silicon" tab](https://docs.docker.com/desktop/install/mac-install/#system-requirements).
 1. Enable Rosetta emulation in the Docker Desktop Settings.
 In the ["General" settings](https://docs.docker.com/desktop/settings/mac/#general) tab, make sure the following are turned **on**:
-    - `Use Virtualization framework`
-    - `Use Rosetta for x86_64/amd64 emulation on Apple Silicon`
+    - "Use Virtualization framework"
+    - "Use Rosetta for x86_64/amd64 emulation on Apple Silicon"
 
 ### Windows users
 

--- a/docs/ensuring-repro/docker/index.md
+++ b/docs/ensuring-repro/docker/index.md
@@ -38,11 +38,17 @@ Follow the instructions to [Install Docker Desktop on Mac](https://docs.docker.c
 
 After installing Docker, we recommend that Apple silicon Mac users follow these additional steps:
 
-1. Install Rosetta 2 [as described in the "System Requirements" section in the "Mac with Apple Silicon" tab](https://docs.docker.com/desktop/install/mac-install/#system-requirements).
+1. Install Rosetta 2 [as described in the "System Requirements" section in the "Mac with Apple silicon" tab](https://docs.docker.com/desktop/install/mac-install/#system-requirements) by running the following in [the terminal](../../getting-started/project-tools/using-the-terminal.md):
+
+    ```sh
+    # Install Rosetta 2, following instructions when prompted
+    softwareupdate --install-rosetta
+    ```
+
 1. Enable Rosetta emulation in the Docker Desktop Settings.
 In the ["General" settings](https://docs.docker.com/desktop/settings/mac/#general) tab, make sure the following are turned **on**:
     - "Use Virtualization framework"
-    - "Use Rosetta for x86_64/amd64 emulation on Apple Silicon"
+    - "Use Rosetta for `x86_64/amd64` emulation on Apple Silicon"
 
 ### Windows users
 

--- a/docs/ensuring-repro/docker/index.md
+++ b/docs/ensuring-repro/docker/index.md
@@ -34,6 +34,16 @@ We will also use Docker images to run the analysis modules in the `OpenScPCA-nf`
 
 Follow the instructions to [Install Docker Desktop on Mac](https://docs.docker.com/desktop/install/mac-install/) on the Docker website.
 
+#### Apple silicon (M1-3) Mac users
+
+After installing Docker, we recommend that Apple silicon Mac users follow these additional steps:
+
+1. Install Rosetta 2 [as described in the "System Requirements" section in the "Mac with Apple Silicon" tab](https://docs.docker.com/desktop/install/mac-install/#system-requirements).
+1. Enable Rosetta emulation in the Docker Desktop Settings.
+In the ["General" settings](https://docs.docker.com/desktop/settings/mac/#general) tab, make sure the following are turned **on**:
+    - `Use Virtualization framework`
+    - `Use Rosetta for x86_64/amd64 emulation on Apple Silicon`
+
 ### Windows users
 
 To enable Docker on the WSL 2 side of your computer, you will need to turn on Docker's built-in [WSL 2 feature](https://docs.docker.com/desktop/wsl/).

--- a/docs/ensuring-repro/docker/index.md
+++ b/docs/ensuring-repro/docker/index.md
@@ -47,6 +47,7 @@ After installing Docker, we recommend that Apple silicon Mac users follow these 
 
 1. Enable Rosetta emulation in the Docker Desktop Settings.
 In the ["General" settings](https://docs.docker.com/desktop/settings/mac/#general) tab, make sure the following are turned **on**:
+    - "Use containerd for pulling and storing images"
     - "Use Virtualization framework"
     - "Use Rosetta for `x86_64/amd64` emulation on Apple Silicon"
 

--- a/docs/ensuring-repro/docker/using-images.md
+++ b/docs/ensuring-repro/docker/using-images.md
@@ -31,7 +31,9 @@ To obtain a local copy of a Docker image, follow these steps:
       ```
 
     !!! tip "Macs with Apple silicon"
-          If you are using an Apple silicon (M-series) Mac, you will need to use the additional flag `--platform linux/x86_64` when pulling an image.
+          If you are using an Apple silicon (M-series) Mac, make sure you have [installed Rosetta 2](index.md#apple-silicon-m-series-mac-users) before pulling (and later running) a Docker image.
+
+          In addition, you will need to use the additional flag `--platform linux/x86_64` when pulling an image.
           Note that the flag `--platform linux/x86_64` _must_ be provided before the image name.
 
           ```sh
@@ -76,6 +78,7 @@ docker run \
       ```
 
       You can safely ignore this warning, or you can silence it by providing the flag `--platform linux/x86_64` to your `docker run` command.
+      Again, make sure you have [installed Rosetta 2](index.md#apple-silicon-m-series-mac-users) before attempting to launch a container.
 
 
 ## Using Docker images on virtual computers

--- a/docs/ensuring-repro/docker/using-images.md
+++ b/docs/ensuring-repro/docker/using-images.md
@@ -31,7 +31,7 @@ To obtain a local copy of a Docker image, follow these steps:
       ```
 
     !!! tip "Macs with Apple silicon"
-          If you are using an Apple silicon (M1-3) Mac, you will need to use the additional flag `--platform linux/x86_64` when pulling an image.
+          If you are using an Apple silicon (M-series) Mac, you will need to use the additional flag `--platform linux/x86_64` when pulling an image.
           Note that the flag `--platform linux/x86_64` _must_ be provided before the image name.
 
           ```sh
@@ -69,7 +69,7 @@ docker run \
 ```
 
 !!! tip "Macs with Apple silicon"
-      If you are using an Apple silicon (M1-3) Mac, you may see this warning when launching the container:
+      If you are using an Apple silicon (M-series) Mac, you may see this warning when launching the container:
 
       ```{.console .no-copy}
       WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested

--- a/docs/ensuring-repro/docker/using-images.md
+++ b/docs/ensuring-repro/docker/using-images.md
@@ -31,7 +31,7 @@ To obtain a local copy of a Docker image, follow these steps:
       ```
 
     !!! tip "Macs with Apple silicon"
-          If you are using an Apple silicon (M-series) Mac, make sure you have [installed Rosetta 2](index.md#apple-silicon-m-series-mac-users) before pulling (and later running) a Docker image.
+          If you are using an Apple silicon (M-series) Mac, make sure you have [installed Rosetta 2 and enabled `x86_64/amd64` emulation](index.md#apple-silicon-m-series-mac-users) before pulling (and later running) a Docker image.
 
           In addition, you will need to use the additional flag `--platform linux/x86_64` when pulling an image.
           Note that the flag `--platform linux/x86_64` _must_ be provided before the image name.

--- a/docs/ensuring-repro/managing-software/using-conda.md
+++ b/docs/ensuring-repro/managing-software/using-conda.md
@@ -59,7 +59,7 @@ You should perform this step before [filing a pull request](../../contributing-t
 
 !!! note
     If the `conda-lock` command fails, it may be because a package is not available for one of the platforms listed in the `environment.yml` file.
-    Usually this will be a package that is not available for the `osx-arm64` (Apple Silicon) platform.
+    Usually this will be a package that is not available for the `osx-arm64` (Apple silicon) platform.
 
     If this happens, see the [Software not available on a specific platform](#adding-dependencies-not-available-on-a-specific-platform) section below for instructions on how to handle this situation.
 
@@ -135,7 +135,7 @@ Alternatively, you can search [anaconda.org](https://anaconda.org) for packages 
 
 While most conda packages are available for all platforms, there may be some cases where a particular platform does not have a version of a package.
 
-Most often this will occur for ARM-based computers, such as macOS computers with Apple Silicon M-series processors.
+Most often this will occur for ARM-based computers, such as macOS computers with Apple silicon M-series processors.
 If you encounter an error with `conda-lock --file environment.yml`, it may be because a package is not available for the `osx-arm64` platform.
 
 In this case, you should edit the `environment.yml` file to *remove* the `- osx-arm64` line from the `platforms:` section.
@@ -155,7 +155,7 @@ conda-lock install --name openscpca-{module_name} conda-linux-64.lock
 conda activate openscpca-{module_name}
 ```
 
-If you are using an Apple Silicon computer, you will need to use the `conda-osx-64.lock` file, with one extra option to allow installation of the non-native platform lockfile, and one extra command to ensure that any future software you install in the environment will use the same architecture:
+If you are using an Apple silicon computer, you will need to use the `conda-osx-64.lock` file, with one extra option to allow installation of the non-native platform lockfile, and one extra command to ensure that any future software you install in the environment will use the same architecture:
 
 ```bash
 conda-lock install --no-validate-platform --name openscpca-{module_name} conda-osx-64.lock
@@ -164,7 +164,7 @@ conda config --env --set subdir osx-64
 ```
 
 !!! tip "Adding packages that are not available for your current platform"
-    If you find you need to add a package to an existing environment that is not available for your _current_ platform (i.e., a package that is only available for Intel on an Apple Silicon computer), the easiest method is to follow a slightly different order of operations:
+    If you find you need to add a package to an existing environment that is not available for your _current_ platform (i.e., a package that is only available for Intel on an Apple silicon computer), the easiest method is to follow a slightly different order of operations:
 
     - First, add the package name and version to the `environment.yml` file.
     - Next, remove the `osx-arm64` line from the `platforms:` section of the `environment.yml` file.

--- a/docs/technical-setup/environment-setup/install-r-rstudio.md
+++ b/docs/technical-setup/environment-setup/install-r-rstudio.md
@@ -24,7 +24,7 @@ The instructions provided here are suitable for the vast majority of contributor
 1. Navigate to the [macOS download page on the CRAN website](https://cran.r-project.org/bin/macosx/).
 
 2. Download the R package that matches your computer's architecture, and follow all installation instructions.
-    - If you're on an Apple silicon (M1-3) Mac, install R from the link `R-X.Y.Z-arm64.pkg`, where `X.Y.Z` is the specific R version.
+    - If you're on an Apple silicon (M-series) Mac, install R from the link `R-X.Y.Z-arm64.pkg`, where `X.Y.Z` is the specific R version.
     - If you're on an Intel Mac, install R from the link `R-X.Y.Z-x86_64.pkg`, where `X.Y.Z` is the specific R version.
 
 

--- a/docs/technical-setup/environment-setup/setup-conda.md
+++ b/docs/technical-setup/environment-setup/setup-conda.md
@@ -36,7 +36,7 @@ If you already have conda on your system, you do not need to re-install it.
 To install Miniconda, [download the graphical installer for macOS](https://docs.anaconda.com/free/miniconda/miniconda-install/), and follow all instructions.
 
   - If you are on a macOS computer, be sure to download one of the links ending in `pkg`, _not `bash`_:
-    - Apple Silicon (M1-3) Mac users should download `Miniconda3 macOS Apple M1 64-bit pkg`
+    - Apple silicon (M1-series) Mac users should download `Miniconda3 macOS Apple M1 64-bit pkg`
     - Intel Mac users should download `Miniconda3 macOS Intel x86 64-bit pkg`
 
 ### Install Miniconda on Windows with WSL 2


### PR DESCRIPTION
Closed #689 

This PR adds documentation that Apple silicon users should enable Rosetta when installing and setting up Docker Desktop. Let me know if we want a screen shot here or any additional info.