### PR TITLE
Switch to using precommit action locally

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,8 @@ It is not meant to be run as a standalone action.
 
 ## Repository maintenance
 
+* `pre-commit.yml` runs pre-commit checks defined by the `.pre-commit-config.yaml` file.
+  When modules reach the development stage where they should be automatically checked, they should be added to this text file.
 * `spellcheck.yml` performs spell checking of markdown and R Markdown documents.
 * `code-styling.yml` performs code styling using `styler` and `ruff`.
   * This workflow also consumes `modules_code-styling.txt` to determine which modules to style.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,7 +20,6 @@ It is not meant to be run as a standalone action.
 ## Repository maintenance
 
 * `pre-commit.yml` runs pre-commit checks defined by the `.pre-commit-config.yaml` file.
-  When modules reach the development stage where they should be automatically checked, they should be added to this text file.
 * `spellcheck.yml` performs spell checking of markdown and R Markdown documents.
 * `code-styling.yml` performs code styling using `styler` and `ruff`.
   * This workflow also consumes `modules_code-styling.txt` to determine which modules to style.

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,4 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - uses: pre-commit/action@v3
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,6 @@ jobs:
   pre-commit:
     if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
-    name: Run Pre-commit
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,17 @@
+name: Pre-commit check
+on:
+  pull_request:
+    branches:
+      - main
+      - feature/*
+
+jobs:
+  pre-commit:
+    if: github.repository_owner == 'AlexsLemonade'
+    runs-on: ubuntu-latest
+    name: Run Pre-commit
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: pre-commit/action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - name: General file size limit
         id: check-added-large-files
@@ -23,7 +23,7 @@ repos:
       - id: check-case-conflict
       - id: check-merge-conflict
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.4
+    rev: v8.20.1
     hooks:
       - id: gitleaks
   - repo: local


### PR DESCRIPTION
Here I am adding a minimal action to run pre-commit via github actions rather than through pre-commit.ci. 

I had this as closing #819, but it doesn't quite, as I will need to remove pre-commit.ci and update the required checks after this goes in. 