### PR TITLE
Run Docker build and push on a larger runner

### DIFF
--- a/.github/workflows/build-push-docker-module.yml
+++ b/.github/workflows/build-push-docker-module.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build and Push Docker Image
     if: inputs.push-ecr && github.repository_owner == 'AlexsLemonade'
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: openscpca-22.04-big-disk
 
     steps:
       - name: Clear space


### PR DESCRIPTION
Closes #717 - this runner has a 150 GB SSD and can only be used by this workflow on the `main` branch.