### PR TITLE
Update rOpenScPCA gha 

### DIFF
--- a/.github/workflows/test_ropenscpca.yml
+++ b/.github/workflows/test_ropenscpca.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - main
       - feature/*
+    paths:
+      - packages/rOpenScPCA/**
 
 name: Check the rOpenScPCA package
 


### PR DESCRIPTION
In https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/769, I noticed the rOpenScPCA check is being run unnecessarily. This PR adds a `paths` field to the yml to avoid unnecessary runs.