### PR TITLE
Second group of manual cell type ontology assignments

### DIFF
--- a/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
+++ b/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
@@ -106,29 +106,29 @@ NA	NA	Distal tubule cells
 NA	NA	Ductal cells
 NA	NA	Endothelial cells (aorta)
 NA	NA	Endothelial cells (blood brain barrier)
-NA	NA	Enteric glia cells
-NA	NA	Enterochromaffin cells
-NA	NA	Epsilon cells
-NA	NA	Erythroid-like and erythroid precursor cells
-NA	NA	Follicular cells
-NA	NA	Foveolar cells
-NA	NA	GABAergic neurons
-NA	NA	Gamma (PP) cells
-NA	NA	Gamma delta T cells
-NA	NA	Gastric chief cells
-NA	NA	Glomus cells
-NA	NA	Glutaminergic neurons
-NA	NA	His bundle cells
-NA	NA	Immature neurons
-NA	NA	Intercalated cells
-NA	NA	Juxtaglomerular cells
-NA	NA	Kidney progenitor cells
-NA	NA	Kupffer cells
-NA	NA	Langerhans cells
-NA	NA	Leydig cells
-NA	NA	Loop of Henle cells
-NA	NA	Luminal epithelial cells
-NA	NA	Mammary epithelial cells
+CL:4040002	enteroglial cell	Enteric glia cells
+CL:0000504	enterochromaffin-like cell	Enterochromaffin cells
+CL:0005019	pancreatic epsilon cell	Epsilon cells
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells
+CL:0002258	thyroid follicular cell	Follicular cells
+CL:0002179	foveolar cell of stomach	Foveolar cells
+CL:0000617	GABAergic neuron	GABAergic neurons
+CL:0000696	PP cell	Gamma (PP) cells
+CL:0000798	gamma-delta T cell	Gamma delta T cells
+CL:0000155	peptic cell	Gastric chief cells
+CL:0002292	type I cell of carotid body	Glomus cells
+CL:0000679	glutamatergic neuron	Glutaminergic neurons
+CL:0010007	His-Purkinje system cell	His bundle cells
+CL:0000540	neuron	Immature neurons
+CL:0005010	renal intercalated cell	Intercalated cells
+CL:1000618	juxtaglomerular complex cell	Juxtaglomerular cells
+CL:0000383	nephrogenic mesenchyme stem cell	Kidney progenitor cells
+CL:0000091	Kupffer cell	Kupffer cells
+CL:0000453	Langerhans cell	Langerhans cells
+CL:0000178	Leydig cell	Leydig cells
+CL:1000909	kidney loop of Henle epithelial cell	Loop of Henle cells
+CL:0002326	luminal epithelial cell of mammary gland	Luminal epithelial cells
+CL:0002327	mammary gland epithelial cell	Mammary epithelial cells
 NA	NA	Meningeal cells
 NA	NA	Merkel cells
 NA	NA	Microfold cells

--- a/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
+++ b/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
@@ -119,7 +119,7 @@ CL:0000155	peptic cell	Gastric chief cells
 CL:0002292	type I cell of carotid body	Glomus cells
 CL:0000679	glutamatergic neuron	Glutaminergic neurons
 CL:0010007	His-Purkinje system cell	His bundle cells
-CL:0000540	neuron	Immature neurons
+CL:4042021	neuronal-restricted precursor	Immature neurons
 CL:0005010	renal intercalated cell	Intercalated cells
 CL:1000618	juxtaglomerular complex cell	Juxtaglomerular cells
 CL:0000383	nephrogenic mesenchyme stem cell	Kidney progenitor cells

--- a/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
+++ b/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
@@ -122,7 +122,7 @@ CL:0010007	His-Purkinje system cell	His bundle cells
 CL:4042021	neuronal-restricted precursor	Immature neurons
 CL:0005010	renal intercalated cell	Intercalated cells
 CL:1000618	juxtaglomerular complex cell	Juxtaglomerular cells
-CL:0000383	nephrogenic mesenchyme stem cell	Kidney progenitor cells
+CL:0000324	metanephric mesenchyme stem cell	Kidney progenitor cells
 CL:0000091	Kupffer cell	Kupffer cells
 CL:0000453	Langerhans cell	Langerhans cells
 CL:0000178	Leydig cell	Leydig cells


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Related to #887 

#### What is the goal of this pull request?

Here I'm adding cell type ontology terms for the next set of cell type terms in the PanglaoDB file. 


#### Briefly describe the general approach you took to achieve this goal.

Most of these were straightforward and had an exact synonym match with a few exceptions to note: 

- The follicular cell type listed here refers to those in the thyroid. This is based on the organ listed in the PanglaoDB file. 
- The `gamma (PP) cells` are just `PP cell` and the description notes that they were formally Gamma cells. 
- I wasn't entirely sure what to do for `Immature neuron` since I couldn't find anything that indicated a neuron that was immature in the description. I looked up synonyms for this cell type and progenitor neuron was suggested so then I found the `neuronal-restricted precursor` which I think is probably the best fit. The other option I had was to just use `neuron`, but that would refer to a mature neuron and my understanding is that an immature neuron is a neuron that is not yet developed, so not quite a neuron. 
- For `Kidney progenitor cells`, I couldn't find any stem or progenitor cells that were just "kidney", but I did find a term, `metanephric mesenchyme stem cell`, which refers to the stem cells that make up the nephron. That may not quite capture everything that is meant by "kidney progenitor cells" since it appears that the kidney is derived from both the metanephric mesenchyme and ureteric bud. But there is not a term that covers both of those so I think using the metanephric mesenchyme cell is okay? 
See [Stem cells in the kidney abstract](https://www.kidney-international.org/article/S0085-2538(15)48226-2/fulltext#:~:text=A%20single%20metanephric%20mesenchymal%20cell,other%20organs%20makes%20this%20likely.)


#### If known, do you anticipate filing additional pull requests to complete this analysis module?

Yes, ~ 3 more groups to go!
