### PR TITLE
Add some words to dictionary

### DIFF
--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -158,6 +158,7 @@ scrublet
 SEACells
 SemVar
 SingleR
+snRNA
 socio
 SSO
 stroma

--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -4,6 +4,8 @@ ADT
 al
 ALSF
 altExp
+anaplasia
+anaplastic
 aneuploid
 AnnData
 anonymize
@@ -18,6 +20,8 @@ benchmarking
 Bioconda
 Bioconductor
 bioinformatics
+blastema
+blastemal
 Bleijs
 Carpentries
 CellAssign
@@ -53,6 +57,7 @@ doxxing
 dropdown
 ECM
 ECR
+endothelium
 enforceability
 Ensembl
 enure
@@ -73,7 +78,9 @@ GitKraken's
 Goodspeed
 GPUs
 GTF
+Halbritter
 heterotypic
+histological
 homotypic
 HPC
 IAM
@@ -111,6 +118,7 @@ Miniconda
 misidentification
 MSC
 multifactor
+myeloid
 natively
 Nextflow
 nonconsensual
@@ -123,6 +131,8 @@ Panglao
 PanglaoDB
 PDX
 pluripotent
+podman
+podocyte
 Posit
 Posit's
 PowerShell
@@ -150,6 +160,8 @@ SemVar
 SingleR
 socio
 SSO
+stroma
+stromal
 Stumptown
 sublicensable
 symlink
@@ -165,10 +177,12 @@ TSV
 UCell
 UMAP
 uncomment
+unhide
 vCPU
 vCPUs
 Visser
 VSCodium
+Wilms
 WIPO
 WisCon
 WSL

--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -158,6 +158,7 @@ scrublet
 SEACells
 SemVar
 SingleR
+scRNA
 snRNA
 socio
 SSO


### PR DESCRIPTION
Closes #719 

This PR adds some of the found typos to the dictionary. Some choices I made:

- I added...
  - "podman" since that is the container software used in the wilms module, but I could alternatively remove it and we could later update it to be `podman` in the module if preferred.
  - unhide." If that's the word R Markdown uses, I guess that's the word!
- I didn't add... 
  - Gene names or words that appear in DOIs (e.g. "oncotarget") since we expect to add those in backticks eventually
  - The cell type "Treg". Should I, or will we eventually want things like that in backticks?

Let me know if you think I missed anything! Here are the typos from #719: [spell_check_errors.tsv.txt](https://github.com/user-attachments/files/16625938/spell_check_errors.tsv.txt)
