### PR TITLE
Add download option to sync script

### DIFF
--- a/scripts/sync-results.py
+++ b/scripts/sync-results.py
@@ -61,6 +61,11 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--download",
+        action="store_true",
+        help="Download files from the S3 bucket to the local directory instead of uploading.",
+    )
+    parser.add_argument(
         "--dryrun",
         action="store_true",
         help="Perform a dry run: show what would be done but do not copy or delete any files.",
@@ -101,12 +106,18 @@ def main() -> None:
         )
         sys.exit(1)
 
+    source = module_root
+    destination = f"s3://{bucket}/{args.module}"
+    if args.download:
+        # if downloading, swap source and destination
+        source, destination = destination, source
+
     sync_cmd = [
         "aws",
         "s3",
         "sync",
-        module_root,
-        f"s3://{bucket}/{args.module}",
+        source,
+        destination,
         "--exclude",
         "*",
     ]
@@ -136,7 +147,10 @@ def main() -> None:
         sys.exit(1)
 
     print("Sync complete.")
-    print(f"Files are now available on S3 at: s3://{bucket}/{args.module}/")
+    if args.download:
+        print(f"Files have been downloaded from '{destination}' to '{source}'")
+    else:
+        print(f"Files are now available on S3 at '{destination}'")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes https://github.com/AlexsLemonade/OpenScPCA-admin/issues/257

Here I added a `--download` flag to the existing `sync-results.py` script. At the moment, this option works quite simply to reverse the source and destination for the internal `aws` sync command, and should allow downloading from a results bucket with code like the following, (assuming the sso login has been performed): 

```
python scripts/sync-results.py cell-type-wilms-tumor-06  --bucket researcher-008971640512-us-east-2 --download
```

All of the other options continue to work, so to use a different profile from the currently active one and perform a dry run, you would add options as follows:

```
python scripts/sync-results.py cell-type-wilms-tumor-06  --bucket researcher-008971640512-us-east-2 --download --profile workload --dryrun
```

My only other thought here is that it might be nice to have the bucket autopopulate for each module if we had a file somewhere that stored the bucket name, such as `<module>/.aws_bucket` which could save a bit of repeated manual checking. But that could be a later PR.