### PR TITLE
Fix linking to use relative links

### DIFF
--- a/download-data.py
+++ b/download-data.py
@@ -172,7 +172,7 @@ def update_symlink(data_dir: pathlib.Path, target: str, dryrun: bool = False) ->
         else:
             current_symlink = data_dir / "current"
             current_symlink.unlink(missing_ok=True)
-            current_symlink.symlink_to(target_path)
+            current_symlink.symlink_to(target) # the relative path
             print(f"Updated 'current' symlink to point to '{target}'.")
 
 


### PR DESCRIPTION
Closes #733

It seems that the problem in #733 was not relative path symlinks being a problem in Docker, but in fact that I had introduced a bug whereby we were creating absolute path symlinks, which I would fully expect to fail when mounted in Docker images. 

This should fix the issue, and does in my local testing. Because this is creating the behavior we expected, I do not think we should need any docs updates, but please do confirm that you agree, and that this fixes the issue.

You should be able to run `./download-data.py --update-symlink` to fix any issues with your current `data/` directory.