### PR TITLE
Remove outdated CNV annotation from CI in Ewing module

### DIFF
--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           conda activate openscpca-cell-type-ewings
           cd $MODULE_PATH
-          bash cnv-annotation.sh
           bash aucell-singler-annotation.sh
           bash evaluate-clusters.sh
           bash run-aucell-ews-signatures.sh

--- a/analyses/cell-type-ewings/README.md
+++ b/analyses/cell-type-ewings/README.md
@@ -265,6 +265,8 @@ The `auc-ews-gene-signatures.tsv` file contains the following columns:
 
 ## CNV annotation workflow
 
+**NOTE:** This workflow is has been removed from CI and is no longer maintained! 
+
 The CNV annotation workflow (`cnv-annotation.sh`) can be used to identify potential tumor cells in a given sample.
 Annotations are obtained by running the following methods within the workflow:
 

--- a/analyses/cell-type-ewings/cnv-annotation.sh
+++ b/analyses/cell-type-ewings/cnv-annotation.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+## THIS WORKFLOW HAS BEEN REMOVED FROM CI AND IS NO LONGER BEING MAINTAINED ##
+
 ####
 : '
 This workflow will identify tumor cells in a single library.

--- a/analyses/cell-type-ewings/scripts/README.md
+++ b/analyses/cell-type-ewings/scripts/README.md
@@ -2,118 +2,19 @@
 
 This directory contains all scripts used for cell typing Ewing sarcoma samples from SCPCP000015.
 
-## Scripts used in the CNV annotation workflow
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents** 
 
-The scripts in the `cnv-workflow` folder are implemented in `cnv-annotation.sh`:
+- [Scripts used to annotate tumor cells with `AUCell` and `SingleR`](#scripts-used-to-annotate-tumor-cells-with-aucell-and-singler)
+- [Scripts used to annotate tumor cells with `SingleR`](#scripts-used-to-annotate-tumor-cells-with-singler)
+- [Scripts used in the clustering workflow](#scripts-used-in-the-clustering-workflow)
+- [Scripts used for running `AUCell` with `EWS-FLI` gene signatures](#scripts-used-for-running-aucell-with-ews-fli-gene-signatures)
+- [Scripts used in the CNV annotation workflow](#scripts-used-in-the-cnv-annotation-workflow)
+- [Utils](#utils)
 
-1. `00-generate-cellassign-refs.R`: This script is used to generate the binary marker gene reference matrices required to run `CellAssign` in `cnv-annotation.sh`.
-   Running this script creates three different references found in `references/cellassign_refs`.
-   See [references/README.md](../references/README.md#cellassign-references) for a full description of all references that are created.
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-To run this script use the following command:
-
-```sh
-Rscript 00-generate-cellassign-refs.R
-```
-
-2. `00-make-gene-order-file.R`: This script is used to generate the [gene order file](https://github.com/broadinstitute/inferCNV/wiki/File-Definitions#gene-ordering-file) needed for running `InferCNV` with `04-run-infercnv.R`.
-   This script downloads the GTF file used to create the original index used in `scpca-nf` (Ensembl v104) from the public bucket `s3://scpca-references`.
-   This file is then converted to the required gene order formatted file for `InferCNV` and saved to `references/infercnv_refs`.
-
-To run this script use the following command:
-
-```sh
-Rscript 00-make-gene-order-file.R
-```
-
-3. `01-select-cell-types.R`: This script is used to generate a table of normal and tumor cells to use as references for downstream analysis and copy number inference methods.
-   The output table contains the following columns:
-
-|                                  |                                                                                                |
-| -------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `barcodes`                       | Cell barcode                                                                                   |
-| `reference_cell_class`           | Indicates if the cell should be uses as a Normal or Tumor cell reference                       |
-| `cellassign_celltype_annotation` | Original annotation as obtained by `CellAssign` in the processed `SingleCellExperiment` object |
-| `singler_celltype_annotation`    | Original annotation as obtained by `SingleR` in the processed `SingleCellExperiment` object    |
-
-To create a table of cells use the `--normal_cells` and/or `--tumor_cells` arguments.
-Any cells that have the same annotation as the annotation provided with the `--normal_cells` argument will be labeled as "Normal".
-Any cells that have the same annotation as the annotation provided with the `--tumor_cells` argument will be labeled as "Tumor".
-
-In addition to providing a list of cell types, you must also provide an input `SingleCellExperiment` object with columns containing cell type annotations and a `output_filename` with the full path to save the reference file.
-
-The following command specifies using cells annotated as endothelial cells as the normal reference and muscle cells as the tumor reference:
-
-```sh
-Rscript 01-select-normal-cells.R \
-  --sce_file <path to processed sce file> \
-  --normal_cells "endothelial cell" \
-  --tumor_cells "smooth-muscle-cell" \
-  --output_filename <full path to TSV file to save output table>
-```
-
-4. `02-run-cellassign.py`: This script runs [`CellAssign`](https://docs.scvi-tools.org/en/stable/user_guide/models/cellassign.html) on a processed `AnnData` object, requiring an `AnnData` object and a binary reference matrix with cell types as columns and genes as rows as input.
-   The output will be a TSV file containing a predictions matrix with all cells in the input `AnnData` object as rows and all possible cell types as columns.
-   The values in the predictions matrix represent the likelihood of each cell being assigned to the respective cell type.
-
-Run this script with the following command:
-
-```sh
-python 02-run-cellassign.py \
-  --anndata_file <path to anndata file> \
-  --output_predictions <path to output tsv file> \
-  --reference <path to marker gene reference>
-```
-
-5. `03-run-copykat.R`: This script is used to run [`CopyKAT`](https://github.com/navinlabcode/copykat) on a processed `SingleCellExperiment` object.
-   `CopyKAT` is run on the object using the default parameters specified in `copykat::copykat()` other than the `id.type`, which is set to `E` to account for Ensembl IDs used in the objects available on the Portal.
-
-To run the script with the default parameters, use the following command:
-
-```sh
-Rscript run-copykat.R \
-  --sce_file <path to processed sce file> \
-  --results_dir <name of folder to save results> \
-  --threads 4
-```
-
-`CopyKAT` can also accept a table output from `01-select-cell-types.R` that contains the `barcodes` and `reference_cell_class` columns using the `--reference_cell_file` argument.
-Any cells where `reference_cell_class` is `Normal` will be used as the baseline reference for assigning cells as diploid or aneuploid.
-
-The following command runs `CopyKAT` with a reference table indicating cells to use as the normal cell reference:
-
-```sh
-Rscript run-copykat.R \
-  --sce_file <path to processed sce file> \
-  --reference_cell_file <path to file with table of normal cell barcodes> \
-  --results_dir <name of folder to save results> \
-  --threads 4
-```
-
-6. `04-run-infercnv.R`: This script is used to run [`InferCNV`](https://github.com/broadinstitute/inferCNV/wiki) on a processed `SingleCellExperiment` object.
-   `InferCNV` is run with a gene cutoff of 0.1 and all other default settings.
-   The heatmap (saved as `.png`), full object from running `InferCNV` and a table with cell by CNV information are saved to a `output_dir` specified at the command line.
-
-All other intermediate files are saved to a `scratch_dir`, which by default is `scratch/infercnv/{library_id}`.
-
-To run `InferCNV`, an [annotations file](https://github.com/broadinstitute/inferCNV/wiki/File-Definitions#sample-annotation-file) containing all cell barcodes and associated annotations must be created.
-This file is created as part of this script and saved to the specified path using `--annotations_file`.
-
-A table containing normal cell barcodes can be provided using the `--reference_cell_file` argument (output from `01-select-normal-cells.R`).
-If this is the case, all normal cells will be annotated as "reference" and all other cells will be denoted as "unknown".
-If no normal cells are provided, then all cells will be labeled as "unknown" and `InferCNV` will be run with `ref_group_names = NULL`.
-
-This script also requires a gene order file (created by `00-make-gene-order-file.R`).
-
-To run this script use the following command:
-
-```sh
-Rscript 04-run-infercnv.Rmd \
-  --annotations_file <path to save annotations file> \
-  --reference_cell_file <path to file with table of normal cell barcodes> \
-  --output_dir <full path to folder to save results> \
-  --threads 4
-```
 
 ## Scripts used to annotate tumor cells with `AUCell` and `SingleR`
 
@@ -290,6 +191,121 @@ To run this script using the default parameters use the following command:
 Rscript 01-aucell.R \
   --sce_file <path to processed SCE file> \
   --output_file <path to TSV file to save AUC results>
+```
+
+## Scripts used in the CNV annotation workflow
+
+**NOTE:** This workflow is has been removed from CI and is no longer maintained! 
+
+The scripts in the `cnv-workflow` folder are implemented in `cnv-annotation.sh`:
+
+1. `00-generate-cellassign-refs.R`: This script is used to generate the binary marker gene reference matrices required to run `CellAssign` in `cnv-annotation.sh`.
+   Running this script creates three different references found in `references/cellassign_refs`.
+   See [references/README.md](../references/README.md#cellassign-references) for a full description of all references that are created.
+
+To run this script use the following command:
+
+```sh
+Rscript 00-generate-cellassign-refs.R
+```
+
+2. `00-make-gene-order-file.R`: This script is used to generate the [gene order file](https://github.com/broadinstitute/inferCNV/wiki/File-Definitions#gene-ordering-file) needed for running `InferCNV` with `04-run-infercnv.R`.
+   This script downloads the GTF file used to create the original index used in `scpca-nf` (Ensembl v104) from the public bucket `s3://scpca-references`.
+   This file is then converted to the required gene order formatted file for `InferCNV` and saved to `references/infercnv_refs`.
+
+To run this script use the following command:
+
+```sh
+Rscript 00-make-gene-order-file.R
+```
+
+3. `01-select-cell-types.R`: This script is used to generate a table of normal and tumor cells to use as references for downstream analysis and copy number inference methods.
+   The output table contains the following columns:
+
+|                                  |                                                                                                |
+| -------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `barcodes`                       | Cell barcode                                                                                   |
+| `reference_cell_class`           | Indicates if the cell should be uses as a Normal or Tumor cell reference                       |
+| `cellassign_celltype_annotation` | Original annotation as obtained by `CellAssign` in the processed `SingleCellExperiment` object |
+| `singler_celltype_annotation`    | Original annotation as obtained by `SingleR` in the processed `SingleCellExperiment` object    |
+
+To create a table of cells use the `--normal_cells` and/or `--tumor_cells` arguments.
+Any cells that have the same annotation as the annotation provided with the `--normal_cells` argument will be labeled as "Normal".
+Any cells that have the same annotation as the annotation provided with the `--tumor_cells` argument will be labeled as "Tumor".
+
+In addition to providing a list of cell types, you must also provide an input `SingleCellExperiment` object with columns containing cell type annotations and a `output_filename` with the full path to save the reference file.
+
+The following command specifies using cells annotated as endothelial cells as the normal reference and muscle cells as the tumor reference:
+
+```sh
+Rscript 01-select-normal-cells.R \
+  --sce_file <path to processed sce file> \
+  --normal_cells "endothelial cell" \
+  --tumor_cells "smooth-muscle-cell" \
+  --output_filename <full path to TSV file to save output table>
+```
+
+4. `02-run-cellassign.py`: This script runs [`CellAssign`](https://docs.scvi-tools.org/en/stable/user_guide/models/cellassign.html) on a processed `AnnData` object, requiring an `AnnData` object and a binary reference matrix with cell types as columns and genes as rows as input.
+   The output will be a TSV file containing a predictions matrix with all cells in the input `AnnData` object as rows and all possible cell types as columns.
+   The values in the predictions matrix represent the likelihood of each cell being assigned to the respective cell type.
+
+Run this script with the following command:
+
+```sh
+python 02-run-cellassign.py \
+  --anndata_file <path to anndata file> \
+  --output_predictions <path to output tsv file> \
+  --reference <path to marker gene reference>
+```
+
+5. `03-run-copykat.R`: This script is used to run [`CopyKAT`](https://github.com/navinlabcode/copykat) on a processed `SingleCellExperiment` object.
+   `CopyKAT` is run on the object using the default parameters specified in `copykat::copykat()` other than the `id.type`, which is set to `E` to account for Ensembl IDs used in the objects available on the Portal.
+
+To run the script with the default parameters, use the following command:
+
+```sh
+Rscript run-copykat.R \
+  --sce_file <path to processed sce file> \
+  --results_dir <name of folder to save results> \
+  --threads 4
+```
+
+`CopyKAT` can also accept a table output from `01-select-cell-types.R` that contains the `barcodes` and `reference_cell_class` columns using the `--reference_cell_file` argument.
+Any cells where `reference_cell_class` is `Normal` will be used as the baseline reference for assigning cells as diploid or aneuploid.
+
+The following command runs `CopyKAT` with a reference table indicating cells to use as the normal cell reference:
+
+```sh
+Rscript run-copykat.R \
+  --sce_file <path to processed sce file> \
+  --reference_cell_file <path to file with table of normal cell barcodes> \
+  --results_dir <name of folder to save results> \
+  --threads 4
+```
+
+6. `04-run-infercnv.R`: This script is used to run [`InferCNV`](https://github.com/broadinstitute/inferCNV/wiki) on a processed `SingleCellExperiment` object.
+   `InferCNV` is run with a gene cutoff of 0.1 and all other default settings.
+   The heatmap (saved as `.png`), full object from running `InferCNV` and a table with cell by CNV information are saved to a `output_dir` specified at the command line.
+
+All other intermediate files are saved to a `scratch_dir`, which by default is `scratch/infercnv/{library_id}`.
+
+To run `InferCNV`, an [annotations file](https://github.com/broadinstitute/inferCNV/wiki/File-Definitions#sample-annotation-file) containing all cell barcodes and associated annotations must be created.
+This file is created as part of this script and saved to the specified path using `--annotations_file`.
+
+A table containing normal cell barcodes can be provided using the `--reference_cell_file` argument (output from `01-select-normal-cells.R`).
+If this is the case, all normal cells will be annotated as "reference" and all other cells will be denoted as "unknown".
+If no normal cells are provided, then all cells will be labeled as "unknown" and `InferCNV` will be run with `ref_group_names = NULL`.
+
+This script also requires a gene order file (created by `00-make-gene-order-file.R`).
+
+To run this script use the following command:
+
+```sh
+Rscript 04-run-infercnv.Rmd \
+  --annotations_file <path to save annotations file> \
+  --reference_cell_file <path to file with table of normal cell barcodes> \
+  --output_dir <full path to folder to save results> \
+  --threads 4
 ```
 
 

--- a/analyses/cell-type-ewings/template_notebooks/README.md
+++ b/analyses/cell-type-ewings/template_notebooks/README.md
@@ -3,5 +3,6 @@
 This folder contains any template notebooks that are rendered as part of a workflow in this module.
 
 1. `cnv-workflow`: This folder contains all template notebooks used in `cnv-annotation.sh`.
+**NOTE:** This workflow is has been removed from CI and is no longer maintained! 
 2. `auc-singler-workflow`: This folder contains all template notebooks used in `auc-singler-annotation.sh`.
 3. `clustering-workflow`: This folder contains all template notebooks used in `evaluate-clusters.sh`. 


### PR DESCRIPTION
Closes #992 

We are no longer using the `cnv-annotation.sh` workflow or any of the outputs for assigning cell types to the Ewing samples.  Since we don't need this workflow to work anymore, we don't need to run it in CI every time we make updates to that code. This should reduce our computational cost of running CI for this module by a lot. 

I thought about moving it from the root directory of this module and reorganizing things, but that seemed like overkill. Instead, I added a bunch of warnings both in the workflow script and in the docs stating that the workflow was not part of CI and was no longer maintained. For the README.md in the scripts directory I ended up moving the description of the scripts in this workflow to the end rather than being at the beginning. Let me know if you think I missed any areas where we should address this in the docs. 