### PR TITLE
Add PNGs to large file exclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,8 @@ repos:
           (?x)(
               \.html$|
               \.ipynb$|
-              conda-lock\.yml$
+              conda-lock\.yml$|
+              \.png$
           )
       - name: Large file size limit
         id: check-added-large-files


### PR DESCRIPTION
### Purpose/implementation Section

Adding PNGs to the file extensions that get checked with the larger of the two file size pre-commit checks. This is because we have large PNGs we would like to add to the repository.
