### PR TITLE
Update sync-results.py printing

### DIFF
--- a/scripts/sync-results.py
+++ b/scripts/sync-results.py
@@ -148,7 +148,7 @@ def main() -> None:
 
     print("Sync complete.")
     if args.download:
-        print(f"Files have been downloaded from '{destination}' to '{source}'")
+        print(f"Files have been downloaded from '{source}' to '{destination}'")
     else:
         print(f"Files are now available on S3 at '{destination}'")
 


### PR DESCRIPTION
I noticed when syncing contributor results with `--download` that the print statement is backwards - 

```
Files have been downloaded from '/Users/sjspielman/ALSF/open-scpca/OpenScPCA-analysis/analyses/cell-type-wilms-tumor-06' to 's3://researcher-008971640512-us-east-2/cell-type-wilms-tumor-06'
```

This PR just flips that printing order.