### PR TITLE
Use docker for seurat-conversion tests

### DIFF
--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -43,6 +43,7 @@ jobs:
           - cell-type-nonETP-ALL-03
           - cell-type-ETP-ALL-03
           - cell-type-consensus
+          - seurat-conversion
     uses: ./.github/workflows/build-push-docker-module.yml
     if: github.repository_owner == 'AlexsLemonade'
     with:

--- a/.github/workflows/run_all-modules.yml
+++ b/.github/workflows/run_all-modules.yml
@@ -43,6 +43,9 @@ jobs:
   cell-type-consensus:
       uses: ./.github/workflows/run_cell-type-consensus.yml
 
+  seurat-conversion:
+      uses: ./.github/workflows/run_seurat-conversion.yml
+
       ## Add additional modules above this comment, and to the needs list below
   check-jobs:
     if: ${{ always() }}
@@ -56,6 +59,7 @@ jobs:
       - cell-type-ETP-ALL-03
       - cell-type-nonETP-ALL-03
       - cell-type-consensus
+      - seurat-conversion
     runs-on: ubuntu-latest
     steps:
       - name: Checkout template file

--- a/.github/workflows/run_seurat-conversion.yml
+++ b/.github/workflows/run_seurat-conversion.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
-          sudo ./aws/install
+          ./aws/install
 
       - name: Download test data
         env:

--- a/.github/workflows/run_seurat-conversion.yml
+++ b/.github/workflows/run_seurat-conversion.yml
@@ -33,7 +33,7 @@ jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
-    container: public.ecr.aws/openscpca/cell-type-wilms-tumor-06:latest
+    container: public.ecr.aws/openscpca/seurat-conversion:latest
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/run_seurat-conversion.yml
+++ b/.github/workflows/run_seurat-conversion.yml
@@ -33,27 +33,20 @@ jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
     runs-on: ubuntu-latest
+    container: public.ecr.aws/openscpca/cell-type-wilms-tumor-06:latest
+    defaults:
+      run:
+        shell: bash -el {0}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: 4.4.0
-          use-public-rspm: true
-
-      - name: Install additional dependencies
+      - name: Install aws-cli
         run: |
-          sudo apt-get install -y \
-            libhdf5-dev \
-            libglpk40
-
-      - name: Set up renv
-        uses: r-lib/actions/setup-renv@v2
-        with:
-          working-directory: ${{ env.MODULE_PATH }}
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
 
       - name: Download test data
         env:


### PR DESCRIPTION
closes #945

This PR converts the actions for the seurat-conversion module to use the Docker image for the module. 

I also added the module to the various run-all workflows.