### PR TITLE
Update creating-vcs.md to no longer reference selecting an Availability Zone

### DIFF
--- a/docs/aws/lsfr/creating-vcs.md
+++ b/docs/aws/lsfr/creating-vcs.md
@@ -66,7 +66,6 @@ Creating an instance via LSfR is _not supported_.
         - If you are planning to develop in R, we recommend choosing `Rstudio`, which includes RStudio.
         - If you are planning to develop in Python, we recommend choosing `VSCodium`, which includes VSCodium, a distribution of Microsoft's editor VS Code.
         - For information on all application options, see [the LSfR documentation on Applications](https://docs.aws.amazon.com/lightsail-for-research/latest/ug/blueprints-plans.html).
-    - Choose the `us-east-2a` availability zone.
     - Name your instance.
     It might be helpful to use the same name as the provisioned product.
     - Pick the size for your instance.


### PR DESCRIPTION
Related to: https://github.com/AlexsLemonade/OpenScPCA-infra/pull/53

Once that's deployed, you will no longer need to select an Availability Zone when creating a Lightsail for Research instance via Service Catalog.

It probably also means ~~some of the screenshots are outdated~~ one screenshot is outdated, but I think it would need to make a material difference to re-do ~~them~~ it, and I'm not sure it meets that threshold.