### PR TITLE
Add docker image for cell-type-wilms-tumor-14

### DIFF
--- a/.github/workflows/docker_cell-type-wilms-tumor-14.yml
+++ b/.github/workflows/docker_cell-type-wilms-tumor-14.yml
@@ -13,22 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  # pull_request:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - "analyses/cell-type-wilms-tumor-14/Dockerfile"
-  #     - "analyses/cell-type-wilms-tumor-14/.dockerignore"
-  #     - "analyses/cell-type-wilms-tumor-14/renv.lock"
-  #     - "analyses/cell-type-wilms-tumor-14/conda-lock.yml"
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - "analyses/cell-type-wilms-tumor-14/Dockerfile"
-  #     - "analyses/cell-type-wilms-tumor-14/.dockerignore"
-  #     - "analyses/cell-type-wilms-tumor-14/renv.lock"
-  #     - "analyses/cell-type-wilms-tumor-14/conda-lock.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "analyses/cell-type-wilms-tumor-14/Dockerfile"
+      - "analyses/cell-type-wilms-tumor-14/.dockerignore"
+      - "analyses/cell-type-wilms-tumor-14/renv.lock"
+      - "analyses/cell-type-wilms-tumor-14/conda-lock.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "analyses/cell-type-wilms-tumor-14/Dockerfile"
+      - "analyses/cell-type-wilms-tumor-14/.dockerignore"
+      - "analyses/cell-type-wilms-tumor-14/renv.lock"
+      - "analyses/cell-type-wilms-tumor-14/conda-lock.yml"
   workflow_dispatch:
     inputs:
       push-ecr:

--- a/analyses/cell-type-wilms-tumor-14/Dockerfile
+++ b/analyses/cell-type-wilms-tumor-14/Dockerfile
@@ -1,10 +1,35 @@
-# A template docker file for creating a new analysis
-FROM ubuntu:22.04
+
+FROM bioconductor/r-ver:3.19
 
 # Labels following the Open Containers Initiative (OCI) recommendations
 # For more information, see https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1
+LABEL org.opencontainers.image.title="openscpca/cell-type-wilms-tumor-14"
+LABEL org.opencontainers.image.description="Docker image for the OpenScPCA analysis module 'cell-type-wilms-tumor-14'"
 LABEL org.opencontainers.image.authors="OpenScPCA scpca@ccdatalab.org"
-LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/templates/analysis-module"
+LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-wilms-tumor-14"
 
 # Set an environment variable to allow checking if we are in an OpenScPCA container
 ENV OPENSCPCA_DOCKER=TRUE
+
+# Install renv
+RUN Rscript -e "install.packages('renv')"
+
+# Disable the renv cache to install packages directly into the R library
+ENV RENV_CONFIG_CACHE_ENABLED=FALSE
+
+# Copy the renv.lock file from the host environment to the image
+COPY renv.lock renv.lock
+
+# Temporarily install Rhtslib separately
+RUN Rscript -e 'BiocManager::install("Rhtslib")'
+
+# restore from renv.lock file and clean up to reduce image size
+RUN Rscript -e 'renv::restore()' \
+  && rm -rf ~/.cache/R/renv \
+  && rm -rf /tmp/downloaded_packages \
+  && rm -rf /tmp/Rtmp*
+
+# Complete installation of zellkonverter conda env
+ENV BASILISK_EXTERNAL_DIR=/usr/local/renv/basilisk
+RUN Rscript -e "proc <- basilisk::basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = 'anndata'); \
+  basilisk::basiliskStop(proc)"

--- a/analyses/cell-type-wilms-tumor-14/renv.lock
+++ b/analyses/cell-type-wilms-tumor-14/renv.lock
@@ -159,6 +159,22 @@
       ],
       "Hash": "395472c65cd9d606a1a345687102f299"
     },
+    "DelayedMatrixStats": {
+      "Package": "DelayedMatrixStats",
+      "Version": "1.26.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "DelayedArray",
+        "IRanges",
+        "Matrix",
+        "MatrixGenerics",
+        "S4Vectors",
+        "methods",
+        "sparseMatrixStats"
+      ],
+      "Hash": "5d9536664ccddb0eaa68a90afe4ee76e"
+    },
     "Deriv": {
       "Package": "Deriv",
       "Version": "4.1.6",
@@ -247,6 +263,29 @@
         "utils"
       ],
       "Hash": "a3c822ef3c124828e25e7a9611beeb50"
+    },
+    "HDF5Array": {
+      "Package": "HDF5Array",
+      "Version": "1.32.1",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "BiocGenerics",
+        "DelayedArray",
+        "IRanges",
+        "Matrix",
+        "R",
+        "Rhdf5lib",
+        "S4Arrays",
+        "S4Vectors",
+        "methods",
+        "rhdf5",
+        "rhdf5filters",
+        "stats",
+        "tools",
+        "utils"
+      ],
+      "Hash": "420012f82591a2a20156ef65d4aa210a"
     },
     "HiddenMarkov": {
       "Package": "HiddenMarkov",
@@ -530,6 +569,16 @@
         "Rcpp"
       ],
       "Hash": "c232938949fcd8126034419cc529333a"
+    },
+    "Rhdf5lib": {
+      "Package": "Rhdf5lib",
+      "Version": "1.26.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "c92ba8b9a2c5c9ff600a1062a3b7b727"
     },
     "RhpcBLASctl": {
       "Package": "RhpcBLASctl",
@@ -943,6 +992,21 @@
         "utils"
       ],
       "Hash": "39d6ecdea862d961c3dfe4d4d7c57920"
+    },
+    "beachmat": {
+      "Package": "beachmat",
+      "Version": "2.20.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "BiocGenerics",
+        "DelayedArray",
+        "Matrix",
+        "Rcpp",
+        "SparseArray",
+        "methods"
+      ],
+      "Hash": "10e94b1bce9070632a40c6b873f8b2d4"
     },
     "bit": {
       "Package": "bit",
@@ -1752,6 +1816,32 @@
         "ggplot2"
       ],
       "Hash": "a57f0f5dbcfd0d77ad4ff33032f5dc79"
+    },
+    "glmGamPoi": {
+      "Package": "glmGamPoi",
+      "Version": "1.16.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "BiocGenerics",
+        "DelayedArray",
+        "DelayedMatrixStats",
+        "HDF5Array",
+        "MatrixGenerics",
+        "Rcpp",
+        "RcppArmadillo",
+        "SingleCellExperiment",
+        "SummarizedExperiment",
+        "beachmat",
+        "matrixStats",
+        "methods",
+        "rlang",
+        "splines",
+        "stats",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "21e305cf5faebb13bee698a5a1c4bced"
     },
     "globals": {
       "Package": "globals",
@@ -2910,6 +3000,29 @@
       ],
       "Hash": "e1a5d04397edc1580c5e0ed1dbdccf76"
     },
+    "rhdf5": {
+      "Package": "rhdf5",
+      "Version": "2.48.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "R",
+        "Rhdf5lib",
+        "methods",
+        "rhdf5filters"
+      ],
+      "Hash": "74d8c5aeb96d090ce8efc9ffd16afa2b"
+    },
+    "rhdf5filters": {
+      "Package": "rhdf5filters",
+      "Version": "1.16.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "Rhdf5lib"
+      ],
+      "Hash": "99e15369f8fb17dc188377234de13fc6"
+    },
     "rjags": {
       "Package": "rjags",
       "Version": "4-16",
@@ -3230,6 +3343,20 @@
         "methods"
       ],
       "Hash": "ffe1f9e95a4375530747b268f82b5086"
+    },
+    "sparseMatrixStats": {
+      "Package": "sparseMatrixStats",
+      "Version": "1.16.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "Matrix",
+        "MatrixGenerics",
+        "Rcpp",
+        "matrixStats",
+        "methods"
+      ],
+      "Hash": "7e500a5a527460ca0406473bdcade286"
     },
     "spatstat.data": {
       "Package": "spatstat.data",

--- a/analyses/cell-type-wilms-tumor-14/scripts/00_preprocess_reference.R
+++ b/analyses/cell-type-wilms-tumor-14/scripts/00_preprocess_reference.R
@@ -32,6 +32,7 @@ library(Seurat)
 library(ggpubr)
 library(zellkonverter)
 library(SingleCellExperiment)
+library(glmGamPoi)
 
 prepare_fetal_atlas <- function(in_fetal_atlas = in_fetal_atlas,
                                 out_fetal_atlas = out_fetal_atlas,

--- a/analyses/cell-type-wilms-tumor-14/scripts/utils/00_preprocessing_rds_functions.R
+++ b/analyses/cell-type-wilms-tumor-14/scripts/utils/00_preprocessing_rds_functions.R
@@ -1,6 +1,8 @@
 library(dplyr)
 library(Seurat)
 library(ggpubr)
+library(glmGamPoi)
+
 pre_seuratobj <- function(obj, nfeatures = 500, run_harmony = TRUE, reduction = "harmony", ndims = 50,
                           skip_logNorm = TRUE){
   ######## Normalize, scale, feature selection


### PR DESCRIPTION
This updates and activates a dockerfile for the `cell-type-wilms-tumor-14` module, with a couple small changes cherry picked from https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/836 top make sure that the `renv` is ready for use in that branch or soon after.

I did not include conda setup in this docker image, as that  seems to be unused at this point, despite the presence of an `environment.yml` file.