### PR TITLE
Don't have spellcheck action fail

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -67,8 +67,8 @@ jobs:
             OpenScPCA admin
             spelling
 
-      - name: Fail if there are spelling errors
-        if: steps.spell.outputs.error_count > 0
+      - name: Fail if there are spelling errors for non-scheduled jobs
+        if: github.event_name != 'schedule' && steps.spell.outputs.error_count > 0
         run: |
           echo "There were ${{ steps.spell.outputs.error_count }} errors"
           column -t spell_check_errors.tsv

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -66,10 +66,3 @@ jobs:
           labels: |
             OpenScPCA admin
             spelling
-
-      - name: Fail if there are spelling errors
-        if: steps.spell.outputs.error_count > 0
-        run: |
-          echo "There were ${{ steps.spell.outputs.error_count }} errors"
-          column -t spell_check_errors.tsv
-          exit 1

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -66,3 +66,10 @@ jobs:
           labels: |
             OpenScPCA admin
             spelling
+
+      - name: Fail if there are spelling errors
+        if: steps.spell.outputs.error_count > 0
+        run: |
+          echo "There were ${{ steps.spell.outputs.error_count }} errors"
+          column -t spell_check_errors.tsv
+          exit 1


### PR DESCRIPTION
(Posting this after I got a workflow failure email that it took me a bit too long to figure out was not really because of something I had done.)

Since the spellcheck action already posts any spelling errors to an issue, we probably don't also need the action to fail as well. It seems like the workflow failure notice maybe goes to the last person to commit to main (did anybody else get it for the most recent failure?), which seems pretty arbitrary.


