### PR TITLE
Add rOpenScPCA install instructions

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -1,7 +1,9 @@
 This directory contains packages written for use with [OpenScPCA analysis modules](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
 
 The recommended version for use is given in the table below.
+Please see the individual package `README` files for installation instructions.
 
 | Package      | Description                              | Version |
 | ------------ | ---------------------------------------- | ------- |
 | `rOpenScPCA` | R functions for use in OpenScPCA modules | `0.1.0` |
+

--- a/packages/rOpenScPCA/README.md
+++ b/packages/rOpenScPCA/README.md
@@ -18,6 +18,8 @@ remotes::install_github("AlexsLemonade/OpenScPCA-analysis/packages/rOpenScPCA")
 <!--
 ## Usage
 
+[FORTHCOMING]
+
 We have compiled example notebooks using this package:
 
 - The `OpenScPCA-analysis` module `hello-clusters` demonstrates how to perform and evaluate clustering with `rOpenScPCA`

--- a/packages/rOpenScPCA/README.md
+++ b/packages/rOpenScPCA/README.md
@@ -1,0 +1,24 @@
+# rOpenScPCA
+
+This package contains utility functions to support single-cell RNAseq analysis in the OpenScPCA project.
+
+## Installation
+
+`rOpenScPCA` can either be installed with `renv` or the `remotes` package:
+
+```r
+# Install the package with renv
+renv::install("AlexsLemonade/OpenScPCA-analysis:packages/rOpenScPCA")
+# You can then add to a renv.lock fole with renv::snapshot()
+
+# Install the package with remotes
+remotes::install_github("AlexsLemonade/OpenScPCA-analysis/packages/rOpenScPCA")
+```
+
+<!--
+## Usage
+
+We have compiled example notebooks using this package:
+
+- The `OpenScPCA-analysis` module `hello-clusters` demonstrates how to perform and evaluate clustering with `rOpenScPCA`
+-->

--- a/packages/rOpenScPCA/README.md
+++ b/packages/rOpenScPCA/README.md
@@ -9,7 +9,7 @@ This package contains utility functions to support single-cell RNAseq analysis i
 ```r
 # Install the package with renv
 renv::install("AlexsLemonade/OpenScPCA-analysis:packages/rOpenScPCA")
-# You can then add to a renv.lock fole with renv::snapshot()
+# You can then add to a renv.lock file with renv::snapshot()
 
 # Install the package with remotes
 remotes::install_github("AlexsLemonade/OpenScPCA-analysis/packages/rOpenScPCA")


### PR DESCRIPTION
Closes #821 

This PR adds some more docs for how to install rOpenScPCA. I also added a `Usage` section into the README, commented out for now until we get some actual notebooks into `hello-clusters`.