### PR TITLE
Test fix for docker actions failing after miniforge

### DIFF
--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -22,6 +22,7 @@ on:
       - main
     paths:
       - analyses/cell-type-ewings/**
+      - "!analyses/cell-type-ewings/Dockerfile"
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'

--- a/analyses/cell-type-ewings/Dockerfile
+++ b/analyses/cell-type-ewings/Dockerfile
@@ -35,9 +35,12 @@ RUN curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/M
   && conda clean --tarballs --index-cache --packages --yes \
   && find /opt/conda -follow -type f -name '*.a' -delete \
   && find /opt/conda -follow -type f -name '*.pyc' -delete \
-  && conda clean --force-pkgs-dirs --all --yes \
-  && echo ". /opt/conda/etc/profile.d/conda.sh && conda activate base" >> /etc/skel/.bashrc \
-  && echo ". /opt/conda/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc
+  && conda clean --force-pkgs-dirs --all --yes
+
+# Activate conda environments in bash
+RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
+  && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+  && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 
 # add conda-lock
 RUN conda install conda-lock && conda clean --all --yes


### PR DESCRIPTION
Looking at the changes made in #740, I think the most likely culprit for the failures in #743 is that I had removed adding conda.sh to `/etc/profile.d`. It seems possible (likely) that GHA isn't activating `.bashrc` when running its jobs, but hope it is the fix. I am just including the cell-type-ewings module for now. If this works after testing, I will add the same changes to all docker files and instructions.