### PR TITLE
improve_07_annotation

### DIFF
--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -147,7 +147,7 @@ for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
     fi
 
     # Run inferCNV
-    Rscript scripts/06_infercnv.R --sample_id $sample_id --reference $reference --HMM i3 ${test_string}
+    Rscript scripts/06_infercnv.R --sample_id $sample_id --reference $reference --HMM i3 ${test_string} --score_threshold ${predicted_celltype_threshold}
 done
 
 

--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -31,7 +31,7 @@ TESTING=${TESTING:-0}
 RUN_EXPLORATORY=${RUN_EXPLORATORY:-0}
 THREADS=${THREADS:-32}
 project_id="SCPCP000006"
-
+predicted_celltype_threshold=0.85
 # Ensure script is being run from its directory
 module_dir=$(dirname "${BASH_SOURCE[0]}")
 cd ${module_dir}
@@ -150,9 +150,10 @@ for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
     Rscript scripts/06_infercnv.R --sample_id $sample_id --reference $reference --HMM i3 ${test_string}
 done
 
+
 # Render notebook to make draft annotations
 Rscript -e "rmarkdown::render('${notebook_dir}/07_combined_annotation_across_samples_exploration.Rmd',
-                        params = list(predicted.celltype.threshold = 0.85, cnv_threshold = 0, testing = ${TESTING}),
+                        params = list(predicted.celltype.threshold = ${predicted_celltype_threshold},  testing = ${TESTING}),
                         output_format = 'html_document',
                         output_file = '07_combined_annotation_across_samples_exploration.html',
                         output_dir = '${notebook_dir}')"

--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -161,7 +161,7 @@ done
 
 # Render notebook to make draft annotations
 Rscript -e "rmarkdown::render('${notebook_dir}/07_combined_annotation_across_samples_exploration.Rmd',
-                        params = list(predicted.celltype.threshold = ${predicted_celltype_threshold}, cnv_threshold_low = ${cnv_threhold_low}, cnv_threshold_high = ${cnv_threhold_high},  testing = ${TESTING}),
+                        params = list(predicted.celltype.threshold = ${predicted_celltype_threshold}, cnv_threshold_low = ${cnv_threshold_low}, cnv_threshold_high = ${cnv_threshold_high},  testing = ${TESTING}),
                         output_format = 'html_document',
                         output_file = '07_combined_annotation_across_samples_exploration.html',
                         output_dir = '${notebook_dir}')"

--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -31,7 +31,15 @@ TESTING=${TESTING:-0}
 RUN_EXPLORATORY=${RUN_EXPLORATORY:-0}
 THREADS=${THREADS:-32}
 project_id="SCPCP000006"
-predicted_celltype_threshold=0.85
+
+# Define the `predicted_celltype_threshold` which is used to identify cells with a high confident label transfer from the fetal kidney reference.
+# This score is used in the script `06_infercnv.R` and in the notebook `07_combined_annotation_across_samples.Rmd`
+predicted_celltype_threshold=0.75
+
+# Define the `cnv_threshold_low/high` which are used to identify cells with no CNV (`cnv_score` <= `cnv_threshold_low`) or with CNV (`cnv_score` > `cnv_threshold_high`)
+cnv_threshold_low=0
+cnv_threshold_high=2
+
 # Ensure script is being run from its directory
 module_dir=$(dirname "${BASH_SOURCE[0]}")
 cd ${module_dir}
@@ -153,7 +161,7 @@ done
 
 # Render notebook to make draft annotations
 Rscript -e "rmarkdown::render('${notebook_dir}/07_combined_annotation_across_samples_exploration.Rmd',
-                        params = list(predicted.celltype.threshold = ${predicted_celltype_threshold},  testing = ${TESTING}),
+                        params = list(predicted.celltype.threshold = ${predicted_celltype_threshold}, cnv_threshold_low = ${cnv_threhold_low}, cnv_threshold_high = ${cnv_threhold_high},  testing = ${TESTING}),
                         output_format = 'html_document',
                         output_file = '07_combined_annotation_across_samples_exploration.html',
                         output_dir = '${notebook_dir}')"

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -3,7 +3,7 @@ title: "Combined annotation exploration for SCPCP000006"
 author: "Maud PLASCHKA"
 date: "`r Sys.Date()`"
 params:
-  predicted.celltype.threshold: 0.85
+  predicted.celltype.threshold: 0.75
   cnv_threshold: 0
   testing: 0
 output:
@@ -47,9 +47,9 @@ _Where `cnv.thr` and `pred.thr` need to be discussed_
 
 | first level annotation | second level annotation | selection of the cells | marker genes for validation | CNV validation |
 | ---------------------- | ----------------------- | ---------------------- | --------------------------- | --------------- |
-| normal                 | endothelial             | `compartment == "endothelium" & predicted.score > pred.thr  & cnv_score < cnv.thr` | `VWF`| no CNV |
-| normal                 | immune                  | `compartment == "immune" & predicted.score > pred.thr & cnv_score < cnv.thr` | `PTPRC`, `CD163`, `CD68`| no CNV |
-| normal                 | kidney                  | `cell_type %in% c("kidney cell","kidney epithelial", "podocyte") & predicted.score > pred.thr & cnv_score < cnv.thr` | `CDH1`, `PODXL`, `LTL`| no CNV |
+| normal                 | endothelial             | `compartment == "endothelium" & predicted.score > pred.thr  | `VWF`| no CNV |
+| normal                 | immune                  | `compartment == "immune" & predicted.score > pred.thr  | `PTPRC`, `CD163`, `CD68`| no CNV |
+| normal                 | kidney                  | `compartment == "fetal_nephron" & predicted.score > pred.thr & cnv_score < cnv.thr` | `CDH1`, `PODXL`, `LTL`| no CNV |
 | normal                 | stroma                  | `compartment == "stroma" & predicted.score > pred.thr & cnv_score < cnv.thr`| `VIM`| no CNV |
 | cancer                 | stroma                  | `compartment == "stroma" & cnv_score > cnv.thr` | `VIM`| `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
 | cancer                 | blastema                | `compartment == "fetal_nephron" & cell_type == "mesenchymal cell" & cnv_score > cnv.thr`  | `CITED1`| `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
@@ -84,6 +84,9 @@ result_dir <- file.path(module_base, "results")
 ```
 
 ### Output files
+
+The report will be saved in the `notebook` directory.
+The final annotation file `SCPCP000006-annotations.tsv` will be saved in the `results` directory.
 
 ```{r}
 # cell type annotation table
@@ -245,9 +248,7 @@ cell_type_df <- sample_ids |>
   dplyr::bind_rows()
 ```
 
-### Output file
 
-The report will be saved in the `notebook` directory.
 
 
 ## Functions
@@ -287,8 +288,17 @@ do_Feature_mean <- function(df, group.by, feature) {
 As done in `06_cnv_infercnv_exploration.Rmd`, we calculate  single CNV score and assess its potential in identifying cells with CNV versus normal cells without CNV.
 
 We simply checked for each chromosome if the cell `has_cnv_chr`.
-Would the cell have more than `cnv_threshold` chromosome with CNV, the global `has_cnv_score` will be TRUE.
-Else, the cell will have a `has_cnv_score` set to FALSE.
+Would the cell have less than `cnv_threshold` chromosome with CNV, the global `has_cnv_score` will be FALSE.
+Would the cell have more than `cnv_threshold` +2 chromosome with CNV, the global `has_cnv_score` will be TRUE.
+The default is set to `unknown`.
+
+The `infercnv` method can lead to false positive CNV.
+We introduced a flexibility of `+2` over the `cnv_threshold` to reduce the risk of misclassification of normal cells as cancer cells.
+
+Please note that some cancer cell might not have any CNV. 
+There is thus a risk of misclassifying cancer cells as normal cells. 
+However, we cannot avoid this risk with the data and tools currently available.
+This is a limitation of our annotations. 
 
 
 
@@ -297,12 +307,12 @@ Else, the cell will have a `has_cnv_score` set to FALSE.
 cell_type_df <- cell_type_df |>
   mutate(has_cnv_score = rowSums(cell_type_df[, grepl("has_cnv_chr", colnames(cell_type_df))])) |>
   mutate(has_cnv_score = case_when(
-    has_cnv_score > params$cnv_threshold ~ "CNV",
-    has_cnv_score <= params$cnv_threshold ~ "no CNV"
+    has_cnv_score > params$cnv_threshold +2 ~ "CNV",
+    has_cnv_score <= params$cnv_threshold ~ "no CNV",
+    .default = "unknown"
   ))
 
 
-table(cell_type_df$has_cnv_score)
 ```
 
 ### First level annotation
@@ -326,11 +336,20 @@ The threshold used for the identification of CNV is also defined as the notebook
 cell_type_df <- cell_type_df |>
   mutate(first.level_annotation = case_when(
     # assign normal/cancer based on condition
-    compartment %in% c("fetal_nephron", "stroma") & has_cnv_score == "no CNV" ~ "normal",
-    compartment %in% c("endothelium", "immune") & cell_type.score > params$predicted.celltype.threshold ~ "normal",
-    compartment %in% c("fetal_nephron", "stroma") & has_cnv_score == "CNV" ~ "cancer",
+    compartment %in% c("fetal_nephron", "stroma") & 
+      compartment.score > params$predicted.celltype.threshold & 
+      has_cnv_score == "no CNV" ~ "normal",
+    
+    compartment %in% c("endothelium", "immune") &
+      cell_type.score > params$predicted.celltype.threshold ~ "normal",
+    
+    compartment %in% c("fetal_nephron", "stroma") & 
+      has_cnv_score == "CNV" ~ "cancer",
+    
     .default = "unknown"
   ))
+
+
 ```
 
 Using this basic strategy, we identified `r table(cell_type_df$first.level_annotation)["cancer"]` _cancer_ cells, `r table(cell_type_df$first.level_annotation)["normal"]` _normal_ cells.
@@ -344,6 +363,31 @@ ggplot(cell_type_df, aes(x = umap.umap_1, y = umap.umap_2, color = first.level_a
   facet_wrap(facets = ~sample_id, ncol = 5) +
   theme_bw() +
   theme(text = element_text(size = 22))
+
+DT::datatable(table(cell_type_df$first.level_annotation, cell_type_df$sample_id))
+
+```
+
+Strikingly, 5 samples show more normal cells than cancer cells:
+
+- `SCPCS000177`
+- `SCPCS000180`
+- `SCPCS000181`
+- `SCPCS000190`
+- `SCPCS000197`
+
+These five samples do not have enough immune and endothelium cell to be used as a normal reference in `scripts/06_infercnv.R` and we previously decided to run `scripts/06_infercnv.R` without any reference for these samples.
+In that case, the mean expression profile over the sample is taken as the normal reference, biaising the inference of CNV. 
+
+For those samples, the annotations based on `infercnv` cannot be trust.
+To avoid any confusion in the following steps of the analysis, we decided to force the annotation of the entire samples to `unknown`.
+
+```{r fig.width=10, fig.height=10, out.width='100%', results='asis'}
+
+cell_type_df$first.level_annotation[cell_type_df$sample_id %in% c("SCPCS000177", "SCPCS000180", "SCPCS000181", "SCPCS000190", "SCPCS000197")] <- "unknown"
+
+DT::datatable(table(cell_type_df$first.level_annotation, cell_type_df$sample_id))
+
 ```
 
 
@@ -377,15 +421,17 @@ cell_type_df <- cell_type_df |>
   mutate(second.level_annotation = case_when(
     # assign normal cells based on condition
     cell_type_df$compartment %in% c("fetal_nephron") &
+      cell_type_df$compartment.score > params$predicted.celltype.threshold &
       cell_type_df$has_cnv_score == "no CNV" ~ "kidney",
+   
     cell_type_df$compartment %in% c("stroma") &
+      cell_type_df$compartment.score > params$predicted.celltype.threshold &
       cell_type_df$has_cnv_score == "no CNV" ~ "normal stroma",
+    
     cell_type_df$compartment %in% c("endothelium") &
-      (cell_type_df$compartment.score > params$predicted.celltype.threshold |
-        cell_type_df$has_cnv_score == "no CNV") ~ "endothelium",
+      (cell_type_df$compartment.score > params$predicted.celltype.threshold) ~ "endothelium",
     cell_type_df$compartment %in% c("immune") &
-      (cell_type_df$compartment.score > params$predicted.celltype.threshold |
-        cell_type_df$has_cnv_score == "no CNV") ~ "immune",
+      (cell_type_df$compartment.score > params$predicted.celltype.threshold) ~ "immune",
 
     # assign cancer cells based on condition
     cell_type_df$compartment %in% c("stroma") &
@@ -398,45 +444,59 @@ cell_type_df <- cell_type_df |>
       cell_type_df$cell_type != "mesenchymal cell" ~ "cancer epithelium",
     .default = "unknown"
   ))
+
+cell_type_df$second.level_annotation[cell_type_df$sample_id %in% c("SCPCS000177", "SCPCS000180", "SCPCS000181", "SCPCS000190", "SCPCS000197")] <- "unknown"
 ```
 
 
+
+#### `Second.level_annotation` of cancer and normal cells - `umap` reduction
+
 ```{r fig.width=20, fig.height=20, out.width='100%', results='asis'}
-ggplot(cell_type_df[cell_type_df$first.level_annotation == "normal", ], aes(x = umap.umap_1, y = umap.umap_2, color = second.level_annotation), shape = 19, size = 1) +
-  geom_point() +
+ggplot(cell_type_df, aes(x = umap.umap_1, y = umap.umap_2, color = second.level_annotation)) +
+  geom_point(size = 0.2, shape = 19) +
   facet_wrap(facets = ~sample_id, ncol = 5) +
   theme_bw() +
   theme(text = element_text(size = 22))
 ```
 
 
-
-
-
+#### `Second.level_annotation` of cancer and normal cells without `unknown` - `umap` reduction
 
 ```{r fig.width=20, fig.height=20, out.width='100%', results='asis'}
-ggplot(cell_type_df[cell_type_df$first.level_annotation == "cancer", ], aes(x = umap.umap_1, y = umap.umap_2, color = second.level_annotation), shape = 19, size = 0.1) +
-  geom_point() +
+tmp <- cell_type_df[cell_type_df$second.level_annotation != "unknown",]
+ggplot(tmp, aes(x = umap.umap_1, y = umap.umap_2, color = second.level_annotation)) +
+  geom_point(size = 0.2, shape = 19) +
   facet_wrap(facets = ~sample_id, ncol = 5) +
   theme_bw() +
   theme(text = element_text(size = 22))
 ```
 
-#### Cancer and normal cells
+
+#### `Second.level_annotation` of cancer cells only - `umap` reduction
+
 
 ```{r fig.width=20, fig.height=20, out.width='100%', results='asis'}
-ggplot(cell_type_df, aes(x = umap.umap_1, y = umap.umap_2, color = second.level_annotation), shape = 19, size = 1) +
-  geom_point() +
+ggplot(cell_type_df[cell_type_df$first.level_annotation == "cancer", ], aes(x = umap.umap_1, y = umap.umap_2, color = second.level_annotation)) +
+  geom_point(size = 0.2, shape = 19) +
   facet_wrap(facets = ~sample_id, ncol = 5) +
   theme_bw() +
   theme(text = element_text(size = 22))
 ```
+
+Per sample, the annotations in the `umap` reduction seem to make sense as we can the three main Wilms tumor components are easily distinguished:
+
+- cancer blastema
+- epithelium
+- stroma
 
 ### Validation cancer versus normal based on the CNV profile
 
+We look for each `second.level_annotation` and `sample_id`, the proportion of cells that has CNV in each of the chromosome.
+
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 for (i in 1:22) {
-  print(do_Feature_mean(cell_type_df, group.by = "second.level_annotation", feature = glue::glue("proportion_cnv_chr", i)))
+  print(do_Feature_mean(cell_type_df, group.by = "second.level_annotation", feature = glue::glue("has_cnv_chr", i)))
 }
 ```
 
@@ -506,13 +566,14 @@ do_Feature_mean(cell_type_df, group.by = "second.level_annotation", feature = "E
 ```
 
 
+
 ## Create annotation table for export
 
 This section creates the cell type annotation table for export.
 
 ```{r}
 annotations_table <- cell_type_df |>
-  select(
+  dplyr::select(
     cell_barcode = barcode,
     scpca_sample_id = sample_id,
     tumor_cell_classification = first.level_annotation,
@@ -541,7 +602,9 @@ length(unique(annotations_table$scpca_sample_id))
 
 ## Conclusion
 
-- Combining label transfer and CNV inference we have produced draft annotations for all 40 Wilms tumor samples in SCPCP000006
+- Combining label transfer and CNV inference we have produced draft annotations for 35/40 Wilms tumor samples in SCPCP000006.
+We decided not to annotate samples for which the `infercnv` couldn't be run with a normal reference, as we don't trust the results in that case and want to avoid misclassification (`SCPCS000177`, `SCPCS000180`, `SCPCS000181`, `SCPCS000190`, `SCPCS000197`).
+
 
 - The heatmaps of CNV proportion and marker genes support our annotations, but signals with some marker genes are very low.
 Also, there is no universal marker for each entity of Wilms tumor that cover all tumor cells from all patient.
@@ -564,5 +627,4 @@ However, as anaplasia can occur in every (but do not has to) Wilms tumor histolo
 # record the versions of the packages used in this analysis and other environment information
 sessionInfo()
 ```
-
 

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -47,7 +47,7 @@ _Where `cnv.thr` and `pred.thr` need to be discussed_
 
 | first level annotation | second level annotation | selection of the cells | marker genes for validation | CNV validation |
 | ---------------------- | ----------------------- | ---------------------- | --------------------------- | --------------- |
-| normal                 | endothelial             | `compartment == "endothelium" & predicted.score > pred.thr  | `VWF`| no CNV |
+| normal                 | endothelial             | `compartment == "endothelium" & predicted.score > pred.thr`  | `VWF`| no CNV |
 | normal                 | immune                  | `compartment == "immune" & predicted.score > pred.thr  | `PTPRC`, `CD163`, `CD68`| no CNV |
 | normal                 | kidney                  | `compartment == "fetal_nephron" & predicted.score > pred.thr & cnv_score < cnv.thr` | `CDH1`, `PODXL`, `LTL`| no CNV |
 | normal                 | stroma                  | `compartment == "stroma" & predicted.score > pred.thr & cnv_score < cnv.thr`| `VIM`| no CNV |

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -48,7 +48,7 @@ _Where `cnv.thr` and `pred.thr` need to be discussed_
 | first level annotation | second level annotation | selection of the cells | marker genes for validation | CNV validation |
 | ---------------------- | ----------------------- | ---------------------- | --------------------------- | --------------- |
 | normal                 | endothelial             | `compartment == "endothelium" & predicted.score > pred.thr`  | `VWF`| no CNV |
-| normal                 | immune                  | `compartment == "immune" & predicted.score > pred.thr  | `PTPRC`, `CD163`, `CD68`| no CNV |
+| normal                 | immune                  | `compartment == "immune" & predicted.score > pred.thr`  | `PTPRC`, `CD163`, `CD68`| no CNV |
 | normal                 | kidney                  | `compartment == "fetal_nephron" & predicted.score > pred.thr & cnv_score < cnv.thr` | `CDH1`, `PODXL`, `LTL`| no CNV |
 | normal                 | stroma                  | `compartment == "stroma" & predicted.score > pred.thr & cnv_score < cnv.thr`| `VIM`| no CNV |
 | cancer                 | stroma                  | `compartment == "stroma" & cnv_score > cnv.thr` | `VIM`| `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -4,7 +4,8 @@ author: "Maud PLASCHKA"
 date: "`r Sys.Date()`"
 params:
   predicted.celltype.threshold: 0.85
-  cnv_threshold: !r c(0, 2)
+  cnv_threshold_low: 0
+  cnv_threshold_high: 2
   testing: 0
 output:
   html_document:
@@ -288,12 +289,12 @@ do_Feature_mean <- function(df, group.by, feature) {
 As done in `06_cnv_infercnv_exploration.Rmd`, we calculate  single CNV score and assess its potential in identifying cells with CNV versus normal cells without CNV.
 
 We simply checked for each chromosome if the cell `has_cnv_chr`.
-Would the cell have less than `r params$cnv_threshold[1]` chromosome with CNV, the global `has_cnv_score` will be FALSE.
-Would the cell have more than `r params$cnv_threshold[2]`  chromosome with CNV, the global `has_cnv_score` will be TRUE.
+Would the cell have less than `r params$cnv_threshold_low` chromosome with CNV, the global `has_cnv_score` will be FALSE.
+Would the cell have more than `r params$cnv_threshold_high`  chromosome with CNV, the global `has_cnv_score` will be TRUE.
 The default is set to `unknown`.
 
 The `infercnv` method can lead to false positive CNV.
-We introduced a flexibility of +`r params$cnv_threshold[2]` over the `cnv_threshold` to reduce the risk of misclassification of normal cells as cancer cells.
+We introduced a flexibility of +`r params$cnv_threshold_high` over the `cnv_threshold` to reduce the risk of misclassification of normal cells as cancer cells.
 
 Please note that some cancer cell might not have any CNV. 
 There is thus a risk of misclassifying cancer cells as normal cells. 
@@ -307,8 +308,8 @@ This is a limitation of our annotations.
 cell_type_df <- cell_type_df |>
   mutate(has_cnv_score = rowSums(cell_type_df[, grepl("has_cnv_chr", colnames(cell_type_df))])) |>
   mutate(has_cnv_score = case_when(
-    has_cnv_score > params$cnv_threshold[2] ~ "CNV",
-    has_cnv_score <= params$cnv_threshold[1] ~ "no CNV",
+    has_cnv_score > params$cnv_threshold_high ~ "CNV",
+    has_cnv_score <= params$cnv_threshold_low ~ "no CNV",
     .default = "unknown"
   ))
 
@@ -324,7 +325,7 @@ We only allow a bit of flexibility in terms of CNV profile for immune and endoth
 Indeed, we know that false positive CNV can be observed in a cell type specific manner.
 
 The threshold used for the `predicted.score` is defined as a parameter of this notebook as `r params$predicted.celltype.threshold`.
-The thresholds used for the identification of CNV are also defined as notebook parameters with a minimum of `r params$cnv_threshold[1]` and a maximum of `r params$cnv_threshold[2]`.
+The thresholds used for the identification of CNV are also defined as notebook parameters with a minimum of `r params$cnv_threshold_low` and a maximum of `r params$cnv_threshold_high`.
 
 - _cancer_ cells are either from the `stroma` or `fetal nephron` compartments and must have at least few CNV
 

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -3,8 +3,8 @@ title: "Combined annotation exploration for SCPCP000006"
 author: "Maud PLASCHKA"
 date: "`r Sys.Date()`"
 params:
-  predicted.celltype.threshold: 0.75
-  cnv_threshold: 0
+  predicted.celltype.threshold: 0.85
+  cnv_threshold: !r c(0, 2)
   testing: 0
 output:
   html_document:
@@ -288,12 +288,12 @@ do_Feature_mean <- function(df, group.by, feature) {
 As done in `06_cnv_infercnv_exploration.Rmd`, we calculate  single CNV score and assess its potential in identifying cells with CNV versus normal cells without CNV.
 
 We simply checked for each chromosome if the cell `has_cnv_chr`.
-Would the cell have less than `cnv_threshold` chromosome with CNV, the global `has_cnv_score` will be FALSE.
-Would the cell have more than `cnv_threshold` +2 chromosome with CNV, the global `has_cnv_score` will be TRUE.
+Would the cell have less than `r params$cnv_threshold[1]` chromosome with CNV, the global `has_cnv_score` will be FALSE.
+Would the cell have more than `r params$cnv_threshold[2]`  chromosome with CNV, the global `has_cnv_score` will be TRUE.
 The default is set to `unknown`.
 
 The `infercnv` method can lead to false positive CNV.
-We introduced a flexibility of `+2` over the `cnv_threshold` to reduce the risk of misclassification of normal cells as cancer cells.
+We introduced a flexibility of +`r params$cnv_threshold[2]` over the `cnv_threshold` to reduce the risk of misclassification of normal cells as cancer cells.
 
 Please note that some cancer cell might not have any CNV. 
 There is thus a risk of misclassifying cancer cells as normal cells. 
@@ -307,8 +307,8 @@ This is a limitation of our annotations.
 cell_type_df <- cell_type_df |>
   mutate(has_cnv_score = rowSums(cell_type_df[, grepl("has_cnv_chr", colnames(cell_type_df))])) |>
   mutate(has_cnv_score = case_when(
-    has_cnv_score > (params$cnv_threshold +2) ~ "CNV",
-    has_cnv_score <= params$cnv_threshold ~ "no CNV",
+    has_cnv_score > params$cnv_threshold[2] ~ "CNV",
+    has_cnv_score <= params$cnv_threshold[1] ~ "no CNV",
     .default = "unknown"
   ))
 
@@ -324,7 +324,7 @@ We only allow a bit of flexibility in terms of CNV profile for immune and endoth
 Indeed, we know that false positive CNV can be observed in a cell type specific manner.
 
 The threshold used for the `predicted.score` is defined as a parameter of this notebook as `r params$predicted.celltype.threshold`.
-The threshold used for the identification of CNV is also defined as the notebook parameter `r params$cnv_threshold`.
+The thresholds used for the identification of CNV are also defined as notebook parameters with a minimum of `r params$cnv_threshold[1]` and a maximum of `r params$cnv_threshold[2]`.
 
 - _cancer_ cells are either from the `stroma` or `fetal nephron` compartments and must have at least few CNV
 

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -307,7 +307,7 @@ This is a limitation of our annotations.
 cell_type_df <- cell_type_df |>
   mutate(has_cnv_score = rowSums(cell_type_df[, grepl("has_cnv_chr", colnames(cell_type_df))])) |>
   mutate(has_cnv_score = case_when(
-    has_cnv_score > params$cnv_threshold +2 ~ "CNV",
+    has_cnv_score > (params$cnv_threshold +2) ~ "CNV",
     has_cnv_score <= params$cnv_threshold ~ "no CNV",
     .default = "unknown"
   ))

--- a/analyses/cell-type-wilms-tumor-06/scripts/06a_build-geneposition.R
+++ b/analyses/cell-type-wilms-tumor-06/scripts/06a_build-geneposition.R
@@ -1,25 +1,87 @@
 # This script downloads and adapt the genome position file for use with infercnv
 
+# load library
+library(dplyr)
+library(stringr)
+
+
 # The base path for the OpenScPCA repository, found by its (hidden) .git directory
 repository_base <- rprojroot::find_root(rprojroot::is_git_root)
 # The path to this module
 module_base <- file.path(repository_base, "analyses", "cell-type-wilms-tumor-06")
 
-# load library
-library(tidyverse)
-# Define the gene order file
-  gene_order_file <- file.path(module_base, "results","references", 'gencode_v19_gene_pos.txt')
+# Define the file paths
+gene_order_file <- file.path(module_base, "results", "references", "gencode_v38_gene_pos.txt")
+arm_order_file <- file.path(module_base, "results", "references", "hg38_cytoBand.txt")
+gene_arm_order_file <- file.path(module_base, "results", "references", "gencode_v38_gene_pos_arm.txt")
 
-# Download the file if ot existing
-if (!file.exists(gene_order_file)) {
-  download.file(url = 'https://data.broadinstitute.org/Trinity/CTAT/cnv/gencode_v19_gen_pos.complete.txt',
-                destfile = gene_order_file)
-  gene_order <- read_tsv(gene_order_file, col_names =  FALSE)
-  tmp <- gsub("\\..*","",gene_order$X1) 
-  tmp <- gsub(".*\\|","",tmp) 
-  gene_order$X1 <- tmp
-  gene_order <- gene_order[grepl("ENSG", x = gene_order$X1),]
+if (!file.exists(gene_arm_order_file)) {
   
-  write_tsv(col_names = FALSE, gene_order, gene_order_file, append = FALSE)
-}
+  # Download the updated gene order file for GENCODE v38 (Ensembl 104)
+  if (!file.exists(gene_order_file)) {
+    download.file(url = "https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_38/gencode.v38.annotation.gtf.gz",
+                  destfile = gene_order_file)
+  }
   
+  # Read the GTF file and extract gene positions
+  gtf_data <- read.table(gzfile(gene_order_file), header = FALSE, sep = "\t", comment.char = "#", stringsAsFactors = FALSE)
+  
+  # Filter for gene entries only
+  gene_order <- gtf_data %>%
+    filter(V3 == "gene") %>%
+    select(V1, V4, V5, V9) %>% # Chromosome, Start, End, Attributes
+    filter(str_detect(V9, "gene_id")) %>% # Ensure we only process lines that contain "gene_id"
+    mutate(Ensembl_Gene_ID = str_extract(V9, "(ENSG[0-9]+)")) %>% # Use str_extract to capture ENSG number
+    select(Ensembl_Gene_ID, V1, V4, V5) %>% # Select relevant columns
+    rename(Chromosome = V1, Start = V4, End = V5)
+  
+  
+  # Download chromosome arm information (cytoBand data)
+  if (!file.exists(arm_order_file)) {
+    download.file(url = "http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/cytoBand.txt.gz",
+                  destfile = arm_order_file)
+  }
+  
+  # Load cytoBand file
+  cytoBand <- read.table(gzfile(arm_order_file), header = FALSE, sep = "\t", stringsAsFactors = FALSE)
+  colnames(cytoBand) <- c("chrom", "start", "end", "band", "stain")
+  
+  # Extract chromosome arm information
+  cytoBand <- cytoBand %>%
+    mutate(arm = substr(band, 1, 1))  # Extract 'p' or 'q' from the band column
+  
+  # Define arm boundaries
+  chromosome_arms <- cytoBand %>%
+    group_by(chrom, arm) %>%
+    summarize(
+      Start = min(start),
+      End = max(end),
+      .groups = "drop"
+    )
+  
+  # Add chromosome arm information
+  gene_order <- gene_order %>%
+    # Join chromosome arm information with gene_order based on Chromosome
+    left_join(chromosome_arms, by = c("Chromosome" = "chrom")) %>%
+    # Determine arm (p or q)
+    mutate(Arm = case_when(
+      (Start.x > End.y & arm == "p") ~ "q",
+      arm == "q" ~ NA,
+      .default = arm)) %>%
+    na.omit() %>%      
+    # Create Chromosome_arm by pasting Chromosome with Arm information
+    mutate(Chromosome = paste0(Chromosome, Arm)) %>%
+    # Define chromosome arm order
+    mutate(Chromosome = factor(Chromosome, levels = c(paste0("chr", rep(1:22, each = 2), c("p", "q")),
+                                                      "chrXp", "chrXq", "chrYp", "chrYq"))) %>%
+    # Sort genes by Chromosome arm and Start position
+    arrange(Chromosome, Start.x)  %>%
+    # Select only relevant column for infercnv
+    select(Ensembl_Gene_ID, Chromosome, Start.x, End.x) %>%
+    # Remove ENSG duplicated (genes that are both on X and Y chromosome need to be remove before infercnv)
+    distinct(Ensembl_Gene_ID, .keep_all = TRUE)
+  
+  # Save the final output
+  write_tsv(gene_order, gene_arm_order_file, col_names = FALSE, append = FALSE)
+
+  }


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

This PR is linked to the [issue 856](https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/856).

#### What is the goal of this pull request?

I aim here to improve the workflow of the annotations performed in `07_combined_annotation_across_samples_exploration.Rmd`.

The suggested changes aim to overcome some misclassification that have been spotted in the first version of the annotation while working on the integration of the data. 

1. In the first version of the annotation, I realized that a lot of immune cells were filtered out because of the `cnv-threshold`. See the expression of PTPRC = CD45 below: 
![image](https://github.com/user-attachments/assets/81484933-7c7c-42f7-8055-c6a9bd55da5e)

We requested immune and endothelial cells to have no infered cnv to be labeled as normal. I think that the few CNV that were infered for immune cells are cell type specific expression of some genes that colocalized on one chromosome. Thus I decided to allow a bit of flexibility in regards to CNV for immune and endothelial cells and only based the annotation of immune and endothelial cells on the `predicted.cell-type` and associated `prediction.score`.

2. Similar to the immune cells, there is a high probability that we also infer false positive CNV in normal epithelial/stroma cells. I am not sure that it will be possible to differentiate between normal cells with false positive CNV from cancer cells. For that reason, I decided to label as `normal` cells with a `cnv-score <= cnv-threshold` and as `cancer` cells with a `cnv-score > cnv-threshold + 2`.
The choice of `+2` is a bit arbitrary, but based on the approximate number of CNV that can be detected in `endothelial` and `immune` cells. 

3. There is the possibility of cancer cell without any CNV. It would be extremly difficult in that case to differentiate them from normal cells. The strategy I decided to go with to reduce the risk of misclassification is to use the prediction score of label transfer. Indeed, we expect normal cells to resemble the cells from the fetal kidney reference and thus have a high `prediction.score`.

4. While working on the integration (see umap reduction here colored by `cnv_score`), I realized that samples -177, -180, -181, -190, -197 have strikingly very low `cnv_score`. The `cnv_score` is simply the number of chromosome presenting a CNV for each patient. Of note, these 5 samples are the ones with no immune and/or endothelial cells for which we couldn’t run `infercnv` properly. We ran `infercnv` without any reference. In that case, the mean over all cellular expression profiles is taken as a reference. If the sample is mostly composed of cancer cell, the cancer-associated CNV are taken as the normal reference...

![image](https://github.com/user-attachments/assets/dcbc8303-1c7b-412f-82ca-1d5606b7faf3)

I am afraid not to have a solution for this, but I am quite sure that the cells for these 5 patients are mis-classified. This will affect the downstream differential expression analysis cancer versus normal and the potential finding of Wilms tumor histology specific markers. This is why I would strongly recommand forcing the annotations for these patients to `unknown`.
![image](https://github.com/user-attachments/assets/1b6c0b15-b6f8-4126-b6a3-776022807193)


6. I slightly changed the summarized CNV heatmap with `do_Feature_mean`. Initially, the `feature` ploted with `do_Feature_mean` was `prop_cnv_chr[i]`, the proportion of the chromosome i affected by a CNV. The function `do_Feature_mean` took then the mean over all cells in a group. This can be misleading are it is then impossible to interpret the mean value. Example with a mean of 0.5, we could say:
- half of the cells in the group gained/lossed the entire chromosome, half are unaffected
- all cells gained/lossed half of the chromosome
- ... all other combinations possible!

For that reason, I changed the `feature` to `has_cnv_chr[i]`, which is a binary information of the presence/absence of CNV in the chromosome i for the given cell.  While taking the mean over all cells in a group, we then have the information of the percentage of cells within the group having any kind of CNV in this chromosome. 


#### If known, do you anticipate filing additional pull requests to complete this analysis module?

-[ ] one for the integration of the samples
-[ ] one for differential expression analysis, looking for Wilms tumor, histology specific markers

### Results

The annotation file is generated automatically while running the script and will be saved in the `results` folder.
The notebook is saved in the `notebook` folder.


### Provide directions for reviewers


#### What are the software and computational requirements needed to be able to run the code in this PR?




#### Are there particularly areas you'd like reviewers to have a close look at?



#### Is there anything that you want to discuss further?






### Author checklists


#### Analysis module and review

- [x] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [ ] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [ ] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [ ] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
