### PR TITLE
Add aws CLI to docker image for consensus cell typing

### DIFF
--- a/analyses/cell-type-consensus/Dockerfile
+++ b/analyses/cell-type-consensus/Dockerfile
@@ -21,6 +21,11 @@ RUN apt-get -y update &&  \
   pandoc \
   && rm -rf /var/lib/apt/lists/*
 
+# Install aws cli 
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+
 # Install renv to enable later package installation
 RUN Rscript -e "install.packages('renv')"
 


### PR DESCRIPTION
It looks like https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/runs/12381052804/job/34558746421 is failing because the AWS CLI is not in the docker image. I think I've seen this before when working on the Ewing module, but we use conda there and install it that way. Here, I just followed the [install instructions for Linux](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to install it in the image. I think this should solve the issues with downloading test data in the GHA. 