### PR TITLE
Update periodic release issue template to minimize steps

### DIFF
--- a/.github/cron-issue-templates/create-periodic-release-template.md
+++ b/.github/cron-issue-templates/create-periodic-release-template.md
@@ -2,7 +2,5 @@ Create a periodic release using [the periodic release workflow](https://github.c
 
 #### Pre-release checklist
 
-- [ ] All scheduled workflows are passing
-  - [ ] [Run all analysis modules](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/workflows/run_all-modules.yml) (trigger manually if needed)
-  - [ ] [Spellcheck](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/workflows/spellcheck.yml) (trigger manually if needed)
+- [ ] The most recent [run all analysis modules workflow](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/workflows/run_all-modules.yml) ran without issue
 - [ ] All blocking issues have been resolved


### PR DESCRIPTION
We would like to limit the work involved in a dated release to just making sure that the most recent run of all modules ran correctly rather than triggering it manually and also running spellcheck.

I left the part about any blocking issues, as I could imagine that would come up from time to time.