### PR TITLE
Do not print messages about syncs completing when using --dryrun

### DIFF
--- a/scripts/sync-results.py
+++ b/scripts/sync-results.py
@@ -146,11 +146,12 @@ def main() -> None:
         )
         sys.exit(1)
 
-    print("Sync complete.")
-    if args.download:
-        print(f"Files have been downloaded from '{source}' to '{destination}'")
-    else:
-        print(f"Files are now available on S3 at '{destination}'")
+    if not args.dryrun:
+      print("Sync complete.")
+      if args.download:
+          print(f"Files have been downloaded from '{source}' to '{destination}'")
+      else:
+          print(f"Files are now available on S3 at '{destination}'")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Purpose/implementation Section

When using `scripts/sync-results.py` with `--dryrun`, I found that the printed messages could be misleading. In particular, I don't think we want to tell folks files have been downloaded or are now available on S3 if they use `--dryrun`. I could be persuaded that "Sync complete" should be outside of this logic.


