### PR TITLE
Make sure cluster assignments are factors 

### DIFF
--- a/analyses/cell-type-ewings/template_notebooks/clustering-workflow/01-clustering-metrics.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/clustering-workflow/01-clustering-metrics.Rmd
@@ -63,7 +63,8 @@ source(clustering_functions)
 sce <- readr::read_rds(params$sce_file)
 
 # read in results file 
-cluster_results_df <- readr::read_tsv(params$cluster_results_file)
+cluster_results_df <- readr::read_tsv(params$cluster_results_file) |> 
+  dplyr::mutate(cluster = as.factor(cluster))
 ```
 
 ## Clustering summary 


### PR DESCRIPTION
I was running the clustering workflow on the Ewing samples and noticed that the plot colors were on a continuous scale so the clusters were hard to distinguish on the UMAP. This is because we are now reading in a data frame with cluster assignments and R thinks it should be a double. This just converts them into factors after reading in the clustering results. 