### PR TITLE
Issue title update for Docker failures

### DIFF
--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -69,7 +69,7 @@ jobs:
         if: contains(needs.*.result, 'failure')
         uses: peter-evans/create-issue-from-file@v5
         with:
-          title: Analysis module failing in CI
+          title: Docker image failing in CI
           content-filepath: |
             .github/cron-issue-templates/all-docker-issue-template.md
           labels: |

--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -69,7 +69,7 @@ jobs:
         if: contains(needs.*.result, 'failure')
         uses: peter-evans/create-issue-from-file@v5
         with:
-          title: Docker image failing in CI
+          title: Docker image build failing in CI
           content-filepath: |
             .github/cron-issue-templates/all-docker-issue-template.md
           labels: |


### PR DESCRIPTION
Just noted that the title for docker images failing was a bit ambiguous (the same as for analysis steps failing). So a very small PR.
