### PR TITLE
Add last group of cell type ontology IDs

### DIFF
--- a/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
+++ b/analyses/cell-type-consensus/references/panglao-cell-type-ontologies.tsv
@@ -153,27 +153,27 @@ NA	NA	Proximal tubule cells
 NA	NA	Pulmonary alveolar type I cells
 NA	NA	Pulmonary alveolar type II cells
 NA	NA	Pulmonary vascular smooth muscle cells
-NA	NA	Purkinje fiber cells
-NA	NA	Purkinje neurons
-NA	NA	Pyramidal cells
-NA	NA	Radial glia cells
-NA	NA	Red pulp macrophages
-NA	NA	Salivary mucous cells
-NA	NA	Satellite cells
-NA	NA	Satellite glial cells
-NA	NA	Schwann cells
-NA	NA	Sebocytes
-NA	NA	Sertoli cells
-NA	NA	Spermatozoa
-NA	NA	T cells naive
-NA	NA	T cytotoxic cells
-NA	NA	T helper cells
-NA	NA	T memory cells
-NA	NA	T regulatory cells
+CL:0002068	Purkinje myocyte	Purkinje fiber cells
+CL:0000121	Purkinje cell	Purkinje neurons
+CL:0000598	pyramidal neuron	Pyramidal cells
+CL:0000681	radial glial cell	Radial glia cells
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages
+CL:1001596	salivary gland glandular cell	Salivary mucous cells
+CL:0000594	skeletal muscle satellite cell	Satellite cells
+CL:0000516	perineural satellite cell	Satellite glial cells
+CL:0002573	Schwann cell	Schwann cells
+CL:0002140	acinar cell of sebaceous gland	Sebocytes
+CL:0000216	Sertoli cell	Sertoli cells
+CL:0000019	sperm	Spermatozoa
+CL:0000898	naive T cell	T cells naive
+CL:0000910	cytotoxic T cell	T cytotoxic cells
+CL:0000912	helper T cell	T helper cells
+CL:0000813	memory T cell	T memory cells
+CL:0000815	regulatory T cell	T regulatory cells
 NA	NA	Transient cells
-NA	NA	Trichocytes
-NA	NA	Trophoblast progenitor cells
-NA	NA	Trophoblast stem cells
-NA	NA	Tuft cells
+CL:0002562	hair germinal matrix cell	Trichocytes
+CL:0000351	trophoblast cell	Trophoblast progenitor cells
+CL:0000351	trophoblast cell	Trophoblast stem cells
+CL:0002204	brush cell	Tuft cells
 NA	NA	Undefined placental cells
-NA	NA	Vascular smooth muscle cells
+CL:0000359	vascular associated smooth muscle cell	Vascular smooth muscle cells


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Closes #887 

#### What is the goal of this pull request?

This is the last group of cell type ontology IDs that needs to be assigned. 

#### Briefly describe the general approach you took to achieve this goal.

- For `salivary mucous cells` I used [`salivary gland glandular cell`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_1001596) since that includes mucous cells in the definition. 
- For the `satellite cells`, I used `skeletal muscle satellite cell` since the organ listed is `skeletal muscle` in the Panglao reference. 
- For `satellite glial cells`, I used [`perineural satellite cell`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0000516). [This paper](https://www.nature.com/articles/s41583-020-0333-z) defines satellite glial cells as: 
> Satellite glial cells (SGCs) closely envelop cell bodies of neurons in sensory, sympathetic and parasympathetic ganglia

This matches the definition on OLS for perineural satellite cells. 
- For the `Transient cells` I couldn't really find any match... I was getting [`transit amplifying cells`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0009010) on OLS but when I google transient cells it instead mentions white blood cells (but this is only in the AI summary and I couldn't find any actual information stating this). I also noticed that the organ for these cells is the kidney and when I searched for transient cells kidney I saw things about transitional cells instead. I felt like I didn't have enough information to assign an ID here so I thought we should use `NA` in this scenario. I think it's okay to have cell types with an unassigned ID if we don't feel we can confidently match it to an ID. 
- Related to the above point, there was a term `Undefined placental cells` that I also couldn't find. I think given these are "undefined" and not a specific placental cell then we should use NA here too. Searching for "placental cell" on OLS only shows "placental epithelial cell, placental pericyte, etc" and no general placental cell term. 
- For the trophoblast stem and precursor cells I was able to find a general term for [`trophoblast cell`](https://www.ebi.ac.uk/ols4/ontologies/cl/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FCL_0000351) and then types of trophoblast cells but not stem or precursor cells. For both of these I ended up just using the `trophoblast cell` term. 


#### If known, do you anticipate filing additional pull requests to complete this analysis module?

Yes, but no more ontology assignments! Next PR will be an exploratory notebook. 