### PR TITLE
Freeze ubuntu runners at 22.04

### DIFF
--- a/.github/workflows/run_cell-type-ETP-ALL-03.yml
+++ b/.github/workflows/run_cell-type-ETP-ALL-03.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash -el {0}
@@ -68,7 +68,7 @@ jobs:
           working-directory: ${{ env.MODULE_PATH }}
 
       - name: Set up conda
-      # Note that this creates and activates an environment named 'test' by default
+        # Note that this creates and activates an environment named 'test' by default
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest

--- a/.github/workflows/run_cell-type-consensus.yml
+++ b/.github/workflows/run_cell-type-consensus.yml
@@ -32,15 +32,15 @@ on:
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: public.ecr.aws/openscpca/cell-type-consensus:latest
 
     steps:
-      - name: Install aws-cli 
-        run: | 
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" 
-          unzip -q awscliv2.zip 
-          ./aws/install 
+      - name: Install aws-cli
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          ./aws/install
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/run_cell-type-dsrct.yml
+++ b/.github/workflows/run_cell-type-dsrct.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/run_cell-type-glioblastoma.yml
+++ b/.github/workflows/run_cell-type-glioblastoma.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/run_cell-type-nonETP-ALL-03.yml
+++ b/.github/workflows/run_cell-type-nonETP-ALL-03.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash -el {0}
@@ -68,7 +68,7 @@ jobs:
           working-directory: ${{ env.MODULE_PATH }}
 
       - name: Set up conda
-      # Note that this creates and activates an environment named 'test' by default
+        # Note that this creates and activates an environment named 'test' by default
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest

--- a/.github/workflows/run_hello-R.yml
+++ b/.github/workflows/run_hello-R.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/run_metacells.yml
+++ b/.github/workflows/run_metacells.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash -el {0}

--- a/templates/workflows/run_conda-module.yml
+++ b/templates/workflows/run_conda-module.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash -el {0}

--- a/templates/workflows/run_conda-renv-module.yml
+++ b/templates/workflows/run_conda-renv-module.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   run-module:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'AlexsLemonade'
     defaults:
       run:

--- a/templates/workflows/run_renv-module.yml
+++ b/templates/workflows/run_renv-module.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   run-module:
     if: github.repository_owner == 'AlexsLemonade'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Closes #1014
(and maybe #1011)

Here I am updating the GHA runners for most of the `run_*` actions to `ubuntu-22.04`. 

I decided that actions that run with docker containters could probably safely be left with `ubuntu-lastest`, and also that the `docker_*` actions were also safe to leave that way. I also left the `hello-python` runner as `latest`, maybe as a kind of bellweather. If that breaks, we have some real trouble that we probably want to know about.

