### PR TITLE
Keep original name from Panglao when creating consensus reference 

### DIFF
--- a/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv
+++ b/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv
@@ -1,302 +1,311 @@
-panglao_ontology	panglao_annotation	blueprint_ontology	blueprint_annotation_main	blueprint_annotation_fine	consensus_ontology	consensus_annotation
-CL:0000583	alveolar macrophage	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000767	basophil	CL:0000775	Neutrophils	Neutrophils	CL:0000094	granulocyte
-CL:0000771	eosinophil	CL:0000775	Neutrophils	Neutrophils	CL:0000094	granulocyte
-CL:0000235	macrophage	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000097	mast cell	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000576	monocyte	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000775	neutrophil	CL:0000775	Neutrophils	Neutrophils	CL:0000775	neutrophil
-CL:0000092	osteoclast	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000091	Kupffer cell	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000453	Langerhans cell	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000129	microglial cell	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000889	myeloid suppressor cell	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000874	splenic red pulp macrophage	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
-CL:0000767	basophil	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
-CL:0000451	dendritic cell	CL:0000576	Monocytes	Monocytes	CL:0000113	mononuclear phagocyte
-CL:0000771	eosinophil	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
-CL:0000097	mast cell	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
-CL:0000576	monocyte	CL:0000576	Monocytes	Monocytes	CL:0000576	monocyte
-CL:0000775	neutrophil	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
-CL:0000784	plasmacytoid dendritic cell	CL:0000576	Monocytes	Monocytes	CL:0000113	mononuclear phagocyte
-CL:0000889	myeloid suppressor cell	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
-CL:0000037	hematopoietic stem cell	CL:0000050	HSC	MEP	CL:0008001	hematopoietic precursor cell
-CL:0000038	erythroid progenitor cell	CL:0000050	HSC	MEP	CL:0008001	hematopoietic precursor cell
-CL:0000084	T cell	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000084	T cell
-CL:0002038	T follicular helper cell	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000624	CD4-positive, alpha-beta T cell
-CL:0000893	thymocyte	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000084	T cell
-CL:0000798	gamma-delta T cell	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000084	T cell
-CL:0000814	mature NK T cell	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000791	mature alpha-beta T cell
-CL:0000898	naive T cell	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
-CL:0000910	cytotoxic T cell	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
-CL:0000912	helper T cell	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
-CL:0000813	memory T cell	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
-CL:0000815	regulatory T cell	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
-CL:0000084	T cell	CL:0000815	CD4+ T-cells	Tregs	CL:0000084	T cell
-CL:0002038	T follicular helper cell	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
-CL:0000893	thymocyte	CL:0000815	CD4+ T-cells	Tregs	CL:0000084	T cell
-CL:0000798	gamma-delta T cell	CL:0000815	CD4+ T-cells	Tregs	CL:0000084	T cell
-CL:0000814	mature NK T cell	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
-CL:0000898	naive T cell	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
-CL:0000910	cytotoxic T cell	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
-CL:0000912	helper T cell	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
-CL:0000813	memory T cell	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
-CL:0000815	regulatory T cell	CL:0000815	CD4+ T-cells	Tregs	CL:0000815	regulatory T cell
-CL:0000084	T cell	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000084	T cell
-CL:0002038	T follicular helper cell	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000624	CD4-positive, alpha-beta T cell
-CL:0000893	thymocyte	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000084	T cell
-CL:0000798	gamma-delta T cell	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000084	T cell
-CL:0000814	mature NK T cell	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000791	mature alpha-beta T cell
-CL:0000898	naive T cell	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0002419	mature T cell
-CL:0000910	cytotoxic T cell	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0002419	mature T cell
-CL:0000912	helper T cell	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0002419	mature T cell
-CL:0000813	memory T cell	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000813	memory T cell
-CL:0000815	regulatory T cell	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0002419	mature T cell
-CL:0000084	T cell	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000084	T cell
-CL:0002038	T follicular helper cell	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000624	CD4-positive, alpha-beta T cell
-CL:0000893	thymocyte	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000084	T cell
-CL:0000798	gamma-delta T cell	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000084	T cell
-CL:0000814	mature NK T cell	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000791	mature alpha-beta T cell
-CL:0000898	naive T cell	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0002419	mature T cell
-CL:0000910	cytotoxic T cell	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0002419	mature T cell
-CL:0000912	helper T cell	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0002419	mature T cell
-CL:0000813	memory T cell	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000813	memory T cell
-CL:0000815	regulatory T cell	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0002419	mature T cell
-CL:0000084	T cell	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000084	T cell
-CL:0002038	T follicular helper cell	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000791	mature alpha-beta T cell
-CL:0000893	thymocyte	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000084	T cell
-CL:0000798	gamma-delta T cell	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000084	T cell
-CL:0000814	mature NK T cell	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000791	mature alpha-beta T cell
-CL:0000898	naive T cell	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0002419	mature T cell
-CL:0000910	cytotoxic T cell	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0002419	mature T cell
-CL:0000912	helper T cell	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0002419	mature T cell
-CL:0000813	memory T cell	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000813	memory T cell
-CL:0000815	regulatory T cell	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0002419	mature T cell
-CL:0000084	T cell	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000084	T cell
-CL:0002038	T follicular helper cell	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000791	mature alpha-beta T cell
-CL:0000893	thymocyte	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000084	T cell
-CL:0000798	gamma-delta T cell	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000084	T cell
-CL:0000814	mature NK T cell	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000791	mature alpha-beta T cell
-CL:0000898	naive T cell	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0002419	mature T cell
-CL:0000910	cytotoxic T cell	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0002419	mature T cell
-CL:0000912	helper T cell	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0002419	mature T cell
-CL:0000813	memory T cell	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000813	memory T cell
-CL:0000815	regulatory T cell	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0002419	mature T cell
-CL:0000623	natural killer cell	CL:0000623	NK cells	NK cells	CL:0000623	natural killer cell
-CL:0001069	group 2 innate lymphoid cell	CL:0000623	NK cells	NK cells	CL:0001065	innate lymphoid cell
-CL:0000236	B cell	CL:0000788	B-cells	naive B-cells	CL:0000236	B cell
-CL:0000786	plasma cell	CL:0000788	B-cells	naive B-cells	CL:0000945	lymphocyte of B lineage
-CL:0000787	memory B cell	CL:0000788	B-cells	naive B-cells	CL:0000785	mature B cell
-CL:0000788	naive B cell	CL:0000788	B-cells	naive B-cells	CL:0000788	naive B cell
-CL:0000236	B cell	CL:0000787	B-cells	Memory B-cells	CL:0000236	B cell
-CL:0000786	plasma cell	CL:0000787	B-cells	Memory B-cells	CL:0000945	lymphocyte of B lineage
-CL:0000787	memory B cell	CL:0000787	B-cells	Memory B-cells	CL:0000787	memory B cell
-CL:0000788	naive B cell	CL:0000787	B-cells	Memory B-cells	CL:0000785	mature B cell
-CL:0000236	B cell	CL:0000972	B-cells	Class-switched memory B-cells	CL:0000236	B cell
-CL:0000786	plasma cell	CL:0000972	B-cells	Class-switched memory B-cells	CL:0000945	lymphocyte of B lineage
-CL:0000787	memory B cell	CL:0000972	B-cells	Class-switched memory B-cells	CL:0000787	memory B cell
-CL:0000788	naive B cell	CL:0000972	B-cells	Class-switched memory B-cells	CL:0000785	mature B cell
-CL:0000646	basal cell	CL:0000037	HSC	HSC	CL:0000723	somatic stem cell
-CL:0002322	embryonic stem cell	CL:0000037	HSC	HSC	CL:0000034	stem cell
-CL:0000352	epiblast cell	CL:0000037	HSC	HSC	CL:0000723	somatic stem cell
-CL:0000037	hematopoietic stem cell	CL:0000037	HSC	HSC	CL:0000037	hematopoietic stem cell
-CL:0005026	hepatoblast	CL:0000037	HSC	HSC	CL:0000034	stem cell
-CL:0002248	pluripotent stem cell	CL:0000037	HSC	HSC	CL:0000723	somatic stem cell
-CL:0002672	retinal progenitor cell	CL:0000037	HSC	HSC	CL:0000034	stem cell
-CL:0002664	cardioblast	CL:0000037	HSC	HSC	CL:0000034	stem cell
-CL:0002250	intestinal crypt stem cell	CL:0000037	HSC	HSC	CL:0000034	stem cell
-CL:0000038	erythroid progenitor cell	CL:0000037	HSC	HSC	CL:0008001	hematopoietic precursor cell
-CL:0000324	metanephric mesenchyme stem cell	CL:0000037	HSC	HSC	CL:0000034	stem cell
-CL:0000037	hematopoietic stem cell	CL:0000837	HSC	MPP	CL:0008001	hematopoietic precursor cell
-CL:0000038	erythroid progenitor cell	CL:0000837	HSC	MPP	CL:0008001	hematopoietic precursor cell
-CL:0000037	hematopoietic stem cell	CL:0000051	HSC	CLP	CL:0008001	hematopoietic precursor cell
-CL:0000038	erythroid progenitor cell	CL:0000051	HSC	CLP	CL:0008001	hematopoietic precursor cell
-CL:0000037	hematopoietic stem cell	CL:0000557	HSC	GMP	CL:0008001	hematopoietic precursor cell
-CL:0000038	erythroid progenitor cell	CL:0000557	HSC	GMP	CL:0008001	hematopoietic precursor cell
-CL:0000583	alveolar macrophage	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
-CL:0000767	basophil	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
-CL:0000771	eosinophil	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
-CL:0000235	macrophage	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
-CL:0000097	mast cell	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
-CL:0000775	neutrophil	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
-CL:0000091	Kupffer cell	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
-CL:0000129	microglial cell	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
-CL:0000889	myeloid suppressor cell	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
-CL:0000874	splenic red pulp macrophage	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
-CL:0000084	T cell	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000084	T cell
-CL:0002038	T follicular helper cell	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000791	mature alpha-beta T cell
-CL:0000893	thymocyte	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000084	T cell
-CL:0000798	gamma-delta T cell	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000084	T cell
-CL:0000814	mature NK T cell	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000791	mature alpha-beta T cell
-CL:0000898	naive T cell	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
-CL:0000910	cytotoxic T cell	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
-CL:0000912	helper T cell	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
-CL:0000813	memory T cell	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
-CL:0000815	regulatory T cell	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
-CL:0000765	erythroblast	CL:0000232	Erythrocytes	Erythrocytes	CL:0000764	erythroid lineage cell
-CL:0000558	reticulocyte	CL:0000232	Erythrocytes	Erythrocytes	CL:0000764	erythroid lineage cell
-CL:0000038	erythroid progenitor cell	CL:0000232	Erythrocytes	Erythrocytes	CL:0000764	erythroid lineage cell
-CL:0000556	megakaryocyte	CL:0000556	HSC	Megakaryocytes	CL:0000556	megakaryocyte
-CL:0000037	hematopoietic stem cell	CL:0000049	HSC	CMP	CL:0008001	hematopoietic precursor cell
-CL:0000038	erythroid progenitor cell	CL:0000049	HSC	CMP	CL:0008001	hematopoietic precursor cell
-CL:0000583	alveolar macrophage	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
-CL:0000767	basophil	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
-CL:0000771	eosinophil	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
-CL:0000235	macrophage	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
-CL:0000097	mast cell	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
-CL:0000775	neutrophil	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
-CL:0000091	Kupffer cell	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
-CL:0000129	microglial cell	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
-CL:0000889	myeloid suppressor cell	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
-CL:0000874	splenic red pulp macrophage	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
-CL:0000583	alveolar macrophage	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
-CL:0000767	basophil	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
-CL:0000771	eosinophil	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
-CL:0000235	macrophage	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
-CL:0000097	mast cell	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
-CL:0000775	neutrophil	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
-CL:0000091	Kupffer cell	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
-CL:0000129	microglial cell	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
-CL:0000889	myeloid suppressor cell	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
-CL:0000874	splenic red pulp macrophage	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
-CL:0000115	endothelial cell	CL:0000115	Endothelial cells	Endothelial cells	CL:0000115	endothelial cell
-CL:0002544	aortic endothelial cell	CL:0000115	Endothelial cells	Endothelial cells	CL:0000115	endothelial cell
-CL:2000044	brain microvascular endothelial cell	CL:0000115	Endothelial cells	Endothelial cells	CL:0000115	endothelial cell
-CL:0000451	dendritic cell	CL:0000451	DC	DC	CL:0000451	dendritic cell
-CL:0000576	monocyte	CL:0000451	DC	DC	CL:0000113	mononuclear phagocyte
-CL:0000784	plasmacytoid dendritic cell	CL:0000451	DC	DC	CL:0000451	dendritic cell
-CL:0000453	Langerhans cell	CL:0000451	DC	DC	CL:0000451	dendritic cell
-CL:0000583	alveolar macrophage	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000767	basophil	CL:0000771	Eosinophils	Eosinophils	CL:0000094	granulocyte
-CL:0000771	eosinophil	CL:0000771	Eosinophils	Eosinophils	CL:0000771	eosinophil
-CL:0000235	macrophage	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000097	mast cell	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000576	monocyte	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000775	neutrophil	CL:0000771	Eosinophils	Eosinophils	CL:0000094	granulocyte
-CL:0000092	osteoclast	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000091	Kupffer cell	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000453	Langerhans cell	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000129	microglial cell	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000889	myeloid suppressor cell	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000874	splenic red pulp macrophage	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
-CL:0000236	B cell	CL:0000786	B-cells	Plasma cells	CL:0000945	lymphocyte of B lineage
-CL:0000786	plasma cell	CL:0000786	B-cells	Plasma cells	CL:0000786	plasma cell
-CL:0000787	memory B cell	CL:0000786	B-cells	Plasma cells	CL:0000945	lymphocyte of B lineage
-CL:0000788	naive B cell	CL:0000786	B-cells	Plasma cells	CL:0000945	lymphocyte of B lineage
-CL:0000138	chondrocyte	CL:0000138	Chondrocytes	Chondrocytes	CL:0000138	chondrocyte
-CL:2000002	decidual cell	CL:0000138	Chondrocytes	Chondrocytes	CL:0000499	stromal cell
-CL:0000632	hepatic stellate cell	CL:0000138	Chondrocytes	Chondrocytes	CL:0000327	extracellular matrix secreting cell
-CL:0000499	stromal cell	CL:0000138	Chondrocytes	Chondrocytes	CL:0000499	stromal cell
-CL:0000708	leptomeningeal cell	CL:0000138	Chondrocytes	Chondrocytes	CL:0000327	extracellular matrix secreting cell
-CL:0000057	fibroblast	CL:0000057	Fibroblasts	Fibroblasts	CL:0000057	fibroblast
-CL:0000632	hepatic stellate cell	CL:0000057	Fibroblasts	Fibroblasts	CL:0000057	fibroblast
-CL:0002410	pancreatic stellate cell	CL:0000057	Fibroblasts	Fibroblasts	CL:0000057	fibroblast
-CL:0002334	preadipocyte	CL:0000057	Fibroblasts	Fibroblasts	CL:0000057	fibroblast
-CL:0000192	smooth muscle cell	CL:0000192	Smooth muscle	Smooth muscle	CL:0000192	smooth muscle cell
-CL:0019019	tracheobronchial smooth muscle cell	CL:0000192	Smooth muscle	Smooth muscle	CL:0000192	smooth muscle cell
-CL:0000746	cardiac muscle cell	CL:0000192	Smooth muscle	Smooth muscle	CL:0000187	muscle cell
-CL:0000359	vascular associated smooth muscle cell	CL:0000192	Smooth muscle	Smooth muscle	CL:0000192	smooth muscle cell
-CL:0002068	Purkinje myocyte	CL:0000192	Smooth muscle	Smooth muscle	CL:0000187	muscle cell
-CL:0000622	acinar cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:1000488	cholangiocyte	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000166	chromaffin cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000584	enterocyte	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000164	enteroendocrine cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000065	ependymal cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000066	epithelial cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000160	goblet cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000501	granulosa cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000182	hepatocyte	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0005006	ionocyte	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000312	keratinocyte	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000077	mesothelial cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000185	myoepithelial cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000165	neuroendocrine cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002167	olfactory epithelial cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000510	paneth cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000162	parietal cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002481	peritubular myoid cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000652	pinealocyte	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000653	podocyte	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000209	taste receptor cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000731	urothelial cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002368	respiratory epithelial cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002370	respiratory goblet cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000171	pancreatic A cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000169	type B pancreatic cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000706	choroid plexus epithelial cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000158	club cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002250	intestinal crypt stem cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000173	pancreatic D cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002305	epithelial cell of distal tubule	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002079	pancreatic ductal cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000504	enterochromaffin-like cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0005019	pancreatic epsilon cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002258	thyroid follicular cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002179	foveolar cell of stomach	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000696	PP cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000155	peptic cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002292	type I cell of carotid body	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0005010	renal intercalated cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:1000909	kidney loop of Henle epithelial cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002326	luminal epithelial cell of mammary gland	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002327	mammary gland epithelial cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000242	Merkel cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000682	M cell of gut	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002199	oxyphil cell of parathyroid gland	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000446	chief cell of parathyroid gland	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0005009	renal principal cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002306	epithelial cell of proximal tubule	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002062	pulmonary alveolar type 1 cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002063	pulmonary alveolar type 2 cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:1001596	salivary gland glandular cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002140	acinar cell of sebaceous gland	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000216	Sertoli cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002562	hair germinal matrix cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0002204	brush cell	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
-CL:0000148	melanocyte	CL:0000148	Melanocytes	Melanocytes	CL:0000148	melanocyte
-CL:0000594	skeletal muscle satellite cell	CL:0000188	Skeletal muscle	Skeletal muscle	CL:0000188	cell of skeletal muscle
-CL:0000166	chromaffin cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
-CL:0000065	ependymal cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
-CL:0000312	keratinocyte	CL:0000312	Keratinocytes	Keratinocytes	CL:0000312	keratinocyte
-CL:0000077	mesothelial cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
-CL:0000165	neuroendocrine cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
-CL:0002167	olfactory epithelial cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
-CL:0002481	peritubular myoid cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
-CL:0000652	pinealocyte	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
-CL:0000706	choroid plexus epithelial cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
-CL:0002292	type I cell of carotid body	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
-CL:0000242	Merkel cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0000312	keratinocyte
-CL:0002062	pulmonary alveolar type 1 cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
-CL:0002063	pulmonary alveolar type 2 cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
-CL:0002140	acinar cell of sebaceous gland	CL:0000312	Keratinocytes	Keratinocytes	CL:0000362	epidermal cell
-CL:0000216	Sertoli cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
-CL:0002562	hair germinal matrix cell	CL:0000312	Keratinocytes	Keratinocytes	CL:0000362	epidermal cell
-CL:0000115	endothelial cell	CL:2000008	Endothelial cells	mv Endothelial cells	CL:0000115	endothelial cell
-CL:0002544	aortic endothelial cell	CL:2000008	Endothelial cells	mv Endothelial cells	CL:0000071	blood vessel endothelial cell
-CL:2000044	brain microvascular endothelial cell	CL:2000008	Endothelial cells	mv Endothelial cells	CL:2000008	microvascular endothelial cell
-CL:0000192	smooth muscle cell	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
-CL:0019019	tracheobronchial smooth muscle cell	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
-CL:0000746	cardiac muscle cell	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
-CL:0000359	vascular associated smooth muscle cell	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
-CL:0002068	Purkinje myocyte	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
-CL:0000136	adipocyte	CL:0000136	Adipocytes	Adipocytes	CL:0000136	adipocyte
-CL:0000650	mesangial cell	CL:0000669	Pericytes	Pericytes	CL:0000669	pericyte
-CL:0000669	pericyte	CL:0000669	Pericytes	Pericytes	CL:0000669	pericyte
-CL:0000127	astrocyte	CL:0000127	Astrocytes	Astrocytes	CL:0000127	astrocyte
-CL:0000065	ependymal cell	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
-CL:0000128	oligodendrocyte	CL:0000127	Astrocytes	Astrocytes	CL:0000126	macroglial cell
-CL:0002085	tanycyte	CL:0000127	Astrocytes	Astrocytes	CL:0000127	astrocyte
-CL:0000644	Bergmann glial cell	CL:0000127	Astrocytes	Astrocytes	CL:0000127	astrocyte
-CL:0000706	choroid plexus epithelial cell	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
-CL:4040002	enteroglial cell	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
-CL:4042021	neuronal-restricted precursor	CL:0000127	Astrocytes	Astrocytes	CL:0000095	neuron associated cell
-CL:0000242	Merkel cell	CL:0000127	Astrocytes	Astrocytes	CL:0000095	neuron associated cell
-CL:0000129	microglial cell	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
-CL:0000636	Mueller cell	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
-CL:0002453	oligodendrocyte precursor cell	CL:0000127	Astrocytes	Astrocytes	CL:0000095	neuron associated cell
-CL:0002573	Schwann cell	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
-CL:0000681	radial glial cell	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
-CL:0000516	perineural satellite cell	CL:0000127	Astrocytes	Astrocytes	CL:0000095	neuron associated cell
-CL:0000650	mesangial cell	CL:0000650	Mesangial cells	Mesangial cells	CL:0000650	mesangial cell
-CL:0000669	pericyte	CL:0000650	Mesangial cells	Mesangial cells	CL:0000669	pericyte
+panglao_ontology	panglao_annotation	original_panglao_name	blueprint_ontology	blueprint_annotation_main	blueprint_annotation_fine	consensus_ontology	consensus_annotation
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000767	basophil	Basophils	CL:0000775	Neutrophils	Neutrophils	CL:0000094	granulocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000775	Neutrophils	Neutrophils	CL:0000094	granulocyte
+CL:0000235	macrophage	Macrophages	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000097	mast cell	Mast cells	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Monocytes	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Osteoclast precursor cells	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000775	Neutrophils	Neutrophils	CL:0000775	neutrophil
+CL:0000092	osteoclast	Osteoclasts	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000453	Langerhans cell	Langerhans cells	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000129	microglial cell	Microglia	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000775	Neutrophils	Neutrophils	CL:0000766	myeloid leukocyte
+CL:0000767	basophil	Basophils	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
+CL:0000451	dendritic cell	Dendritic cells	CL:0000576	Monocytes	Monocytes	CL:0000113	mononuclear phagocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
+CL:0000097	mast cell	Mast cells	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Monocytes	CL:0000576	Monocytes	Monocytes	CL:0000576	monocyte
+CL:0000576	monocyte	Osteoclast precursor cells	CL:0000576	Monocytes	Monocytes	CL:0000576	monocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
+CL:0000784	plasmacytoid dendritic cell	Plasmacytoid dendritic cells	CL:0000576	Monocytes	Monocytes	CL:0000113	mononuclear phagocyte
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000576	Monocytes	Monocytes	CL:0000766	myeloid leukocyte
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000050	HSC	MEP	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000050	HSC	MEP	CL:0008001	hematopoietic precursor cell
+CL:0000084	T cell	T cells	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000624	CD4-positive, alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000624	CD4+ T-cells	CD4+ T-cells	CL:0002419	mature T cell
+CL:0000084	T cell	T cells	CL:0000815	CD4+ T-cells	Tregs	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000815	CD4+ T-cells	Tregs	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000815	CD4+ T-cells	Tregs	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
+CL:0000898	naive T cell	T cells naive	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000815	CD4+ T-cells	Tregs	CL:0002419	mature T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000815	CD4+ T-cells	Tregs	CL:0000815	regulatory T cell
+CL:0000084	T cell	T cells	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000624	CD4-positive, alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0000813	memory T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000904	CD4+ T-cells	CD4+ Tcm	CL:0002419	mature T cell
+CL:0000084	T cell	T cells	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000624	CD4-positive, alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0000813	memory T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000905	CD4+ T-cells	CD4+ Tem	CL:0002419	mature T cell
+CL:0000084	T cell	T cells	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000791	mature alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0000813	memory T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000907	CD8+ T-cells	CD8+ Tcm	CL:0002419	mature T cell
+CL:0000084	T cell	T cells	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000791	mature alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0000813	memory T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000913	CD8+ T-cells	CD8+ Tem	CL:0002419	mature T cell
+CL:0000623	natural killer cell	NK cells	CL:0000623	NK cells	NK cells	CL:0000623	natural killer cell
+CL:0001069	group 2 innate lymphoid cell	Nuocytes	CL:0000623	NK cells	NK cells	CL:0001065	innate lymphoid cell
+CL:0000236	B cell	B cells	CL:0000788	B-cells	naive B-cells	CL:0000236	B cell
+CL:0000786	plasma cell	Plasma cells	CL:0000788	B-cells	naive B-cells	CL:0000945	lymphocyte of B lineage
+CL:0000787	memory B cell	B cells memory	CL:0000788	B-cells	naive B-cells	CL:0000785	mature B cell
+CL:0000788	naive B cell	B cells naive	CL:0000788	B-cells	naive B-cells	CL:0000788	naive B cell
+CL:0000236	B cell	B cells	CL:0000787	B-cells	Memory B-cells	CL:0000236	B cell
+CL:0000786	plasma cell	Plasma cells	CL:0000787	B-cells	Memory B-cells	CL:0000945	lymphocyte of B lineage
+CL:0000787	memory B cell	B cells memory	CL:0000787	B-cells	Memory B-cells	CL:0000787	memory B cell
+CL:0000788	naive B cell	B cells naive	CL:0000787	B-cells	Memory B-cells	CL:0000785	mature B cell
+CL:0000236	B cell	B cells	CL:0000972	B-cells	Class-switched memory B-cells	CL:0000236	B cell
+CL:0000786	plasma cell	Plasma cells	CL:0000972	B-cells	Class-switched memory B-cells	CL:0000945	lymphocyte of B lineage
+CL:0000787	memory B cell	B cells memory	CL:0000972	B-cells	Class-switched memory B-cells	CL:0000787	memory B cell
+CL:0000788	naive B cell	B cells naive	CL:0000972	B-cells	Class-switched memory B-cells	CL:0000785	mature B cell
+CL:0000646	basal cell	Basal cells	CL:0000037	HSC	HSC	CL:0000723	somatic stem cell
+CL:0002322	embryonic stem cell	Embryonic stem cells	CL:0000037	HSC	HSC	CL:0000034	stem cell
+CL:0000352	epiblast cell	Epiblast cells	CL:0000037	HSC	HSC	CL:0000723	somatic stem cell
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000037	HSC	HSC	CL:0000037	hematopoietic stem cell
+CL:0005026	hepatoblast	Hepatoblasts	CL:0000037	HSC	HSC	CL:0000034	stem cell
+CL:0002248	pluripotent stem cell	Pluripotent stem cells	CL:0000037	HSC	HSC	CL:0000723	somatic stem cell
+CL:0002672	retinal progenitor cell	Retinal progenitor cells	CL:0000037	HSC	HSC	CL:0000034	stem cell
+CL:0002664	cardioblast	Cardiac stem and precursor cells	CL:0000037	HSC	HSC	CL:0000034	stem cell
+CL:0002250	intestinal crypt stem cell	Crypt cells	CL:0000037	HSC	HSC	CL:0000034	stem cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000037	HSC	HSC	CL:0008001	hematopoietic precursor cell
+CL:0000324	metanephric mesenchyme stem cell	Kidney progenitor cells	CL:0000037	HSC	HSC	CL:0000034	stem cell
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000837	HSC	MPP	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000837	HSC	MPP	CL:0008001	hematopoietic precursor cell
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000051	HSC	CLP	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000051	HSC	CLP	CL:0008001	hematopoietic precursor cell
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000557	HSC	GMP	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000557	HSC	GMP	CL:0008001	hematopoietic precursor cell
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
+CL:0000767	basophil	Basophils	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
+CL:0000235	macrophage	Macrophages	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
+CL:0000097	mast cell	Mast cells	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
+CL:0000129	microglial cell	Microglia	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000235	Macrophages	Macrophages	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000235	Macrophages	Macrophages	CL:0000235	macrophage
+CL:0000084	T cell	T cells	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000084	T cell
+CL:0002038	T follicular helper cell	T follicular helper cells	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000791	mature alpha-beta T cell
+CL:0000893	thymocyte	Thymocytes	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	Gamma delta T cells	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000084	T cell
+CL:0000814	mature NK T cell	Natural killer T cells	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0000791	mature alpha-beta T cell
+CL:0000898	naive T cell	T cells naive	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
+CL:0000910	cytotoxic T cell	T cytotoxic cells	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
+CL:0000912	helper T cell	T helper cells	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
+CL:0000813	memory T cell	T memory cells	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
+CL:0000815	regulatory T cell	T regulatory cells	CL:0000625	CD8+ T-cells	CD8+ T-cells	CL:0002419	mature T cell
+CL:0000765	erythroblast	Erythroblasts	CL:0000232	Erythrocytes	Erythrocytes	CL:0000764	erythroid lineage cell
+CL:0000558	reticulocyte	Reticulocytes	CL:0000232	Erythrocytes	Erythrocytes	CL:0000764	erythroid lineage cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000232	Erythrocytes	Erythrocytes	CL:0000764	erythroid lineage cell
+CL:0000556	megakaryocyte	Megakaryocytes	CL:0000556	HSC	Megakaryocytes	CL:0000556	megakaryocyte
+CL:0000037	hematopoietic stem cell	Hematopoietic stem cells	CL:0000049	HSC	CMP	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	Erythroid-like and erythroid precursor cells	CL:0000049	HSC	CMP	CL:0008001	hematopoietic precursor cell
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
+CL:0000767	basophil	Basophils	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
+CL:0000235	macrophage	Macrophages	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
+CL:0000097	mast cell	Mast cells	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
+CL:0000129	microglial cell	Microglia	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000863	Macrophages	Macrophages M1	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000863	Macrophages	Macrophages M1	CL:0000235	macrophage
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
+CL:0000767	basophil	Basophils	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
+CL:0000235	macrophage	Macrophages	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
+CL:0000097	mast cell	Mast cells	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
+CL:0000129	microglial cell	Microglia	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000890	Macrophages	Macrophages M2	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000890	Macrophages	Macrophages M2	CL:0000235	macrophage
+CL:0000115	endothelial cell	Endothelial cells	CL:0000115	Endothelial cells	Endothelial cells	CL:0000115	endothelial cell
+CL:0002544	aortic endothelial cell	Endothelial cells (aorta)	CL:0000115	Endothelial cells	Endothelial cells	CL:0000115	endothelial cell
+CL:2000044	brain microvascular endothelial cell	Endothelial cells (blood brain barrier)	CL:0000115	Endothelial cells	Endothelial cells	CL:0000115	endothelial cell
+CL:0000451	dendritic cell	Dendritic cells	CL:0000451	DC	DC	CL:0000451	dendritic cell
+CL:0000576	monocyte	Monocytes	CL:0000451	DC	DC	CL:0000113	mononuclear phagocyte
+CL:0000576	monocyte	Osteoclast precursor cells	CL:0000451	DC	DC	CL:0000113	mononuclear phagocyte
+CL:0000784	plasmacytoid dendritic cell	Plasmacytoid dendritic cells	CL:0000451	DC	DC	CL:0000451	dendritic cell
+CL:0000453	Langerhans cell	Langerhans cells	CL:0000451	DC	DC	CL:0000451	dendritic cell
+CL:0000583	alveolar macrophage	Alveolar macrophages	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000767	basophil	Basophils	CL:0000771	Eosinophils	Eosinophils	CL:0000094	granulocyte
+CL:0000771	eosinophil	Eosinophils	CL:0000771	Eosinophils	Eosinophils	CL:0000771	eosinophil
+CL:0000235	macrophage	Macrophages	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000097	mast cell	Mast cells	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Monocytes	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000576	monocyte	Osteoclast precursor cells	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000775	neutrophil	Neutrophils	CL:0000771	Eosinophils	Eosinophils	CL:0000094	granulocyte
+CL:0000092	osteoclast	Osteoclasts	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000091	Kupffer cell	Kupffer cells	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000453	Langerhans cell	Langerhans cells	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000129	microglial cell	Microglia	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000889	myeloid suppressor cell	Myeloid-derived suppressor cells	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000874	splenic red pulp macrophage	Red pulp macrophages	CL:0000771	Eosinophils	Eosinophils	CL:0000766	myeloid leukocyte
+CL:0000236	B cell	B cells	CL:0000786	B-cells	Plasma cells	CL:0000945	lymphocyte of B lineage
+CL:0000786	plasma cell	Plasma cells	CL:0000786	B-cells	Plasma cells	CL:0000786	plasma cell
+CL:0000787	memory B cell	B cells memory	CL:0000786	B-cells	Plasma cells	CL:0000945	lymphocyte of B lineage
+CL:0000788	naive B cell	B cells naive	CL:0000786	B-cells	Plasma cells	CL:0000945	lymphocyte of B lineage
+CL:0000138	chondrocyte	Chondrocytes	CL:0000138	Chondrocytes	Chondrocytes	CL:0000138	chondrocyte
+CL:2000002	decidual cell	Decidual cells	CL:0000138	Chondrocytes	Chondrocytes	CL:0000499	stromal cell
+CL:0000632	hepatic stellate cell	Hepatic stellate cells	CL:0000138	Chondrocytes	Chondrocytes	CL:0000327	extracellular matrix secreting cell
+CL:0000499	stromal cell	Stromal cells	CL:0000138	Chondrocytes	Chondrocytes	CL:0000499	stromal cell
+CL:0000708	leptomeningeal cell	Meningeal cells	CL:0000138	Chondrocytes	Chondrocytes	CL:0000327	extracellular matrix secreting cell
+CL:0000057	fibroblast	Fibroblasts	CL:0000057	Fibroblasts	Fibroblasts	CL:0000057	fibroblast
+CL:0000632	hepatic stellate cell	Hepatic stellate cells	CL:0000057	Fibroblasts	Fibroblasts	CL:0000057	fibroblast
+CL:0002410	pancreatic stellate cell	Pancreatic stellate cells	CL:0000057	Fibroblasts	Fibroblasts	CL:0000057	fibroblast
+CL:0002334	preadipocyte	Adipocyte progenitor cells	CL:0000057	Fibroblasts	Fibroblasts	CL:0000057	fibroblast
+CL:0000192	smooth muscle cell	Smooth muscle cells	CL:0000192	Smooth muscle	Smooth muscle	CL:0000192	smooth muscle cell
+CL:0019019	tracheobronchial smooth muscle cell	Airway smooth muscle cells	CL:0000192	Smooth muscle	Smooth muscle	CL:0000192	smooth muscle cell
+CL:0000746	cardiac muscle cell	Cardiomyocytes	CL:0000192	Smooth muscle	Smooth muscle	CL:0000187	muscle cell
+CL:0000746	cardiac muscle cell	Myocytes	CL:0000192	Smooth muscle	Smooth muscle	CL:0000187	muscle cell
+CL:0000359	vascular associated smooth muscle cell	Pulmonary vascular smooth muscle cells	CL:0000192	Smooth muscle	Smooth muscle	CL:0000192	smooth muscle cell
+CL:0000359	vascular associated smooth muscle cell	Vascular smooth muscle cells	CL:0000192	Smooth muscle	Smooth muscle	CL:0000192	smooth muscle cell
+CL:0002068	Purkinje myocyte	Purkinje fiber cells	CL:0000192	Smooth muscle	Smooth muscle	CL:0000187	muscle cell
+CL:0000622	acinar cell	Acinar cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:1000488	cholangiocyte	Cholangiocytes	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000166	chromaffin cell	Chromaffin cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000584	enterocyte	Enterocytes	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000164	enteroendocrine cell	Enteroendocrine cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000065	ependymal cell	Ependymal cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000066	epithelial cell	Epithelial cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000160	goblet cell	Goblet cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000501	granulosa cell	Granulosa cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000182	hepatocyte	Hepatocytes	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0005006	ionocyte	Ionocytes	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000312	keratinocyte	Keratinocytes	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000077	mesothelial cell	Mesothelial cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000185	myoepithelial cell	Myoepithelial cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000165	neuroendocrine cell	Neuroendocrine cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002167	olfactory epithelial cell	Olfactory epithelial cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000510	paneth cell	Paneth cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000162	parietal cell	Parietal cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002481	peritubular myoid cell	Peritubular myoid cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000652	pinealocyte	Pinealocytes	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000653	podocyte	Podocytes	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000209	taste receptor cell	Taste receptor cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000731	urothelial cell	Urothelial cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002368	respiratory epithelial cell	Airway epithelial cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002370	respiratory goblet cell	Airway goblet cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000171	pancreatic A cell	Alpha cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000169	type B pancreatic cell	Beta cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000706	choroid plexus epithelial cell	Choroid plexus cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000158	club cell	Clara cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002250	intestinal crypt stem cell	Crypt cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000173	pancreatic D cell	Delta cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002305	epithelial cell of distal tubule	Distal tubule cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002079	pancreatic ductal cell	Ductal cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000504	enterochromaffin-like cell	Enterochromaffin cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0005019	pancreatic epsilon cell	Epsilon cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002258	thyroid follicular cell	Follicular cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002179	foveolar cell of stomach	Foveolar cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000696	PP cell	Gamma (PP) cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000155	peptic cell	Gastric chief cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002292	type I cell of carotid body	Glomus cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0005010	renal intercalated cell	Intercalated cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:1000909	kidney loop of Henle epithelial cell	Loop of Henle cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002326	luminal epithelial cell of mammary gland	Luminal epithelial cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002327	mammary gland epithelial cell	Mammary epithelial cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000242	Merkel cell	Merkel cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000682	M cell of gut	Microfold cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002199	oxyphil cell of parathyroid gland	Oxyphil cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000446	chief cell of parathyroid gland	Parathyroid chief cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0005009	renal principal cell	Principal cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002306	epithelial cell of proximal tubule	Proximal tubule cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002062	pulmonary alveolar type 1 cell	Pulmonary alveolar type I cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002063	pulmonary alveolar type 2 cell	Pulmonary alveolar type II cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:1001596	salivary gland glandular cell	Salivary mucous cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002140	acinar cell of sebaceous gland	Sebocytes	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000216	Sertoli cell	Sertoli cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002562	hair germinal matrix cell	Trichocytes	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0002204	brush cell	Tuft cells	CL:0000066	Epithelial cells	Epithelial cells	CL:0000066	epithelial cell
+CL:0000148	melanocyte	Melanocytes	CL:0000148	Melanocytes	Melanocytes	CL:0000148	melanocyte
+CL:0000594	skeletal muscle satellite cell	Satellite cells	CL:0000188	Skeletal muscle	Skeletal muscle	CL:0000188	cell of skeletal muscle
+CL:0000166	chromaffin cell	Chromaffin cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
+CL:0000065	ependymal cell	Ependymal cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
+CL:0000312	keratinocyte	Keratinocytes	CL:0000312	Keratinocytes	Keratinocytes	CL:0000312	keratinocyte
+CL:0000077	mesothelial cell	Mesothelial cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
+CL:0000165	neuroendocrine cell	Neuroendocrine cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
+CL:0002167	olfactory epithelial cell	Olfactory epithelial cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
+CL:0002481	peritubular myoid cell	Peritubular myoid cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
+CL:0000652	pinealocyte	Pinealocytes	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
+CL:0000706	choroid plexus epithelial cell	Choroid plexus cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
+CL:0002292	type I cell of carotid body	Glomus cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0002077	ecto-epithelial cell
+CL:0000242	Merkel cell	Merkel cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0000312	keratinocyte
+CL:0002062	pulmonary alveolar type 1 cell	Pulmonary alveolar type I cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
+CL:0002063	pulmonary alveolar type 2 cell	Pulmonary alveolar type II cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
+CL:0002140	acinar cell of sebaceous gland	Sebocytes	CL:0000312	Keratinocytes	Keratinocytes	CL:0000362	epidermal cell
+CL:0000216	Sertoli cell	Sertoli cells	CL:0000312	Keratinocytes	Keratinocytes	CL:0000076	squamous epithelial cell
+CL:0002562	hair germinal matrix cell	Trichocytes	CL:0000312	Keratinocytes	Keratinocytes	CL:0000362	epidermal cell
+CL:0000115	endothelial cell	Endothelial cells	CL:2000008	Endothelial cells	mv Endothelial cells	CL:0000115	endothelial cell
+CL:0002544	aortic endothelial cell	Endothelial cells (aorta)	CL:2000008	Endothelial cells	mv Endothelial cells	CL:0000071	blood vessel endothelial cell
+CL:2000044	brain microvascular endothelial cell	Endothelial cells (blood brain barrier)	CL:2000008	Endothelial cells	mv Endothelial cells	CL:2000008	microvascular endothelial cell
+CL:0000192	smooth muscle cell	Smooth muscle cells	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
+CL:0019019	tracheobronchial smooth muscle cell	Airway smooth muscle cells	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
+CL:0000746	cardiac muscle cell	Cardiomyocytes	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
+CL:0000746	cardiac muscle cell	Myocytes	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
+CL:0000359	vascular associated smooth muscle cell	Pulmonary vascular smooth muscle cells	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
+CL:0000359	vascular associated smooth muscle cell	Vascular smooth muscle cells	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
+CL:0002068	Purkinje myocyte	Purkinje fiber cells	CL:0000187	Myocytes	Myocytes	CL:0000187	muscle cell
+CL:0000136	adipocyte	Adipocytes	CL:0000136	Adipocytes	Adipocytes	CL:0000136	adipocyte
+CL:0000650	mesangial cell	Mesangial cells	CL:0000669	Pericytes	Pericytes	CL:0000669	pericyte
+CL:0000669	pericyte	Pericytes	CL:0000669	Pericytes	Pericytes	CL:0000669	pericyte
+CL:0000127	astrocyte	Astrocytes	CL:0000127	Astrocytes	Astrocytes	CL:0000127	astrocyte
+CL:0000065	ependymal cell	Ependymal cells	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
+CL:0000128	oligodendrocyte	Oligodendrocytes	CL:0000127	Astrocytes	Astrocytes	CL:0000126	macroglial cell
+CL:0002085	tanycyte	Tanycytes	CL:0000127	Astrocytes	Astrocytes	CL:0000127	astrocyte
+CL:0000644	Bergmann glial cell	Bergmann glia	CL:0000127	Astrocytes	Astrocytes	CL:0000127	astrocyte
+CL:0000706	choroid plexus epithelial cell	Choroid plexus cells	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
+CL:4040002	enteroglial cell	Enteric glia cells	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
+CL:4042021	neuronal-restricted precursor	Immature neurons	CL:0000127	Astrocytes	Astrocytes	CL:0000095	neuron associated cell
+CL:0000242	Merkel cell	Merkel cells	CL:0000127	Astrocytes	Astrocytes	CL:0000095	neuron associated cell
+CL:0000129	microglial cell	Microglia	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
+CL:0000636	Mueller cell	Müller cells	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
+CL:0002453	oligodendrocyte precursor cell	Oligodendrocyte progenitor cells	CL:0000127	Astrocytes	Astrocytes	CL:0000095	neuron associated cell
+CL:0002573	Schwann cell	Peri-islet Schwann cells	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
+CL:0002573	Schwann cell	Schwann cells	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
+CL:0000681	radial glial cell	Radial glia cells	CL:0000127	Astrocytes	Astrocytes	CL:0000125	glial cell
+CL:0000516	perineural satellite cell	Satellite glial cells	CL:0000127	Astrocytes	Astrocytes	CL:0000095	neuron associated cell
+CL:0000650	mesangial cell	Mesangial cells	CL:0000650	Mesangial cells	Mesangial cells	CL:0000650	mesangial cell
+CL:0000669	pericyte	Pericytes	CL:0000650	Mesangial cells	Mesangial cells	CL:0000669	pericyte

--- a/analyses/cell-type-consensus/scripts/02-prepare-consensus-reference.R
+++ b/analyses/cell-type-consensus/scripts/02-prepare-consensus-reference.R
@@ -27,10 +27,11 @@ panglao_df <- readr::read_tsv(panglao_ref_file) |>
   # rename columns to have panglao in them for easy joining later
   dplyr::select(
     panglao_ontology = "ontology_id",
-    panglao_annotation = "human_readable_value"
+    panglao_annotation = "human_readable_value",
+    original_panglao_name = "panglao_cell_type" # keep original name since some map to the same ontology ID
   ) |> 
   # remove any cell types that don't have ontologies 
-  tidyr::drop_na()
+  tidyr::drop_na() 
 
 # grab singler ref from celldex
 blueprint_ref <- celldex::BlueprintEncodeData()
@@ -116,6 +117,7 @@ consensus_labels_df <- lca_df |>
   dplyr::select(
     panglao_ontology, 
     panglao_annotation, 
+    original_panglao_name,
     blueprint_ontology, 
     blueprint_annotation_main, 
     blueprint_annotation_fine, 


### PR DESCRIPTION
I was working on #969 and I noticed that we don't actually keep the original name used in the cell type assignment from Panglao/CellAssign when we create the reference table for consensus labels. We were only saving the cell ontology ID and the name in the cell ontology. This means we can't actually join that table with the `colData` for ScPCA samples since there won't be a column that matches. 

At first I thought we could just use the table that we made that maps each name from Panglao to the cell ontology ID, but there are cases where we have multiple ontology IDs that map to different Panglao assignments. So here I'm adding in a column to the consensus cell types and adding a few more rows to the reference that account for cases where the same ontology ID maps to different names in Panglao. 