### PR TITLE
Add SingleCellExperiment to renv for consensus cell typing

### DIFF
--- a/analyses/cell-type-consensus/renv.lock
+++ b/analyses/cell-type-consensus/renv.lock
@@ -549,6 +549,23 @@
       ],
       "Hash": "20149fcead4dd6f9da3605f98b5220fc"
     },
+    "SingleCellExperiment": {
+      "Package": "SingleCellExperiment",
+      "Version": "1.28.1",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.20",
+      "Requirements": [
+        "BiocGenerics",
+        "DelayedArray",
+        "GenomicRanges",
+        "S4Vectors",
+        "SummarizedExperiment",
+        "methods",
+        "stats",
+        "utils"
+      ],
+      "Hash": "48880101d1aacf03683ed4cff15d1192"
+    },
     "SparseArray": {
       "Package": "SparseArray",
       "Version": "1.6.0",
@@ -1114,6 +1131,16 @@
       ],
       "Hash": "15e9634c0fcd294799e9b2e929ed1b86"
     },
+    "getopt": {
+      "Package": "getopt",
+      "Version": "1.20.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "stats"
+      ],
+      "Hash": "ed33b16c6d24f7ced1d68877ac2509ee"
+    },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.5.1",
@@ -1612,6 +1639,18 @@
         "askpass"
       ],
       "Hash": "d413e0fef796c9401a4419485f709ca1"
+    },
+    "optparse": {
+      "Package": "optparse",
+      "Version": "1.7.5",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "getopt",
+        "methods"
+      ],
+      "Hash": "ce5f8381cd2c38d1fc14c83d8b21efd0"
     },
     "paintmap": {
       "Package": "paintmap",


### PR DESCRIPTION
This PR makes the relevant `renv` updates to be able to run the scripts added in #977, specifically adding in `SingleCellExperimnt` and `optparse`. 