### PR TITLE
Disable second docker build summary 

### DIFF
--- a/.github/workflows/build-push-docker-module.yml
+++ b/.github/workflows/build-push-docker-module.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Push image
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           push: true
           context: "{{defaultContext}}:analyses/${{ inputs.module }}"


### PR DESCRIPTION
Since we don't need two summaries when building Docker images, this disables the summary for the job that does the pushing. 