### PR TITLE
Add first set of manual cell ontology assignments

### DIFF
--- a/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
+++ b/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
@@ -100,7 +100,7 @@ CL:0002664	cardioblast	Cardiac stem and precursor cells
 CL:0000746	cardiac muscle cell	Cardiomyocytes
 CL:0000706	choroid plexus epithelial cell	Choroid plexus cells
 CL:0000158	club cell	Clara cells
-CL:0009043	intestinal crypt stem cell of colon	Crypt cells
+CL:0002250	intestinal crypt stem cell	Crypt cells
 CL:0000173	pancreatic D cell	Delta cells
 CL:0002305	epithelial cell of distal tubule	Distal tubule cells
 CL:0002079	pancreatic ductal cell	Ductal cells

--- a/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
+++ b/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
@@ -85,27 +85,27 @@ CL:0000893	thymocyte	Thymocytes
 CL:4023169	trigeminal neuron	Trigeminal neurons
 CL:0000351	trophoblast cell	Trophoblast cells
 CL:0000731	urothelial cell	Urothelial cells
-NA	NA	Adipocyte progenitor cells
-NA	NA	Airway epithelial cells
-NA	NA	Airway goblet cells
-NA	NA	Airway smooth muscle cells
-NA	NA	Alpha cells
-NA	NA	Anterior pituitary gland cells
-NA	NA	B cells memory
-NA	NA	B cells naive
-NA	NA	Bergmann glia
-NA	NA	Beta cells
-NA	NA	Cajal-Retzius cells
-NA	NA	Cardiac stem and precursor cells
-NA	NA	Cardiomyocytes
-NA	NA	Choroid plexus cells
-NA	NA	Clara cells
-NA	NA	Crypt cells
-NA	NA	Delta cells
-NA	NA	Distal tubule cells
-NA	NA	Ductal cells
-NA	NA	Endothelial cells (aorta)
-NA	NA	Endothelial cells (blood brain barrier)
+CL:0002334	preadipocyte	Adipocyte progenitor cells
+CL:0002368	respiratory epithelial cell	Airway epithelial cells
+CL:0002370	respiratory goblet cell	Airway goblet cells
+CL:0019019	tracheobronchial smooth muscle cell	Airway smooth muscle cells
+CL:0000171	pancreatic A cell	Alpha cells
+CL:0000637	chromophil cell of anterior pituitary gland	Anterior pituitary gland cells
+CL:0000787	memory B cell	B cells memory
+CL:0000788	naive B cell	B cells naive
+CL:0000644	Bergmann glial cell	Bergmann glia
+CL:0000169	type B pancreatic cell	Beta cells
+CL:0000695	Cajal-Retzius cell	Cajal-Retzius cells
+CL:0002664	cardioblast	Cardiac stem and precursor cells
+CL:0000746	cardiac muscle cell	Cardiomyocytes
+CL:0000706	choroid plexus epithelial cell	Choroid plexus cells
+CL:0000158	club cell	Clara cells
+CL:0009043	intestinal crypt stem cell of colon	Crypt cells
+CL:0000173	pancreatic D cell	Delta cells
+CL:0002305	epithelial cell of distal tubule	Distal tubule cells
+CL:0002079	pancreatic ductal cell	Ductal cells
+CL:0002544	aortic endothelial cell	Endothelial cells (aorta)
+CL:2000044	brain microvascular endothelial cell	Endothelial cells (blood brain barrier)
 NA	NA	Enteric glia cells
 NA	NA	Enterochromaffin cells
 NA	NA	Epsilon cells


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Related to #887

#### What is the goal of this pull request?

Here I am adding the first group of manually assigned cell ontology id terms (~ 20 terms). 

#### Briefly describe the general approach you took to achieve this goal.

I am going alphabetical starting with the first NA and filling them in from there. For a lot of terms there was an exact synonym that matched the listed cell type from the PanglaoDB file or there was a word that was interchangeable like respiratory and airway. There were some terms that I had to check more closely and make some decisions which I explain here:

- The alpha, beta, delta, and ductal cells all are from the pancreas when checking with the assigned organ in the original PanglaoDB file. This confirmed that when referring to these cells we are referring to "pancreatic X cell". 

- The `Airway smooth muscle cell` didn't have an exact match or exact synonym when searching with airway or respiratory. To label this cell type, I looked at the descendants for the term `smooth muscle cell` and identified the `tracheobronchial smooth muscle cell`. All the other ones were for organs that very clearly didn't involve the airway or respiratory system. From [this article on the airway smooth muscle](https://www.sciencedirect.com/science/article/abs/pii/B0123708796002532) I thought using tracheobronchial made sense. 

> [Airway smooth muscle](https://www.sciencedirect.com/topics/medicine-and-dentistry/airway-smooth-muscle) (ASM) is the primary [effector cell](https://www.sciencedirect.com/topics/medicine-and-dentistry/effector-cell) responsible for controlling airway caliber and thus the resistance to airflow of the entire [tracheobronchial tree](https://www.sciencedirect.com/topics/medicine-and-dentistry/tracheobronchial-tree).

- For `endothelial cell (blood brain barrier)`, I used `brain microvascular endothelial cell`. From [this paper on the BBB](https://fluidsbarrierscns.biomedcentral.com/articles/10.1186/s12987-020-00230-3): 

> The BBB is formed by microvascular endothelial cells lining the cerebral capillaries penetrating the brain and spinal cord of most mammals and other organisms with a well-developed CNS 

#### If known, do you anticipate filing additional pull requests to complete this analysis module?

Yes, I will continue to file PRs to assign the rest of the cell type ontology terms manually. 