### PR TITLE
Propagate miniforge Docker changes

### DIFF
--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -23,6 +23,7 @@ on:
     paths:
       - analyses/cell-type-ewings/**
       - "!analyses/cell-type-ewings/Dockerfile"
+      - "!analyses/cell-type-ewings/.dockerignore"
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'

--- a/.github/workflows/run_cell-type-wilms-tumor-06.yml
+++ b/.github/workflows/run_cell-type-wilms-tumor-06.yml
@@ -25,6 +25,8 @@ on:
       - main
     paths:
       - "analyses/cell-type-wilms-tumor-06/**"
+      - "!analyses/cell-type-wilms-tumor-06/Dockerfile"
+      - "!analyses/cell-type-wilms-tumor-06/.dockerignore"
 
 jobs:
   run-module:

--- a/.github/workflows/run_doublet-detection.yml
+++ b/.github/workflows/run_doublet-detection.yml
@@ -24,7 +24,9 @@ on:
       - main
     paths:
       - analyses/doublet-detection/**
-      - .github/workflows/run_doublet-detection.yml
+      - "!analyses/doublet-detection/Dockerfile"
+      - "!analyses/doublet-detection/.dockerignore"
+      # - .github/workflows/run_doublet-detection.yml
 
 jobs:
   run-module:
@@ -44,7 +46,7 @@ jobs:
           # Use all samples for testing unless this is triggered by a PR, in which case only use a subset of samples for faster testing
           # A single sample (or combination of samples for multiplexed data) was chosen for each ScPCA project as:
           #  Unless otherwise stated, the first sample ID in the given project
-          #  For the multiplexed project SCPCP000009, set of samples `SCPCS000133,SCPCS000134,SCPCS000135,SCPCS000136` (this group of samples has 2 associated libraries). Only `SCPCS000133` is specifed in the SAMPLES string here.
+          #  For the multiplexed project SCPCP000009, set of samples `SCPCS000133,SCPCS000134,SCPCS000135,SCPCS000136` (this group of samples has 2 associated libraries). Only `SCPCS000133` is specified in the SAMPLES string here.
           #   For the project SCPCP000011, the sample SCPCS000435 was specifically selected as an edge case sample with <10 cells
           SAMPLES: ${{ github.event_name != 'pull_request' && 'all' || 'SCPCS000001,SCPCS000024,SCPCS000050,SCPCS000101,SCPCS000124,SCPCS000133,SCPCS000168,SCPCS000216,SCPCS000246,SCPCS000250,SCPCS000298,SCPCS000435,SCPCS000481,SCPCS000484,SCPCS000490,SCPCS000502,SCPCS000514,SCPCS000616,SCPCS000632,SCPCS000758' }}
 

--- a/analyses/doublet-detection/Dockerfile
+++ b/analyses/doublet-detection/Dockerfile
@@ -22,9 +22,12 @@ RUN curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/M
   && conda clean --tarballs --index-cache --packages --yes \
   && find /opt/conda -follow -type f -name '*.a' -delete \
   && find /opt/conda -follow -type f -name '*.pyc' -delete \
-  && conda clean --force-pkgs-dirs --all --yes \
-  && echo ". /opt/conda/etc/profile.d/conda.sh && conda activate base" >> /etc/skel/.bashrc \
-  && echo ". /opt/conda/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc
+  && conda clean --force-pkgs-dirs --all --yes
+
+# Activate conda environments in bash
+RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
+  && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+  && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 
 # Install conda-lock
 RUN conda install --channel=conda-forge --name=base conda-lock \

--- a/docs/ensuring-repro/docker/docker-images.md
+++ b/docs/ensuring-repro/docker/docker-images.md
@@ -158,9 +158,12 @@ RUN curl -L "https://github.com/conda-forge/miniforge/releases/latest/download/M
   && conda clean --tarballs --index-cache --packages --yes \
   && find /opt/conda -follow -type f -name '*.a' -delete \
   && find /opt/conda -follow -type f -name '*.pyc' -delete \
-  && conda clean --force-pkgs-dirs --all --yes \
-  && echo ". /opt/conda/etc/profile.d/conda.sh && conda activate base" >> /etc/skel/.bashrc \
-  && echo ". /opt/conda/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc
+  && conda clean --force-pkgs-dirs --all --yes
+
+# Activate conda environments in bash
+RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
+  && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/skel/.bashrc \
+  && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 
 # Install conda-lock
 RUN conda install --channel=conda-forge --name=base conda-lock \


### PR DESCRIPTION
Closes #743

This PR propagates changes from #744 to all Dockerfiles where conda is installed separately through miniforge, and to the docs with miniforge installation instructions for Docker. I had checked that #744 was successful by running the [Run cell-type-ewings analysis module ](https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/runs/10687269539/job/29624484348) which is not yet complete, but is successfully running in the provided docker container. 

I also temporarily removed the trigger for `doublet-detection` to run on workflow changes, just because at the moment that would run using the old docker image. Once this PR is in and the new docker image has been pushed to ECR, this change can be reverted.