### PR TITLE
Create shell script for wilms-06 workflow

### DIFF
--- a/.github/workflows/run_cell-type-wilms-tumor-06.yml
+++ b/.github/workflows/run_cell-type-wilms-tumor-06.yml
@@ -23,6 +23,7 @@ on:
   pull_request:
     branches:
       - main
+      - feature/*
     paths:
       - analyses/cell-type-wilms-tumor-06/**
       - "!analyses/cell-type-wilms-tumor-06/Dockerfile"
@@ -61,5 +62,5 @@ jobs:
         run: ./download-data.py --test-data --format SCE --projects SCPCP000006
 
       - name: Run analysis module
-        run: Rscript 00_run_workflow.R --testing
+        run: TESTING=1 bash 00_run_workflow.sh
         working-directory: ${{ env.MODULE_PATH }}

--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# This script runs the module workflow.
+#
+# USAGE:
+# bash 00_run_workflow.sh
+#
+# USAGE in CI:
+# TESTING=1 bash 00_run_workflow.sh
+
+set -euo pipefail
+
+IS_CI=${TESTING:-0}
+project_id="SCPCP000006"
+
+# Ensure script is being run from its directory
+module_dir=$(dirname "${BASH_SOURCE[0]}")
+cd ${module_dir}
+
+# Define directories
+data_dir="../../data/current"
+notebook_template_dir="notebook_template"
+notebook_output_dir="notebook"
+
+
+# Download and create the fetal kidney reference (Stewart et al)
+Rscript scripts/download-and-create-fetal-kidney-ref.R
+
+# Build the gene position file reference for infercnv
+Rscript scripts/06a_build-geneposition.R
+
+# Characterize the fetal kidney reference (Stewart et al.)
+Rscript -e "rmarkdown::render('${notebook_template_dir}/00b_characterize_fetal_kidney_reference_Stewart.Rmd',
+    output_format = 'html_document',
+    output_file = '00b_characterization_fetal_kidney_reference_Stewart.html',
+    output_dir = '${notebook_output_dir}/00-reference')"
+
+
+# Run the label transfer and cluster exploration for all samples in the project
+for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
+    sample_id=$(basename $sample_dir)
+
+    # define and create sample-specific directories
+    # directory for the pre-processed and labeled `Seurat` objects
+    results_dir=results/${sample_id}
+    # directory for sample-specific notebooks
+    sample_notebook_dir=notebook/${sample_id}
+
+    mkdir -p $results_dir
+    mkdir -p $sample_notebook_dir
+
+    # Pre-process the data - `Seurat` workflow
+    Rscript -e "rmarkdown::render('${notebook_template_dir}/01_seurat-processing.Rmd',
+                    params = list(scpca_project_id = ${project_id}, sample_id = ${sample_id}),
+                    output_format = 'html_document',
+                    output_file = '01_seurat_processing_${sample_id}.html',
+                    output_dir = '${sample_notebook_dir}')"
+
+    # Temporarily this code is not run in CI.
+    if [[ $IS_CI -eq 0 ]]; then
+
+        # Label transfer from the Cao reference using Azimuth
+        Rscript -e "rmarkdown::render('${notebook_template_dir}/02a_label-transfer_fetal_full_reference_Cao.Rmd',
+                        params = list(scpca_project_id = ${project_id}, sample_id = ${sample_id}),
+                        output_format = 'html_document',
+                        output_file = '02a_fetal_all_reference_Cao_${sample_id}.html',
+                        output_dir = '${sample_notebook_dir}')"
+
+        # Label transfer from the Stewart reference using Seurat
+        Rscript -e "rmarkdown::render('${notebook_template_dir}/02a_label-transfer_fetal_full_reference_Stewart.Rmd',
+                        params = list(scpca_project_id = ${project_id}, sample_id = ${sample_id}),
+                        output_format = 'html_document',
+                        output_file = '02a_fetal_all_reference_Stewart_${sample_id}.html',
+                        output_dir = '${sample_notebook_dir}')"
+
+        # Cluster exploration
+        Rscript -e "rmarkdown::render('${notebook_template_dir}/03_clustering_exploration.Rmd',
+                        params = list(scpca_project_id = ${project_id}, sample_id = ${sample_id}),
+                        output_format = 'html_document',
+                        output_file = '03_clustering_exploration_${sample_id}.html',
+                        output_dir = '${sample_notebook_dir}')"
+    fi
+done
+
+# Temporarily this code is not run in CI.
+if [[ $IS_CI -eq 0 ]]; then
+
+  # Run notebook template to explore label transfer and clustering for all samples at once
+  Rscript -e "rmarkdown::render('${notebook_output_dir}/04_annotation_Across_Samples_exploration.Rmd',
+                  output_format = 'html_document',
+                  output_file = '04_annotation_Across_Samples_exploration.html',
+                  output_dir = ${notebook_output_dir})"
+
+  # Run infercnv and copykat for a selection of samples
+  # This script calls scripts/05_copyKAT.R and scripts/06_infercnv.R
+  Rscript scripts/explore-cnv-methods.R
+
+fi
+
+
+
+
+
+
+

--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -51,7 +51,7 @@ for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
 
     # Pre-process the data - `Seurat` workflow
     Rscript -e "rmarkdown::render('${notebook_template_dir}/01_seurat-processing.Rmd',
-                    params = list(scpca_project_id = ${project_id}, sample_id = ${sample_id}),
+                    params = list(scpca_project_id = '${project_id}', sample_id = '${sample_id}'),
                     output_format = 'html_document',
                     output_file = '01_seurat_processing_${sample_id}.html',
                     output_dir = '${sample_notebook_dir}')"
@@ -61,21 +61,21 @@ for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
 
         # Label transfer from the Cao reference using Azimuth
         Rscript -e "rmarkdown::render('${notebook_template_dir}/02a_label-transfer_fetal_full_reference_Cao.Rmd',
-                        params = list(scpca_project_id = ${project_id}, sample_id = ${sample_id}),
+                        params = list(scpca_project_id = '${project_id}', sample_id = '${sample_id}'),
                         output_format = 'html_document',
                         output_file = '02a_fetal_all_reference_Cao_${sample_id}.html',
                         output_dir = '${sample_notebook_dir}')"
 
         # Label transfer from the Stewart reference using Seurat
         Rscript -e "rmarkdown::render('${notebook_template_dir}/02a_label-transfer_fetal_full_reference_Stewart.Rmd',
-                        params = list(scpca_project_id = ${project_id}, sample_id = ${sample_id}),
+                        params = list(scpca_project_id = '${project_id}', sample_id = '${sample_id}'),
                         output_format = 'html_document',
                         output_file = '02a_fetal_all_reference_Stewart_${sample_id}.html',
                         output_dir = '${sample_notebook_dir}')"
 
         # Cluster exploration
         Rscript -e "rmarkdown::render('${notebook_template_dir}/03_clustering_exploration.Rmd',
-                        params = list(scpca_project_id = ${project_id}, sample_id = ${sample_id}),
+                        params = list(scpca_project_id = '${project_id}', sample_id = '${sample_id}'),
                         output_format = 'html_document',
                         output_file = '03_clustering_exploration_${sample_id}.html',
                         output_dir = '${sample_notebook_dir}')"

--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -96,10 +96,3 @@ if [[ $IS_CI -eq 0 ]]; then
   Rscript scripts/explore-cnv-methods.R
 
 fi
-
-
-
-
-
-
-

--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -26,9 +26,6 @@ notebook_output_dir="notebook"
 # Download and create the fetal kidney reference (Stewart et al)
 Rscript scripts/download-and-create-fetal-kidney-ref.R
 
-# Build the gene position file reference for infercnv
-Rscript scripts/06a_build-geneposition.R
-
 # Characterize the fetal kidney reference (Stewart et al.)
 Rscript -e "rmarkdown::render('${notebook_template_dir}/00b_characterize_fetal_kidney_reference_Stewart.Rmd',
     output_format = 'html_document',
@@ -90,6 +87,9 @@ if [[ $IS_CI -eq 0 ]]; then
                   output_format = 'html_document',
                   output_file = '04_annotation_Across_Samples_exploration.html',
                   output_dir = ${notebook_output_dir})"
+
+  # Build the gene position file reference for infercnv
+  Rscript scripts/06a_build-geneposition.R
 
   # Run infercnv and copykat for a selection of samples
   # This script calls scripts/05_copyKAT.R and scripts/06_infercnv.R

--- a/analyses/cell-type-wilms-tumor-06/README.md
+++ b/analyses/cell-type-wilms-tumor-06/README.md
@@ -70,17 +70,17 @@ Some differenices are expected, some marker genes or pathways are associated wit
 
 for each of the steps, we have two types of `output`:
 
-- the `notebook` saved in the `notebook` directory, with a subfolder for each sample. 
+- the `notebook` saved in the `notebook` directory, with a subfolder for each sample.
 
-- the created objects saved in `results` directory, with a subfolder for each sample. 
+- the created objects saved in `results` directory, with a subfolder for each sample.
 
 
 # Analysis
 
 ## Marker sets
 
-We first build a resource for later validation of the annotated cell types. 
-We gather from the litterature marker genes and specific genomic alterations that could help us characterizing the Wilms tumor ecosystem, including cancer and non-cancer cells. 
+We first build a resource for later validation of the annotated cell types.
+We gather from the litterature marker genes and specific genomic alterations that could help us characterizing the Wilms tumor ecosystem, including cancer and non-cancer cells.
 
 ### The table CellType_metadata.csv contains the following column and information:
 
@@ -137,11 +137,11 @@ We gather from the litterature marker genes and specific genomic alterations tha
 
 ## Clustering and label transfer from fetal references
 
-R Script to be rendered : `00_run_workflow.R`
+R Script to be rendered : `00_run_workflow.sh`
 
 ### Introduction
 
-The `00_run_workflow.R` contains the following steps:
+The `00_run_workflow.sh` contains the following steps:
 
 - define paths
 
@@ -152,19 +152,19 @@ The `00_run_workflow.R` contains the following steps:
 - loop for each samples:
 
   - `Seurat workflow`, normalization and clustering: `01_seurat-processing.Rmd` in `notebook_template`
-    
+
   - `Azimuth` label transfer from the fetal full reference (Cao et al.): `02a_label-transfer_fetal_full_reference_Cao.Rmd` in `notebook_template`
-    
+
   - `Azimuth` label transfer from the fetal kidney reference (Stewart et al.): `02b_label-transfer_fetal_kidney_reference_Stewart.Rmd` in `notebook_template`
-    
+
   - Exploration of clustering, label transfers, marker genes and pathways: `03_clustering_exploration.Rmd` in `notebook_template`
-    
+
 
 For each sample and each of the step, an html report is generated and accessible in the directory `notebook`.
 
-### Justification 
+### Justification
 
-The use of the right reference is crucial. 
+The use of the right reference is crucial.
 It is recommended that the cell types in the reference is representative to the cell types to be annotated in the query.
 
 Wilms tumors can contain up to three histologies that resemble fetal kidney: blastema, stroma, and epithelia [1-2].
@@ -174,22 +174,22 @@ We thus decided to test and compare two fetal (kidney) references that could be 
 
 ##### Human fetal kidney atlas Stewart et al.
 
-We first wanted to try the human fetal kidney atlas to transfer label into the Wilms tumor samples using azimuth. 
+We first wanted to try the human fetal kidney atlas to transfer label into the Wilms tumor samples using azimuth.
 You can find more about the human kidney atlas here: https://www.kidneycellatlas.org/ [3]
 
 ##### Human Azimuth fetal reference from Cao et al.
 
-Azimuth also provide a human fetal atlas as a reference [4]. 
+Azimuth also provide a human fetal atlas as a reference [4].
 
-The data can be found on Zenodo: 
+The data can be found on Zenodo:
 https://zenodo.org/records/4738021#.YJIW4C2ZNQI
 
-The reference contain cells from 15 organs including kidney from fetal samples. 
+The reference contain cells from 15 organs including kidney from fetal samples.
 Here we will use `Azimuth` to transfer labels from the reference.
 
 ### Input and outputs
 
-We start with the `_process.Rds` data to run `01_seurat-processing.Rmd`. 
+We start with the `_process.Rds` data to run `01_seurat-processing.Rmd`.
 The output of `01_seurat-processing.Rmd` is saved in `results` in a subfolder for each sample and is the input of the second step `02a_label-transfer_fetal_full_reference_Cao.Rmd`.
 The output of `02a_label-transfer_fetal_full_reference_Cao.Rmd` is then the input of `02b_label-transfer_fetal_kidney_reference_Stewart.Rmd`.
 Following the same approach, the output of `02b_label-transfer_fetal_kidney_reference_Stewart.Rmd` is the input of `03_clustering_exploration.Rmd`.
@@ -242,7 +242,7 @@ If you are on a Mac with an M series chip, you will not be able to use RStudio S
 You must build an ARM image locally to be able to use RStudio Server within the container.
 
 #### A note for Halbritter lab internal development
-This work has been developed on a system that uses podman instead of docker. The steps to run the docker/podman images are slightly different and we saved in run-podman-internal.sh our internal approach to run the container. Please, refer to the Docker section to build and run the container instead. 
+This work has been developed on a system that uses podman instead of docker. The steps to run the docker/podman images are slightly different and we saved in run-podman-internal.sh our internal approach to run the container. Please, refer to the Docker section to build and run the container instead.
 
 ### renv
 
@@ -254,13 +254,13 @@ The `renv` lockfile is used to install R packages in the Docker image.
 ## Computational resources
 
 
-## References 
+## References
 
-- [1] https://www.ncbi.nlm.nih.gov/books/NBK373356/ 
+- [1] https://www.ncbi.nlm.nih.gov/books/NBK373356/
 
-- [2] https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9915828/ 
+- [2] https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9915828/
 
-- [3] https://www.science.org/doi/10.1126/science.aat5031 
+- [3] https://www.science.org/doi/10.1126/science.aat5031
 
 - [4] https://www.science.org/doi/10.1126/science.aba7721
 

--- a/analyses/cell-type-wilms-tumor-06/README.md
+++ b/analyses/cell-type-wilms-tumor-06/README.md
@@ -137,7 +137,7 @@ We gather from the litterature marker genes and specific genomic alterations tha
 
 ## Clustering and label transfer from fetal references
 
-R Script to be rendered : `00_run_workflow.sh`
+Bash script to be run : `00_run_workflow.sh`
 
 ### Introduction
 


### PR DESCRIPTION
Towards #816 

This PR adds a new shell script to run the `cell-type-wilms-tumor-06` workflow. This does NOT contain any of the active changes in #814, since I wanted to make sure a directly comparable version of this script was in place before changing up the steps. As such, this is basically a "shell version" of `00_run_workflow.R`.

Other changes include:
- updating the workflow yaml file to use this script, and run on this branch
- updating the module README to reference this script instead of the old one. Note this file got got by precommit, hence whitespace diffs.

EDIT: Link to workflow R script for comparison during review: https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/feature/wilms-tumor-06-azimuth/analyses/cell-type-wilms-tumor-06/00_run_workflow.R