### PR TITLE
Update hello-python docker image

### DIFF
--- a/analyses/hello-python/Dockerfile
+++ b/analyses/hello-python/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the hello-python analysis
-FROM condaforge/miniforge3:24.3.0-0
+FROM condaforge/miniforge3:24.9.0-0
 
 # Labels following the Open Containers Initiative (OCI) recommendations
 # For more information, see https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1


### PR DESCRIPTION
Closes #849

It seems that there was some kind of conflict with older python versions and some versions of conda that created a bit of conflict when running conda-lock. Updating the base docker image should fix it, while preserving the conda environment.

I could also update the conda environment to include more recent packages, but that did not seem to be necessary for this particular issue, so I left it as is. Let me know if you think I should update the environment as well!