### PR TITLE
Only skip push step in build action

### DIFF
--- a/.github/workflows/build-push-docker-module.yml
+++ b/.github/workflows/build-push-docker-module.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build-push:
     name: Build and Push Docker Image
-    if: inputs.push-ecr && github.repository_owner == 'AlexsLemonade'
+    if: github.repository_owner == 'AlexsLemonade'
     environment: prod
     runs-on: openscpca-22.04-big-disk
 
@@ -80,7 +80,7 @@ jobs:
         env:
           DOCKER_BUILD_SUMMARY: false
         with:
-          push: true
+          push: inputs.push-ecr
           context: "{{defaultContext}}:analyses/${{ inputs.module }}"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
When performing a test run of https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/runs/12434358502, I found that all the jobs were being skipped, which kind of defeats the testing!

So here I am updating the action to only skip the `push` step of the action. 