### PR TITLE
Update monthly GHA timing

### DIFF
--- a/.github/workflows/file_periodic_release_issue.yml
+++ b/.github/workflows/file_periodic_release_issue.yml
@@ -1,4 +1,4 @@
-# This files an issue for creating a release every month on the 6th
+# This files an issue for creating a release every month on the 5th
 name: File create a release issue
 on:
   schedule: # run monthly on the 5th (intended to run after all modules are run)

--- a/.github/workflows/file_periodic_release_issue.yml
+++ b/.github/workflows/file_periodic_release_issue.yml
@@ -1,8 +1,8 @@
-# This files an issue for creating a release every month on the 1st
+# This files an issue for creating a release every month on the 6th
 name: File create a release issue
 on:
-  schedule: # run monthly on the 1st
-    - cron: 0 0 1 * *
+  schedule: # run monthly on the 6th (intended to run after all modules are run)
+    - cron: 0 0 6 * *
 
 jobs:
   post_issue:

--- a/.github/workflows/file_periodic_release_issue.yml
+++ b/.github/workflows/file_periodic_release_issue.yml
@@ -1,8 +1,8 @@
 # This files an issue for creating a release every month on the 6th
 name: File create a release issue
 on:
-  schedule: # run monthly on the 6th (intended to run after all modules are run)
-    - cron: 0 0 6 * *
+  schedule: # run monthly on the 5th (intended to run after all modules are run)
+    - cron: 0 0 5 * *
 
 jobs:
   post_issue:

--- a/.github/workflows/run_all-modules.yml
+++ b/.github/workflows/run_all-modules.yml
@@ -6,8 +6,8 @@
 
 name: Run all analysis workflows
 on:
-  schedule: # run monthly on the 4th (intended to run after docker images are built)
-    - cron: "0 0 4 * *"
+  schedule: # run monthly on the 3rd (intended to run after docker images are built)
+    - cron: "0 0 3 * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I realized that we are got slightly out of order here for monthly releases. Currently, we:

- Build all Docker images on the 1st https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/b7b4473c129db9a6af83361a44e0a0e37b1d952e/.github/workflows/docker_all-modules.yml#L15-L16
- Run all modules on the 4th https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/b7b4473c129db9a6af83361a44e0a0e37b1d952e/.github/workflows/run_all-modules.yml#L9-L10
- Post issue about release on the 1st https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/b7b4473c129db9a6af83361a44e0a0e37b1d952e/.github/workflows/file_periodic_release_issue.yml#L4-L5

Ideally this issue would be posted after running all modules. So, I've changed up the timing a bit so we:

- Build all Docker images on the 1st
- Run all modules on the 3rd
- Post issue about release on the 5th

Let me know if this seems reasonable! It could be 1st, 2nd, 3rd, but I thought a bit of buffer would be good in case there are problems to catch, though of course weekends exist so it may not matter much. 