### PR TITLE
Install zellkonverter env as rstudio user

### DIFF
--- a/analyses/cell-type-wilms-tumor-06/Dockerfile
+++ b/analyses/cell-type-wilms-tumor-06/Dockerfile
@@ -30,8 +30,13 @@ RUN Rscript -e 'renv::restore()' && \
   rm -rf /tmp/downloaded_packages && \
   rm -rf /tmp/Rtmp*
 
-# Complete installation of zellkonverter conda env
-ENV BASILISK_EXTERNAL_DIR /usr/local/renv/basilisk
-RUN Rscript -e "proc <- basilisk::basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = 'anndata'); \
+# Set basilisk directory and set for rstudio user
+ENV BASILISK_EXTERNAL_DIR=/usr/share/basilisk
+RUN mkdir -p ${BASILISK_EXTERNAL_DIR} && \
+  chown rstudio:rstudio ${BASILISK_EXTERNAL_DIR}
+# install zellkonverter environment as rstudio user
+RUN sudo -u rstudio \
+  Rscript -e "Sys.setenv(BASILISK_EXTERNAL_DIR = '${BASILISK_EXTERNAL_DIR}'); \
+  proc <- basilisk::basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = 'anndata'); \
   basilisk::basiliskStop(proc); \
   basilisk.utils::cleanConda()"


### PR DESCRIPTION
This PR is a partial fix to #972

I updated the Dockerfile for the `cell-type-wilms-tumor-06` module to install zellkonverter packages as the `rstudio` user. This allows both the `rstudio` user and `root` to have access to the installed files, and prevents the lockfile permissions issue that we were seeing. 

When running R from the terminal, this seems to solve the zellkonverter problem, and everything works as expected.

However, when running `zellkonverter::readH5AD()` (or a `basilisk::basiliskStart()`) in the RStudio console, I now get the following error: 

```
Error in py_module_import(module, convert = convert) : 
  ImportError: /usr/lib/x86_64-linux-gnu/libssl.so.3: version `OPENSSL_3.2.0' not found (required by /usr/share/basilisk/1.16.0/zellkonverter/1.14.1/zellkonverterAnnDataEnv-0.10.6/lib/python3.12/site-packages/h5py/../../.././libcurl.so.4) 
```

This can be avoided by running `Sys.unsetenv("BASILISK_EXTERNAL_DIR")` and reinstalling the `zellkonverter` environment, so I suspect that the RStudio startup is somehow setting something differently from R in the terminal, but I can't yet figure out what that might be. 

