### PR TITLE
Third group of cell ontology assignments

### DIFF
--- a/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
+++ b/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
@@ -143,7 +143,7 @@ CL:0000338	neuroblast (sensu Nematoda and Protostomia)	Neuroblasts
 CL:0000623	natural killer cell	NK cells
 CL:0001069	group 2 innate lymphoid cell	Nuocytes
 CL:0002453	oligodendrocyte precursor cell	Oligodendrocyte progenitor cells
-CL:0000778	mononuclear osteoclast	Osteoclast precursor cells
+CL:0000576	monocyte	Osteoclast precursor cells
 CL:0002199	oxyphil cell of parathyroid gland	Oxyphil cells
 CL:0002351	progenitor cell of endocrine pancreas	Pancreatic progenitor cells
 CL:0000446	chief cell of parathyroid gland	Parathyroid chief cells

--- a/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
+++ b/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
@@ -129,30 +129,30 @@ CL:0000178	Leydig cell	Leydig cells
 CL:1000909	kidney loop of Henle epithelial cell	Loop of Henle cells
 CL:0002326	luminal epithelial cell of mammary gland	Luminal epithelial cells
 CL:0002327	mammary gland epithelial cell	Mammary epithelial cells
-NA	NA	Meningeal cells
-NA	NA	Merkel cells
-NA	NA	Microfold cells
-NA	NA	Microglia
-NA	NA	Müller cells
-NA	NA	Myeloid-derived suppressor cells
-NA	NA	Myocytes
-NA	NA	Myofibroblasts
-NA	NA	Natural killer T cells
-NA	NA	Neural stem/precursor cells
-NA	NA	Neuroblasts
-NA	NA	NK cells
-NA	NA	Nuocytes
-NA	NA	Oligodendrocyte progenitor cells
-NA	NA	Osteoclast precursor cells
-NA	NA	Oxyphil cells
-NA	NA	Pancreatic progenitor cells
-NA	NA	Parathyroid chief cells
-NA	NA	Peri-islet Schwann cells
-NA	NA	Principal cells
-NA	NA	Proximal tubule cells
-NA	NA	Pulmonary alveolar type I cells
-NA	NA	Pulmonary alveolar type II cells
-NA	NA	Pulmonary vascular smooth muscle cells
+CL:0000708	leptomeningeal cell	Meningeal cells
+CL:0000242	Merkel cell	Merkel cells
+CL:0000682	M cell of gut	Microfold cells
+CL:0000129	microglial cell	Microglia
+CL:0000636	Mueller cell	Müller cells
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells
+CL:0000746	cardiac muscle cell	Myocytes
+CL:0000186	myofibroblast cell	Myofibroblasts
+CL:0000814	NK lymphocyte	Natural killer T cells
+CL:0000047	neural stem cell	Neural stem/precursor cells
+CL:0000338	neuroblast (sensu Nematoda and Protostomia)	Neuroblasts
+CL:0000623	natural killer cell	NK cells
+CL:0001069	group 2 innate lymphoid cell	Nuocytes
+CL:0002453	oligodendrocyte precursor cell	Oligodendrocyte progenitor cells
+CL:0000778	mononuclear osteoclast	Osteoclast precursor cells
+CL:0002199	oxyphil cell of parathyroid gland	Oxyphil cells
+CL:0002351	progenitor cell of endocrine pancreas	Pancreatic progenitor cells
+CL:0000446	chief cell of parathyroid gland	Parathyroid chief cells
+CL:0002573	Schwann cell	Peri-islet Schwann cells
+CL:0005009	renal principal cell	Principal cells
+CL:0002306	epithelial cell of proximal tubule	Proximal tubule cells
+CL:0002062	pulmonary alveolar type 1 cell	Pulmonary alveolar type I cells
+CL:0002063	pulmonary alveolar type 1 cell	Pulmonary alveolar type II cells
+CL:0000359	vascular associated smooth muscle cell	Pulmonary vascular smooth muscle cells
 NA	NA	Purkinje fiber cells
 NA	NA	Purkinje neurons
 NA	NA	Pyramidal cells

--- a/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
+++ b/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
@@ -151,7 +151,7 @@ CL:0002573	Schwann cell	Peri-islet Schwann cells
 CL:0005009	renal principal cell	Principal cells
 CL:0002306	epithelial cell of proximal tubule	Proximal tubule cells
 CL:0002062	pulmonary alveolar type 1 cell	Pulmonary alveolar type I cells
-CL:0002063	pulmonary alveolar type 1 cell	Pulmonary alveolar type II cells
+CL:0002063	pulmonary alveolar type 2 cell	Pulmonary alveolar type II cells
 CL:0000359	vascular associated smooth muscle cell	Pulmonary vascular smooth muscle cells
 NA	NA	Purkinje fiber cells
 NA	NA	Purkinje neurons


### PR DESCRIPTION
### Purpose/implementation Section
#### Please link to the GitHub issue that this pull request addresses.

#887 

#### What is the goal of this pull request?

Here I am adding in the third group of ontology labels for cell types. 
As a heads up, this is the second to last PR with these label additions. The next one will be the last one since there are only ~25 labels left. 


#### Briefly describe the general approach you took to achieve this goal.

- I could not find a term for `meningeal cells` other than [`meningeal macrophage`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0000879), which seemed too specific since there are multiple cell types in the meninges. The closest term for general cell types that are part of the meninges, was [`leptomeningeal cell`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0000708). It looks like the leptomeninges is just part of the meninges but the only other option I could find was [`neural cell`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0002319) which seemed too broad. 
- There was no general term for myocytes, just sub classes of myocytes so I used the parent term for the subclasses, which was `cardiac muscle cell`. 
- I couldn't find a term for osteoclast precursor cells and from looking at some papers, it looks like there is not a ton known about exactly what characterizes an osteoclast precursor cell. One option would be to use a [mononuclear osteoclast](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0000778), which is a precursor to a fully activated osteoclast. Another option would be to use [monocyte](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0000576), since they differentiate into osteoclasts. I ended up using this term. 
- The oxyphil cells are specific to the parathyroid gland in the Panglao reference, so I used `oxyphil cell of parathyroid gland` as the term. 
- For `pancreatic progenitor cells` I used [`progenitor cell of endocrine pancreas`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0002351), but this doesn't cover the exocrine pancreas. I couldn't find a term that encompasses both and the next best term was `progenitor cell` which seemed too broad. 
- `principal cells` are from the Kidney in the Panglao reference, so I used `renal principal cell`. 
- For `pulmonary vascular smooth muscle cells` I found [`smooth muscle cell of the pulmonary artery`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0002591?lang=en), but that is specific to the pulmonary artery and not other vasculature that is part of the pulmonary system. Additionally, these cells have `smooth muscle` listed as the organ in the panglao reference, so I ended up going with [`vascular associated smooth muscle cell`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0000359?lang=en). 

#### If known, do you anticipate filing additional pull requests to complete this analysis module?
Yes, one more PR for ontology terms. 


