### PR TITLE
Install fetusref package and track in renv

### DIFF
--- a/analyses/cell-type-wilms-tumor-06/components/dependencies.R
+++ b/analyses/cell-type-wilms-tumor-06/components/dependencies.R
@@ -3,9 +3,8 @@ library(tidyverse)
 library(assertthat)
 
 # Single-cell packages
-library(Seurat)  # remotes::install_github("satijalab/seurat@v5.1.0")
-library(presto)  # remotes::install_github("immunogenomics/presto")
-library(Azimuth)  # remotes::install_github("satijalab/azimuth")
+library(presto) # remotes::install_github("immunogenomics/presto")
 library(SCpubr)
 library(ggplotify)
 library(edgeR)
+library(fetusref.SeuratData)

--- a/analyses/cell-type-wilms-tumor-06/renv.lock
+++ b/analyses/cell-type-wilms-tumor-06/renv.lock
@@ -3,6 +3,26 @@
     "Version": "4.4.1",
     "Repositories": [
       {
+        "Name": "BioCsoft",
+        "URL": "https://bioconductor.org/packages/3.19/bioc"
+      },
+      {
+        "Name": "BioCann",
+        "URL": "https://bioconductor.org/packages/3.19/data/annotation"
+      },
+      {
+        "Name": "BioCexp",
+        "URL": "https://bioconductor.org/packages/3.19/data/experiment"
+      },
+      {
+        "Name": "BioCworkflows",
+        "URL": "https://bioconductor.org/packages/3.19/workflows"
+      },
+      {
+        "Name": "BioCbooks",
+        "URL": "https://bioconductor.org/packages/3.19/books"
+      },
+      {
         "Name": "CRAN",
         "URL": "https://p3m.dev/cran/latest"
       }
@@ -2206,6 +2226,17 @@
         "R"
       ],
       "Hash": "8c406b7284bbaef08e01c6687367f195"
+    },
+    "fetusref.SeuratData": {
+      "Package": "fetusref.SeuratData",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "SeuratObject"
+      ],
+      "Hash": "e4067e51f621452d39ac5180af0735f7"
     },
     "fgsea": {
       "Package": "fgsea",

--- a/analyses/cell-type-wilms-tumor-06/scripts/prepare-fetal-references.R
+++ b/analyses/cell-type-wilms-tumor-06/scripts/prepare-fetal-references.R
@@ -168,9 +168,7 @@ saveRDS(stewart_ref_list, stewart_ref_file)
 
 # Prepare Cao (full fetal organ) reference ------------------------------
 
-# Install and load in the reference, keeping only the $map portion
-options(timeout = 600) # often needed for SeuratData installs
-SeuratData::InstallData("fetusref")
+# Load in the reference, keeping only the $map portion
 fetus_ref <- SeuratData::LoadData("fetusref", type = "azimuth")$map
 
 


### PR DESCRIPTION
This PR updates `cell-type-wilms-tumor-06` to track `fetusref.SeuratData` with renv instead of installing it in a script. I also removed Seurat and Azimuth from `dependencies.R` since I'm confident at least they don't need to be there. `renv` apparently decided to add more BioC remotes too, which seems fine.

Noting this should go in _after_ #827.