### PR TITLE
Compare clusters to cell types and marker gene set expression

### DIFF
--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -49,4 +49,4 @@ jobs:
           cd $MODULE_PATH
           bash cnv-annotation.sh
           bash aucell-singler-annotation.sh
-          run_metrics=1 bash evaluate-clusters.sh
+          bash evaluate-clusters.sh

--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -49,4 +49,4 @@ jobs:
           cd $MODULE_PATH
           bash cnv-annotation.sh
           bash aucell-singler-annotation.sh
-          bash evaluate-clusters.sh
+          run_metrics=1 bash evaluate-clusters.sh

--- a/analyses/cell-type-ewings/README.md
+++ b/analyses/cell-type-ewings/README.md
@@ -150,7 +150,7 @@ The workflow can be run using the following command:
 ./evaluate-clusters.sh
 ```
 
-Calculating the clusters and the metrics can be time consuming and takes ~ 24 hours for all samples in the project. 
+Calculating the clusters and the metrics can be time consuming and takes ~ 24 hours on a laptop for all samples in the project. 
 To skip this step and only render the second report to look at cell types and marker gene expression, use the `skip_metrics=1` option: 
 
 ```sh

--- a/analyses/cell-type-ewings/README.md
+++ b/analyses/cell-type-ewings/README.md
@@ -5,20 +5,23 @@ This module will include code to annotate cell types in the Ewing sarcoma sample
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-**Table of Contents**
-
-- [`AUCell` and `SingleR` annotation workflow](#aucell-annotation-workflow)
+- [`AUCell` and `SingleR` annotation workflow](#aucell-and-singler-annotation-workflow)
   - [Usage](#usage)
   - [Input files](#input-files)
   - [Output files](#output-files)
   - [Computational resources](#computational-resources)
-- [CNV annotation workflow](#cnv-annotation-workflow)
+- [Clustering workflow](#clustering-workflow)
   - [Usage](#usage-1)
-  - [Sample metadata](#sample-metadata)
   - [Input files](#input-files-1)
   - [Output files](#output-files-1)
-  - [Annotation files](#annotation-files)
   - [Computational resources](#computational-resources-1)
+- [CNV annotation workflow](#cnv-annotation-workflow)
+  - [Usage](#usage-2)
+  - [Sample metadata](#sample-metadata)
+  - [Input files](#input-files-2)
+  - [Output files](#output-files-2)
+  - [Annotation files](#annotation-files)
+  - [Computational resources](#computational-resources-2)
 - [Exploratory analyses](#exploratory-analyses)
 - [Software requirements](#software-requirements)
 
@@ -128,8 +131,15 @@ For all processed `SingleCellExperiment` objects that are part of `SCPCP000015`,
 - Resolution (Louvain and Leiden with modularity): 0.5, 1, 1.5 
 - Resolution (Leiden with CPM): 0.001, 0.005, 0.01
 
-After clusters are calculated, a report summarizing clustering metrics is generated for each object. 
-The report includes summary plots showing silhouette width, cluster purity, and cluster stability for each set of parameters used to calculate clusters. 
+After clusters are calculated, a report with summary plots showing silhouette width, cluster purity, and cluster stability for each set of parameters used to calculate clusters is created. 
+
+Clusters identified using the Leiden algorithm with the modularity objective function are then explored in a secondary report. 
+A report is generated for resolution 0.5 and resolution 1.
+This report includes: 
+
+- A comparison of cluster assignments to cell type assignments (output from the `aucell-singler-annotation.sh` workflow) for all values of nearest neighbors used. 
+- Marker gene set expression in each cluster for all marker gene sets in `references/visser-all-marker-genes.tsv`
+
 
 ### Usage
 
@@ -138,6 +148,13 @@ The workflow can be run using the following command:
 
 ```sh
 ./evaluate-clusters.sh
+```
+
+Calculating the clusters and the metrics can be time consuming and takes ~ 24 hours for all samples in the project. 
+To skip this step and only render the second report to look at cell types and marker gene expression, use the `skip_metrics=1` option: 
+
+```sh
+skip_metrics=1 ./evaluate-clusters.sh
 ```
 
 ### Input files 

--- a/analyses/cell-type-ewings/evaluate-clusters.sh
+++ b/analyses/cell-type-ewings/evaluate-clusters.sh
@@ -32,7 +32,7 @@ module_dir=$(pwd)
 threads=${threads:-4}
 seed=${seed:-2024}
 
-# parameter to repeat clustering metrics 
+# parameter to skip clustering metrics 
 skip_metrics=${skip_metrics:-0}
 
 # set up input and output file paths

--- a/analyses/cell-type-ewings/evaluate-clusters.sh
+++ b/analyses/cell-type-ewings/evaluate-clusters.sh
@@ -19,9 +19,8 @@
 
 # Usage: ./evaluate-clusters.sh
 
-# to run clustering and calculate metrics again: 
-# this is how the workflow is run in CI, but otherwise this section will be skipped 
-# run_metrics=1 ./evaluate-clusters.sh
+# to skip clustering and calculating metrics again: 
+# skip_metrics=1 ./evaluate-clusters.sh
 
 set -euo pipefail
 
@@ -34,7 +33,7 @@ threads=${threads:-4}
 seed=${seed:-2024}
 
 # parameter to repeat clustering metrics 
-run_metrics=${run_metrics:-0}
+skip_metrics=${skip_metrics:-0}
 
 # set up input and output file paths
 # make sure full paths are provided for notebook rendering
@@ -71,7 +70,7 @@ for sample_id in $sample_ids; do
         sample_aucell_results="${aucell_results_dir}/${sample_id}/${library_id}_singler-classifications.tsv"
 
         # only perform clustering and metrics if specified 
-        if [[ $run_metrics -eq 1 ]]; then
+        if [[ $skip_metrics -ne 1 ]]; then
 
             # generate clusters 
             # use all three clustering methods

--- a/analyses/cell-type-ewings/evaluate-clusters.sh
+++ b/analyses/cell-type-ewings/evaluate-clusters.sh
@@ -19,6 +19,10 @@
 
 # Usage: ./evaluate-clusters.sh
 
+# to run clustering and calculate metrics again: 
+# this is how the workflow is run in CI, but otherwise this section will be skipped 
+# run_metrics=1 ./evaluate-clusters.sh
+
 set -euo pipefail
 
 # navigate to where script lives
@@ -26,8 +30,11 @@ cd $(dirname "$0")
 module_dir=$(pwd)
 
 # use 4 CPUs and define seed
-threads=4
-seed=2024
+threads=${threads:-4}
+seed=${seed:-2024}
+
+# parameter to repeat clustering metrics 
+run_metrics=${run_metrics:-0}
 
 # set up input and output file paths
 # make sure full paths are provided for notebook rendering
@@ -36,8 +43,12 @@ results_dir="${module_dir}/results/clustering"
 mkdir -p ${results_dir}
 
 # define scripts and notebook directories
-scripts_dir="scripts/clustering-workflow"
-notebook_dir="template_notebooks/clustering-workflow"
+scripts_dir="${module_dir}/scripts/clustering-workflow"
+notebook_dir="${module_dir}/template_notebooks/clustering-workflow"
+
+# define other files 
+marker_genes_file="${module_dir}/references/visser-all-marker-genes.tsv"
+aucell_results_dir="${module_dir}/results/aucell_singler_annotation"
 
 # define all sample IDs 
 sample_ids=$(basename -a ${data_dir}/SCPCS*)
@@ -56,26 +67,53 @@ for sample_id in $sample_ids; do
         # define output files
         cluster_results="${sample_results_dir}/${library_id}_cluster-results.tsv"
 
-        # generate clusters 
-        # use all three clustering methods
-        echo "Generating clusters for sample: $sample_id and library: $library_id"
-        Rscript $scripts_dir/01-clustering.R \
-            --sce_file $sce_file \
-            --output_file $cluster_results \
-            --louvain --leiden_mod --leiden_cpm \
-            --threads $threads \
-            --seed $seed
+        # define singler results file 
+        sample_aucell_results="${aucell_results_dir}/${sample_id}/${library_id}_singler-classifications.tsv"
 
-        # render notebook
-        Rscript -e "rmarkdown::render('$notebook_dir/01-clustering-metrics.Rmd', \
-          clean = TRUE, \
-          output_dir = '$sample_results_dir', \
-          output_file = '${library_id}_cluster-summary-report.html', \
-          params = list(library_id = '$library_id', \
-                        sce_file = '$sce_file', \
-                        cluster_results_file = '$cluster_results',
-                        threads = $threads), \
-          envir = new.env()) \
-        "
+        # only perform clustering and metrics if specified 
+        if [[ $run_metrics -eq 1 ]]; then
+
+            # generate clusters 
+            # use all three clustering methods
+            echo "Generating clusters for sample: $sample_id and library: $library_id"
+            Rscript $scripts_dir/01-clustering.R \
+                --sce_file $sce_file \
+                --output_file $cluster_results \
+                --louvain --leiden_mod --leiden_cpm \
+                --threads $threads \
+                --seed $seed
+
+            # render clustering metrics notebook
+            Rscript -e "rmarkdown::render('$notebook_dir/01-clustering-metrics.Rmd', \
+              clean = TRUE, \
+              output_dir = '$sample_results_dir', \
+              output_file = '${library_id}_cluster-summary-report.html', \
+              params = list(library_id = '$library_id', \
+                            sce_file = '$sce_file', \
+                            cluster_results_file = '$cluster_results',
+                            threads = $threads), \
+              envir = new.env()) \
+            "
+        
+        fi 
+
+        # render cell type and gene set notebook 
+        # use default leiden, modularity clustering 
+        # one notebook for each resolutions .5 and 1
+        resolution_array=(0.5 1)
+        for resolution in ${resolution_array[@]}; do 
+            Rscript -e "rmarkdown::render('$notebook_dir/02-clustering-celltypes.Rmd', \
+                clean = TRUE, \
+                output_dir = '$sample_results_dir', \
+                output_file = '${library_id}_${resolution}_cluster-celltype-report.html', \
+                params = list(library_id = '$library_id', \
+                              sce_file = '$sce_file', \
+                              cluster_results_file = '$cluster_results', \
+                              singler_results_file = '$sample_aucell_results', \
+                              marker_genes_file = '$marker_genes_file', \
+                              resolution = $resolution)
+            )"
+
+        done 
     done
 done

--- a/analyses/cell-type-ewings/scripts/utils/clustering-functions.R
+++ b/analyses/cell-type-ewings/scripts/utils/clustering-functions.R
@@ -176,7 +176,7 @@ cluster_celltype_heatmap <- function(cluster_classification_df) {
     })
   
   # turn into heatmap list
-  make_heatmap_list(jaccard_df_list, column_title = "clusters", legend_match = "nn-5", cluster_rows = TRUE)
+  make_heatmap_list(jaccard_df_list, column_title = "clusters", legend_match = "nn-5", cluster_rows = FALSE)
 }
 
 

--- a/analyses/cell-type-ewings/scripts/utils/clustering-functions.R
+++ b/analyses/cell-type-ewings/scripts/utils/clustering-functions.R
@@ -162,19 +162,21 @@ plot_cluster_stability <- function(stat_df,
 
 # heatmap comparing cluster assignments to SingleR labels
 cluster_celltype_heatmap <- function(cluster_classification_df) {
+  
   # get a jaccard mtx for each cluster param
   jaccard_df_list <- cluster_classification_df |>
-    split(cluster_classification_df$nn_param) |>
+    split(cluster_classification_df$nn_char) |>
     purrr::map(\(df) {
       make_jaccard_matrix(
         df,
         "cluster",
         "singler_lumped"
-      )
+      ) |>
+        t() # not every value of k has the same number of clusters and we need columns to match
     })
-
+  
   # turn into heatmap list
-  make_heatmap_list(jaccard_df_list, column_title = "clusters", legend_match = "k_5", cluster_rows = FALSE)
+  make_heatmap_list(jaccard_df_list, column_title = "clusters", legend_match = "nn-5", cluster_rows = TRUE)
 }
 
 
@@ -185,7 +187,7 @@ plot_marker_genes <- function(cluster_exp_df,
                               k_value) {
   # pick clustering to use and select those columns
   final_clusters_df <- cluster_exp_df |>
-    dplyr::filter(nn_param == k_value)
+    dplyr::filter(nn == k_value)
 
   # grab columns that contain marker gene sums
   marker_gene_columns <- colnames(final_clusters_df)[which(endsWith(colnames(final_clusters_df), "_sum"))]
@@ -200,5 +202,5 @@ plot_marker_genes <- function(cluster_exp_df,
       ) +
         labs(y = "Cluster")
     }) |>
-    patchwork::wrap_plots(ncol = 2) + patchwork::plot_annotation(glue::glue("{k_value}-clusters"))
+    patchwork::wrap_plots(ncol = 2) + patchwork::plot_annotation(glue::glue("nn-{k_value}"))
 }

--- a/analyses/cell-type-ewings/scripts/utils/tumor-validation-helpers.R
+++ b/analyses/cell-type-ewings/scripts/utils/tumor-validation-helpers.R
@@ -359,6 +359,7 @@ plot_faceted_umap <- function(classification_df,
       )
     ) +
     theme(
-      aspect.ratio = 1
+      aspect.ratio = 1,
+      panel.border = element_rect(color = "black", fill = NA)
     )
 }

--- a/analyses/cell-type-ewings/template_notebooks/clustering-workflow/02-clustering-celltypes.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/clustering-workflow/02-clustering-celltypes.Rmd
@@ -24,7 +24,7 @@ We expect that "good" clusters will be compromised of cells belonging to the sam
 Clustering was calculated using the following parameters: 
 
 - Algorithm: `r params$algorithm` 
-- Objective function: `r params$objective_function`
+- Objective function (if Leiden): `r params$objective_function`
 - Resolution: `r params$resolution`
 
 Results will be shown for all values of nearest neighbors used to perform clustering found in the cluster results file. 
@@ -92,9 +92,9 @@ clusters_df <- readr::read_tsv(params$cluster_results_file) |>
                 resolution == params$resolution) |> 
   # modify the nn column to be a character for easy plot labels
   dplyr::mutate(cluster = as.factor(cluster),
-                nn_char = glue::glue("nn-{nn}") |> 
-                  # make sure 5 comes first 
-                  forcats::fct_relevel("nn-5", after = 0)) |> 
+                # make sure 5 comes first 
+                nn_char = forcats::fct_relevel(glue::glue("nn-{nn}"), "nn-5", after = 0)
+         ) |>
   # rename barcode column for joining
   dplyr::rename(barcodes = "cell_id")
 ```

--- a/analyses/cell-type-ewings/template_notebooks/clustering-workflow/02-clustering-celltypes.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/clustering-workflow/02-clustering-celltypes.Rmd
@@ -11,14 +11,23 @@ params:
   library_id: "SCPCL000822"
   sce_file: "../../../../data/current/SCPCP000015/SCPCS000490/SCPCL000822_processed.rds"
   singler_results_file: "../../results/aucell_singler_annotation/SCPCS000490/SCPCL000822_singler-classifications.tsv"
-  cluster_results_file: "../../results/cluster_exploration/SCPCS000490/SCPCL000822_clusters.tsv"
+  cluster_results_file: "../../results/clustering/SCPCS000490/SCPCL000822_cluster-results.tsv"
   marker_genes_file: "../../references/visser-all-marker-genes.tsv"
+  algorithm: "leiden"
+  objective_function: "modularity"
+  resolution: 1
 ---
 
-TODO: Update this notebook to take as input a clustering algorithm, nn (range of nn?), resolution, and optional objective function to display in SingleR and marker gene plots
+This notebook will compare cluster assignments to cell type assignments and look at expression of tumor and normal marker genes. 
+We expect that "good" clusters will be compromised of cells belonging to the same cell type and express marker genes for a single cell type (e.g., only tumor or only immune markers). 
 
-- The clusters are then compared to the results from running `SingleR` in the `aucell-singler-annotation.sh` workflow.
-- We then look at marker gene expression across the clusters and assign each cluster to a cell type. 
+Clustering was calculated using the following parameters: 
+
+- Algorithm: `r params$algorithm` 
+- Objective function: `r params$objective_function`
+- Resolution: `r params$resolution`
+
+Results will be shown for all values of nearest neighbors used to perform clustering found in the cluster results file. 
 
 ## Setup
 
@@ -27,6 +36,7 @@ TODO: Update this notebook to take as input a clustering algorithm, nn (range of
 stopifnot(
   "sce file does not exist" = file.exists(params$sce_file),
   "SingleR results file does not exist" = file.exists(params$singler_results_file),
+  "Clustering results file does not exist" = file.exists(params$cluster_results_file),
   "Marker genes file does not exist" = file.exists(params$marker_genes_file)
 )
 ```
@@ -57,7 +67,7 @@ set.seed(2024)
 # The path to this module
 module_base <- rprojroot::find_root(rprojroot::is_renv_project)
 
-# source in helper functions: calculate_sum_markers()
+# source in helper functions: calculate_sum_markers() and plot_faceted_umap()
 validation_functions <- file.path(module_base, "scripts", "utils", "tumor-validation-helpers.R")
 source(validation_functions)
 
@@ -72,23 +82,57 @@ source(clustering_functions)
 sce <- readr::read_rds(params$sce_file)
 
 # read in singler results
-singler_classification_df <- readr::read_tsv(params$singler_results_file) |>
-  dplyr::rename("cell_id" = "barcodes")
+singler_classification_df <- readr::read_tsv(params$singler_results_file)
+
+# read in clustering results 
+clusters_df <- readr::read_tsv(params$cluster_results_file) |> 
+  # filter to specified parameters 
+  dplyr::filter(algorithm == params$algorithm,
+                objective_function == params$objective_function,
+                resolution == params$resolution) |> 
+  # modify the nn column to be a character for easy plot labels
+  dplyr::mutate(cluster = as.factor(cluster),
+                nn_char = glue::glue("nn-{nn}") |> 
+                  # make sure 5 comes first 
+                  forcats::fct_relevel("nn-5", after = 0)) |> 
+  # rename barcode column for joining
+  dplyr::rename(barcodes = "cell_id")
 ```
 
-
-## Clusters vs. `SingleR` {.tabset}
-
-Now we will compare the clustering results to the cell type assignments obtained from `SingleR` in the `aucell-singler-annotation.sh` workflow. 
-To compare results we will calculate the Jaccard similarity index between clusters and cell types. 
-We expect that good clustering will line up with the cell type assignments so that there is ~ 1 cell type per cluster. 
-
-For the plots, we will only display the top 7 cell types identified by `SingleR` and all other cells will be lumped together into `All remaining cell types`. 
+## UMAP of cluster assignments
 
 ```{r}
-cluster_classification_df <- all_cluster_results |>
+# get umap embeddings and combine into a data frame with cluster assignments
+umap_df <- sce |>
+  scuttle::makePerCellDF(use.dimred = "UMAP") |>
+  # replace UMAP.1 with UMAP1 and get rid of excess columns
+  dplyr::select(barcodes, UMAP1 = UMAP.1, UMAP2 = UMAP.2) |>
+  dplyr::left_join(clusters_df, by = "barcodes")
+```
+
+```{r fig.height=10, fig.width=10}
+ggplot(umap_df, aes(x = UMAP1, y = UMAP2, color = cluster)) +
+  geom_point(alpha = 0.5, size = 0.1) +
+  facet_wrap(vars(nn),
+             labeller = labeller(nn = ~ glue::glue("{.}-nn"))) +
+  theme(
+    aspect.ratio = 1,
+    legend.position = "none", 
+    panel.border = element_rect(color = "black", fill = NA)
+  )
+```
+
+## Clusters vs. `SingleR`
+
+Now we will compare the clustering results to the cell type assignments obtained from `SingleR` in the `aucell-singler-annotation.sh` workflow. 
+For the plots, we will only display the top 7 cell types identified by `SingleR` and all other cells will be lumped together into `All remaining cell types`. 
+
+
+```{r}
+# prep classifications and clusters for plots 
+cluster_classification_df <- umap_df |>
   # add in classifications from singler
-  dplyr::left_join(singler_classification_df, by = "cell_id") |>
+  dplyr::left_join(singler_classification_df, by = "barcodes") |>
   dplyr::mutate(
     # first grab anything that is tumor and label it tumor
     # NA should be unknown
@@ -104,20 +148,28 @@ cluster_classification_df <- all_cluster_results |>
       forcats::fct_infreq() |>
       forcats::fct_relevel("All remaining cell types", after = Inf)
   )
-
-cluster_classification_df |> 
-  split(cluster_classification_df$resolution) |> 
-  purrr::map(\(df){cluster_celltype_heatmap(df)}) 
-
 ```
 
-```{r, fig.height=10, fig.width=7}
+
+First, we just look at the cell type assignments on the UMAP. 
+
+```{r fig.height=10, fig.width=10}
+celltype_plot_df <- cluster_classification_df |> 
+  dplyr::select(barcodes, UMAP1, UMAP2, singler_lumped)
+
+plot_faceted_umap(celltype_plot_df, singler_lumped)
+```
+
+To compare results we will calculate the Jaccard similarity index between clusters and cell types. 
+We expect that good clustering will line up with the cell type assignments so that there is ~ 1 cell type per cluster. 
+
+```{r, fig.height=15, fig.width=7}
 # get heatmap for showing cluster assignments vs. singler assignments
 cluster_celltype_heatmap(cluster_classification_df)
 ```
 
 
-## Marker gene expression {.tabset} 
+## Marker gene expression
 
 Finally, we will look at the expression of marker genes across each cluster for each value of `k`. 
 In these plots, each row shows the distribution of the specified marker genes in that cluster. 
@@ -141,19 +193,20 @@ gene_exp_df <- cell_types |>
   purrr::reduce(dplyr::inner_join, by = "barcodes")
 
 # join sum expression columns with clustering results
-cluster_exp_df <- all_cluster_results |>
+cluster_exp_df <- clusters_df |>
   dplyr::left_join(gene_exp_df, by = "barcodes")
 ```
 
 ```{r, fig.height=7, fig.width=7}
 # plot to look at marker gene expression for all cell types across all clusters and all params
-k_params <- unique(cluster_exp_df$nn_param) |>
-  as.character()
+k_params <- unique(cluster_exp_df$nn_char)
 
 k_params |>
   purrr::map(\(k) {
+    k_num <- stringr::str_remove(k, "nn-")
+    
     plot_marker_genes(cluster_exp_df,
-      k_value = k
+      k_value = k_num
     )
   })
 ```

--- a/analyses/cell-type-ewings/template_notebooks/clustering-workflow/02-clustering-celltypes.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/clustering-workflow/02-clustering-celltypes.Rmd
@@ -171,7 +171,7 @@ cluster_celltype_heatmap(cluster_classification_df)
 
 ## Marker gene expression
 
-Finally, we will look at the expression of marker genes across each cluster for each value of `k`. 
+Finally, we will look at the expression of marker genes across each cluster for each value of `nn`. 
 In these plots, each row shows the distribution of the specified marker genes in that cluster. 
 Each panel is labeled with the marker gene expression being plotted. 
 

--- a/analyses/cell-type-ewings/template_notebooks/clustering-workflow/02-clustering-celltypes.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/clustering-workflow/02-clustering-celltypes.Rmd
@@ -99,6 +99,18 @@ clusters_df <- readr::read_tsv(params$cluster_results_file) |>
   dplyr::rename(barcodes = "cell_id")
 ```
 
+## Number of clusters
+
+Below is a table showing the number of clusters found for each value of `nn`.
+
+```{r}
+clusters_df |> 
+  dplyr::select(nn, cluster) |> 
+  dplyr::group_by(nn) |> 
+  dplyr::summarise(num_of_clusters = length(unique(cluster)))
+``` 
+
+
 ## UMAP of cluster assignments
 
 ```{r}


### PR DESCRIPTION
### Purpose/implementation Section
#### Please link to the GitHub issue that this pull request addresses.

Closes #896 

#### What is the goal of this pull request?

Here I am updating the second report for the clustering workflow. Originally this was all part of one report, but I pulled out the plots in this report as part of #895. The purpose of this report is to be able to help pick the best clustering parameters by looking at cell types found in each cluster and expression of cell type specific marker genes in each cluster. 

After looking at the metric reports, I saw that Leiden-modularity and Louvain were pretty similar. Leiden-CPM for the most part was pretty bad. Because of this, I'm choosing to only generate these reports using Lieden-modularity. 

#### Briefly describe the general approach you took to achieve this goal.

- The report now has been updated to take in a single clustering algorithm, objective function and resolution. Then I have the same plots that look at cell type assignments vs. cluster assignments for all values of nn and marker gene set expression for each cluster across all values of nn. To me, the differences between nn values were very subtle when looking at metrics, so this report should help us narrow in on a value of nn to use for that sample. 
- I also added some UMAPs to the report showing the cluster assignments and the cell type assignments. I think its helpful to have the UMAP shown again here for easy reference. 
- I updated the `evaluate-clusters.sh` workflow to render this report. In doing that I also added an argument that allows you to skip running the clustering and metrics. That part is really time consuming (took me ~24 hours to run all the samples locally), so I wanted to be sure we could skip it if we ever change rendering the report which is downstream. 
 - When looking at the resolution, there were clear differences between .5, 1, and 1.5, with .5 generally having the fewest clusters and 1.5 having the most. Using 1.5 showed clusters that had lower purity and stability across the board, so I don't think we want to use that resolution. Depending on the sample .5 and 1 were the "best". However, looking at two resolutions and all nn made the report really busy, so I updated the workflow to generate a single report for .5 and another report for 1.


#### If known, do you anticipate filing additional pull requests to complete this analysis module?

Yes, but probably not before the end of 2024. 

### Results

#### What is the name of your results bucket on S3?

`s3://researcher-211125375652-us-east-2/cell-type-ewings/results/clustering`

#### What types of results does your code produce (e.g., table, figure)?

New reports have been added looking at cell type vs. clusters and marker gene expression across clusters for each sample. 

#### What is your summary of the results?

Generally these samples are pretty uniform and most are tumor cells. Using a resolution of both 1 or .5 with either k=20 or k=25 gives clusters that have clear separation of marker gene expression (e.g., clusters with tumor cells express tumor cell markers and do not express immune cell markers). I think we could realistically use any of those parameter options for all samples. 

However, part of the reason we are doing this is to define tumor cell states eventually. So we expect multiple clusters of tumor cells in anticipation that these clusters have cells from different tumor cell states. But we don't really know how heterogeneous these samples are. Using a resolution of .5 produces clusters that have higher purity and stability for the most part and a fewer number of clusters. My guess is that a lot of these samples are homogenous. I think before we dive into defining tumor cell states we may want to look at these reports in depth. Another alternative will be to subcluster only tumor cells (which for most samples is most cells). But that will all be answered at a later time and is outside of the scope of this PR. 

### Provide directions for reviewers

Attached is an example of one of the reports for easy review: 

[SCPCL000822_0.5_cluster-celltype-report.html.zip](https://github.com/user-attachments/files/18028852/SCPCL000822_0.5_cluster-celltype-report.html.zip)

#### What are the software and computational requirements needed to be able to run the code in this PR?

I ran this locally using `skip_metrics=1`



### Author checklists

_Check all those that apply._
_Note that you may find it easier to check off these items after the pull request is actually filed._


#### Analysis module and review

- [ ] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [x] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [x] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [x] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
