### PR TITLE
add 3 modules with PR triggers to the run all workflow

### DIFF
--- a/.github/workflows/run_all-modules.yml
+++ b/.github/workflows/run_all-modules.yml
@@ -22,8 +22,17 @@ jobs:
   doublet-detection:
     uses: ./.github/workflows/run_doublet-detection.yml
 
+  metacells:
+    uses: ./.github/workflows/run_metacells.yml
+
   cell-type-ewings:
     uses: ./.github/workflows/run_cell-type-ewings.yml
+
+  cell-type-wilms-06:
+    uses: ./.github/workflows/run_cell-type-wilms-tumor-06.yml
+
+  cell-type-wilms-14:
+    uses: ./.github/workflows/run_cell-type-wilms-tumor-14.yml
 
   ## Add additional modules above this comment, and to the needs list below
   check-jobs:


### PR DESCRIPTION
Preface to #785 

This PR adds a few more modules which have the PR trigger to the `run_all-modules.yml` workflow. Anything without a hashtag is now in the file:

```
(base) workflows ➤ grep "pull_request:" run*yml
run_cell-type-dsrct.yml:  # pull_request:
run_cell-type-ewings.yml:  pull_request:
run_cell-type-nonETP-ALL-03.yml:  # pull_request:
run_cell-type-wilms-tumor-06.yml:  pull_request:
run_cell-type-wilms-tumor-14.yml:  pull_request:
run_celltype-glioblastoma.yml:  # pull_request:
run_doublet-detection.yml:  pull_request:
run_hello-R.yml:  pull_request:
run_hello-python.yml:  pull_request:
run_metacells.yml:  pull_request:
```

This workflow itself doesn't have PR trigger, so I'll run it once this goes in to prep for release. 