### PR TITLE
Specify number of threads used when calculating cluster stability 

### DIFF
--- a/analyses/cell-type-ewings/evaluate-clusters.sh
+++ b/analyses/cell-type-ewings/evaluate-clusters.sh
@@ -73,7 +73,8 @@ for sample_id in $sample_ids; do
           output_file = '${library_id}_cluster-summary-report.html', \
           params = list(library_id = '$library_id', \
                         sce_file = '$sce_file', \
-                        cluster_results_file = '$cluster_results'), \
+                        cluster_results_file = '$cluster_results',
+                        threads = $threads), \
           envir = new.env()) \
         "
     done

--- a/analyses/cell-type-ewings/scripts/utils/clustering-functions.R
+++ b/analyses/cell-type-ewings/scripts/utils/clustering-functions.R
@@ -65,7 +65,7 @@ get_cluster_stats <- function(sce,
 # must have `cluster_params` column
 get_cluster_stability <- function(sce,
                                   all_cluster_results,
-                                  threads) {
+                                  threads = 1) {
   pcs <- reducedDim(sce, "PCA")
   
   # split clustering results by param used

--- a/analyses/cell-type-ewings/scripts/utils/clustering-functions.R
+++ b/analyses/cell-type-ewings/scripts/utils/clustering-functions.R
@@ -64,7 +64,8 @@ get_cluster_stats <- function(sce,
 # get cluster stability for each unique combination of params used for clustering
 # must have `cluster_params` column
 get_cluster_stability <- function(sce,
-                                  all_cluster_results) {
+                                  all_cluster_results,
+                                  threads) {
   pcs <- reducedDim(sce, "PCA")
   
   # split clustering results by param used
@@ -87,7 +88,8 @@ get_cluster_stability <- function(sce,
                                       algorithm = unique(df$algorithm),
                                       nn = unique(df$nn),
                                       resolution = unique(df$resolution),
-                                      objective_function = objective_function)
+                                      objective_function = objective_function,
+                                      threads = threads)
       
     }) |>
     dplyr::bind_rows(.id = "cluster_params")

--- a/analyses/cell-type-ewings/template_notebooks/clustering-workflow/01-clustering-metrics.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/clustering-workflow/01-clustering-metrics.Rmd
@@ -11,6 +11,7 @@ params:
   library_id: "SCPCL000822"
   sce_file: "../../../../data/current/SCPCP000015/SCPCS000490/SCPCL000822_processed.rds"
   cluster_results_file: "../../results/clustering/SCPCS000490/SCPCL000822_cluster-results.tsv"
+  threads: 1
 ---
 
 This notebook summarizes clustering metrics for `r params$library_id`.
@@ -169,7 +170,7 @@ all_stats |>
 ```{r, warning=FALSE, message=FALSE}
 # calculate cluster stability
 stability_stats <- split_umap_df |> 
-  purrr::map(\(df){ get_cluster_stability(sce, df)})
+  purrr::map(\(df){ get_cluster_stability(sce, df, params$threads)})
 ```
 
 


### PR DESCRIPTION
This is just a small fix to specify the number of threads to use when getting cluster stability in the clustering workflow for Ewing samples. It was taking a really long time to run this, so this should hopefully help with that. 
