### PR TITLE
Update Rcpp packages for parallelDist error

### DIFF
--- a/analyses/cell-type-ETP-ALL-03/cell-type-ETP-ALL-03.Rproj
+++ b/analyses/cell-type-ETP-ALL-03/cell-type-ETP-ALL-03.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 7a861b3e-3cf8-449a-b34d-18e074ce6717
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/analyses/cell-type-ETP-ALL-03/renv.lock
+++ b/analyses/cell-type-ETP-ALL-03/renv.lock
@@ -378,14 +378,14 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.13",
+      "Version": "1.0.14",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "f27411eb6d9c3dada5edd444b8416675"
+      "Hash": "e7bdd9ee90e96921ca8a0f1972d66682"
     },
     "RcppAnnoy": {
       "Package": "RcppAnnoy",
@@ -401,7 +401,7 @@
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "14.0.2-1",
+      "Version": "14.2.2-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -411,7 +411,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "edff747eebfb8f2e18eed194e000caa1"
+      "Hash": "9da7c242d94a8419d045f6b3a64b9765"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
@@ -439,13 +439,13 @@
     },
     "RcppParallel": {
       "Package": "RcppParallel",
-      "Version": "5.1.9",
+      "Version": "5.1.10",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "f38a72a419b91faac0ce5d9eee04c120"
+      "Hash": "34ee3ba92c1b2df651980325523ed22a"
     },
     "RcppProgress": {
       "Package": "RcppProgress",
@@ -2385,7 +2385,7 @@
         "tibble",
         "tidyr"
       ],
-      "Hash": "4b9dcd60f9ae2a2e1999acbd49d7b07a"
+      "Hash": "07bd50436bff14982bc07f3459e9554c"
     },
     "rappdirs": {
       "Package": "rappdirs",

--- a/analyses/cell-type-ewings/ewings-cell-type.Rproj
+++ b/analyses/cell-type-ewings/ewings-cell-type.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: be2aaf55-5c6f-4cc1-a54b-0330df4fb278
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/analyses/cell-type-ewings/renv.lock
+++ b/analyses/cell-type-ewings/renv.lock
@@ -859,14 +859,14 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.13",
+      "Version": "1.0.14",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "f27411eb6d9c3dada5edd444b8416675"
+      "Hash": "e7bdd9ee90e96921ca8a0f1972d66682"
     },
     "RcppAnnoy": {
       "Package": "RcppAnnoy",
@@ -882,9 +882,9 @@
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "14.0.0-1",
+      "Version": "14.2.2-1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "Rcpp",
@@ -892,7 +892,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "a711769be34214addf7805278b72d56b"
+      "Hash": "9da7c242d94a8419d045f6b3a64b9765"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
@@ -920,13 +920,13 @@
     },
     "RcppParallel": {
       "Package": "RcppParallel",
-      "Version": "5.1.8",
+      "Version": "5.1.10",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "21c1466a17de6b1f5f4bc0569868775e"
+      "Hash": "34ee3ba92c1b2df651980325523ed22a"
     },
     "RcppProgress": {
       "Package": "RcppProgress",

--- a/analyses/cell-type-nonETP-ALL-03/cell-type-nonETP-ALL-03.Rproj
+++ b/analyses/cell-type-nonETP-ALL-03/cell-type-nonETP-ALL-03.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 0b9b46bd-d486-49ce-969b-0cf717076c14
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/analyses/cell-type-nonETP-ALL-03/renv.lock
+++ b/analyses/cell-type-nonETP-ALL-03/renv.lock
@@ -446,14 +446,14 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.13",
+      "Version": "1.0.14",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "f27411eb6d9c3dada5edd444b8416675"
+      "Hash": "e7bdd9ee90e96921ca8a0f1972d66682"
     },
     "RcppAnnoy": {
       "Package": "RcppAnnoy",
@@ -469,7 +469,7 @@
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "14.0.2-1",
+      "Version": "14.2.2-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -479,7 +479,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "edff747eebfb8f2e18eed194e000caa1"
+      "Hash": "9da7c242d94a8419d045f6b3a64b9765"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
@@ -507,13 +507,13 @@
     },
     "RcppParallel": {
       "Package": "RcppParallel",
-      "Version": "5.1.9",
+      "Version": "5.1.10",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "f38a72a419b91faac0ce5d9eee04c120"
+      "Hash": "34ee3ba92c1b2df651980325523ed22a"
     },
     "RcppProgress": {
       "Package": "RcppProgress",
@@ -2634,7 +2634,7 @@
         "tibble",
         "tidyr"
       ],
-      "Hash": "4b9dcd60f9ae2a2e1999acbd49d7b07a"
+      "Hash": "07bd50436bff14982bc07f3459e9554c"
     },
     "rappdirs": {
       "Package": "rappdirs",

--- a/analyses/cell-type-wilms-tumor-06/Dockerfile
+++ b/analyses/cell-type-wilms-tumor-06/Dockerfile
@@ -31,7 +31,7 @@ RUN Rscript -e 'renv::restore()' && \
   rm -rf /tmp/Rtmp*
 
 # Complete installation of zellkonverter conda env
-ENV BASILISK_EXTERNAL_DIR /usr/local/renv/basilisk
+ENV BASILISK_EXTERNAL_DIR=/usr/local/renv/basilisk
 RUN Rscript -e "proc <- basilisk::basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = 'anndata'); \
   basilisk::basiliskStop(proc); \
   basilisk.utils::cleanConda()"

--- a/analyses/cell-type-wilms-tumor-06/cell-type-wilms-tumor-06.Rproj
+++ b/analyses/cell-type-wilms-tumor-06/cell-type-wilms-tumor-06.Rproj
@@ -1,0 +1,14 @@
+Version: 1.0
+ProjectId: 913f3e82-4d60-48ab-86eb-d7b752e801d1
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/analyses/cell-type-wilms-tumor-06/renv.lock
+++ b/analyses/cell-type-wilms-tumor-06/renv.lock
@@ -848,14 +848,14 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.13",
+      "Version": "1.0.14",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "f27411eb6d9c3dada5edd444b8416675"
+      "Hash": "e7bdd9ee90e96921ca8a0f1972d66682"
     },
     "RcppAnnoy": {
       "Package": "RcppAnnoy",
@@ -871,9 +871,9 @@
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "14.0.0-1",
+      "Version": "14.2.2-1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "Rcpp",
@@ -881,7 +881,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "a711769be34214addf7805278b72d56b"
+      "Hash": "9da7c242d94a8419d045f6b3a64b9765"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
@@ -909,13 +909,13 @@
     },
     "RcppParallel": {
       "Package": "RcppParallel",
-      "Version": "5.1.9",
+      "Version": "5.1.10",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "f38a72a419b91faac0ce5d9eee04c120"
+      "Hash": "34ee3ba92c1b2df651980325523ed22a"
     },
     "RcppProgress": {
       "Package": "RcppProgress",

--- a/analyses/cell-type-wilms-tumor-06/renv/settings.json
+++ b/analyses/cell-type-wilms-tumor-06/renv/settings.json
@@ -1,5 +1,5 @@
 {
-  "bioconductor.version": null,
+  "bioconductor.version": "3.19",
   "external.libraries": [],
   "ignored.packages": [],
   "package.dependency.fields": [
@@ -7,9 +7,9 @@
     "Depends",
     "LinkingTo"
   ],
-  "ppm.enabled": null,
+  "ppm.enabled": true,
   "ppm.ignored.urls": [],
-  "r.version": null,
+  "r.version": "4.4.0",
   "snapshot.type": "implicit",
   "use.cache": true,
   "vcs.ignore.cellar": true,

--- a/analyses/cell-type-wilms-tumor-14/cell-type-wilms-tumor-14.Rproj
+++ b/analyses/cell-type-wilms-tumor-14/cell-type-wilms-tumor-14.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 726c4876-87e2-4357-a506-db22dd434108
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/analyses/cell-type-wilms-tumor-14/renv.lock
+++ b/analyses/cell-type-wilms-tumor-14/renv.lock
@@ -483,14 +483,14 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.13",
+      "Version": "1.0.14",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "f27411eb6d9c3dada5edd444b8416675"
+      "Hash": "e7bdd9ee90e96921ca8a0f1972d66682"
     },
     "RcppAnnoy": {
       "Package": "RcppAnnoy",
@@ -506,7 +506,7 @@
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "14.0.2-1",
+      "Version": "14.2.2-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -516,7 +516,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "edff747eebfb8f2e18eed194e000caa1"
+      "Hash": "9da7c242d94a8419d045f6b3a64b9765"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
@@ -544,13 +544,13 @@
     },
     "RcppParallel": {
       "Package": "RcppParallel",
-      "Version": "5.1.9",
+      "Version": "5.1.10",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "f38a72a419b91faac0ce5d9eee04c120"
+      "Hash": "34ee3ba92c1b2df651980325523ed22a"
     },
     "RcppProgress": {
       "Package": "RcppProgress",
@@ -1259,7 +1259,6 @@
       "RemoteSha": "d7d6569ae9e30bf774908301af312f626de4cbd5",
       "Requirements": [
         "MCMCpack",
-        "R",
         "RColorBrewer",
         "cluster",
         "dlm",
@@ -1268,7 +1267,7 @@
         "parallel",
         "parallelDist"
       ],
-      "Hash": "e356046a6ab19635791f7ce46ecd5991"
+      "Hash": "efd05c69dffe1128eb4843f3107eb606"
     },
     "corrplot": {
       "Package": "corrplot",

--- a/analyses/doublet-detection/Dockerfile
+++ b/analyses/doublet-detection/Dockerfile
@@ -69,7 +69,7 @@ RUN Rscript -e 'renv::restore()' \
   && rm -rf /tmp/Rtmp*
 
 # Complete installation of zellkonverter conda env
-ENV BASILISK_EXTERNAL_DIR /usr/local/renv/basilisk
+ENV BASILISK_EXTERNAL_DIR=/usr/local/renv/basilisk
 RUN Rscript -e "proc <- basilisk::basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = 'anndata'); \
   basilisk::basiliskStop(proc); \
   basilisk.utils::cleanConda()"


### PR DESCRIPTION
After some local testing in Docker, I think that I may be able to solve #1011 with an update to the packages that `parallelDist` relies on. 

To do this, I ran `renv::update(c("Rcpp", "RcppArmadillo", "RcppParallel"))` followed by `renv::snapshot()`.

At the moment, only the `cell-type-ETP-ALL-03` package has been updated; will update others if this works as expected in testing.

Update: I added all other failing packages, and things seem to be working now. 

As such I am now flagging this with:
closes #1011 
closes #1018 
