### PR TITLE
Fix spelling in advance of v0.2.1

### DIFF
--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -187,6 +187,7 @@ OpenScPCA's
 osteoblasts
 osteoclast
 osteoclasts
+outsized
 overclustered
 Panglao
 PanglaoDB

--- a/analyses/cell-type-consensus/exploratory-notebooks/02-explore-consensus-results.Rmd
+++ b/analyses/cell-type-consensus/exploratory-notebooks/02-explore-consensus-results.Rmd
@@ -258,7 +258,7 @@ A few observations:
 
 - Cell types identified tend to line up with expectations for the type of tumor. 
 For example, leukemia libraries have T and B cells, brain tumors have macrophages, and solid tumors have fibroblasts and muscle cells. 
-- Projects that I would expect to be more difficult to classify (sarcomas, wilms, RB) have fewer cells classified then things like brain and leukemia. 
+- Projects that I would expect to be more difficult to classify (sarcomas, Wilms, RB) have fewer cells classified then things like brain and leukemia. 
 Notably many of the solid tumor projects (4, 5, 12-16, and 23) have a handful of PDX samples where I would expect to see fewer normal cells. 
 
 ## Most frequently observed cell types 

--- a/analyses/cell-type-ewings/README.md
+++ b/analyses/cell-type-ewings/README.md
@@ -256,7 +256,7 @@ The `auc-ews-gene-signatures.tsv` file contains the following columns:
 | `barcodes`           | Unique cell barcode                                                                                                                                  |
 | `gene_set`           | The name associated with the gene set used for calculating AUC values                                                                                |
 | `auc`                | AUC value reported by running `AUCell`                                                                                                               |
-| `auc_threshold` | The threshold AUC value used to classify cells as having high expression of genes in the gene siganture as reported by `AUCell` |
+| `auc_threshold` | The threshold AUC value used to classify cells as having high expression of genes in the gene signature as reported by `AUCell` |
 
 
 ### Computational resources 

--- a/analyses/cell-type-ewings/ewings-cell-type.Rproj
+++ b/analyses/cell-type-ewings/ewings-cell-type.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: be2aaf55-5c6f-4cc1-a54b-0330df4fb278
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/analyses/cell-type-ewings/ewings-cell-type.Rproj
+++ b/analyses/cell-type-ewings/ewings-cell-type.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: be2aaf55-5c6f-4cc1-a54b-0330df4fb278
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/analyses/cell-type-ewings/exploratory_analysis/07-identify-max-rank-aucell.Rmd
+++ b/analyses/cell-type-ewings/exploratory_analysis/07-identify-max-rank-aucell.Rmd
@@ -125,7 +125,7 @@ Now we will look at the potential thresholds for `aucMaxRank` using 5% and 1% of
 The numbers printed here represent the total number of genes that would be used as the `aucMaxRank` for a given dataset using the threshold. 
 We can then use the histograms to see how many cells have at least that number of genes detected. 
 Remember, we want to pick a number of genes that are detected in most cells.
-If we picked a max rank higher than the number of genes detected in most cells, the non-detected genes that are randomly ordered would play an oversized role in our AUC values.
+If we picked a max rank higher than the number of genes detected in most cells, the non-detected genes that are randomly ordered would play an outsized role in our AUC values.
 
 ### 5%  
 

--- a/analyses/cell-type-ewings/exploratory_analysis/07-identify-max-rank-aucell.Rmd
+++ b/analyses/cell-type-ewings/exploratory_analysis/07-identify-max-rank-aucell.Rmd
@@ -12,7 +12,7 @@ This notebook is used to find the appropriate `aucMaxRank` to use with `AUCell` 
 
 From the  [`AUCell` vignette](https://bioconductor.org/packages/release/bioc/vignettes/AUCell/inst/doc/AUCell.html):
 
-> It is important to check that most cells have at least the number of expressed/detected genes that are going to be used to calculate the AUC (aucMaxRank in calcAUC()). The histogram provided by AUCell_buildRankings() allows to quickly check this distribution. 
+> It is important to check that most cells have at least the number of expressed/detected genes that are going to be used to calculate the AUC (`aucMaxRank` in `calcAUC`()). The histogram provided by `AUCell_buildRankings`() allows to quickly check this distribution. 
 
 Here we will look at a histogram showing the number of genes detected per cell for each sample and use that information to pick a threshold (percentage of genes) to use across all samples. 
 
@@ -125,7 +125,7 @@ Now we will look at the potential thresholds for `aucMaxRank` using 5% and 1% of
 The numbers printed here represent the total number of genes that would be used as the `aucMaxRank` for a given dataset using the threshold. 
 We can then use the histograms to see how many cells have at least that number of genes detected. 
 Remember, we want to pick a number of genes that are detected in most cells.
-If we picked a max rank higher than the number of genes detected in most cells, the non-detected genes that are randomly ordered would play an outsized role in our AUC values.
+If we picked a max rank higher than the number of genes detected in most cells, the non-detected genes that are randomly ordered would play an oversized role in our AUC values.
 
 ### 5%  
 

--- a/analyses/cell-type-ewings/exploratory_analysis/07-identify-max-rank-aucell.html
+++ b/analyses/cell-type-ewings/exploratory_analysis/07-identify-max-rank-aucell.html
@@ -11,7 +11,7 @@
 
 <meta name="author" content="Ally Hawkins" />
 
-<meta name="date" content="2025-01-21" />
+<meta name="date" content="2025-02-03" />
 
 <title>Identify max rank for AUCell</title>
 
@@ -352,7 +352,7 @@ display: none;
 
 <h1 class="title toc-ignore">Identify max rank for AUCell</h1>
 <h4 class="author">Ally Hawkins</h4>
-<h4 class="date">2025-01-21</h4>
+<h4 class="date">2025-02-03</h4>
 
 </div>
 
@@ -379,8 +379,9 @@ vignette</a>:</p>
 <blockquote>
 <p>It is important to check that most cells have at least the number of
 expressed/detected genes that are going to be used to calculate the AUC
-(aucMaxRank in calcAUC()). The histogram provided by
-AUCell_buildRankings() allows to quickly check this distribution.</p>
+(<code>aucMaxRank</code> in <code>calcAUC</code>()). The histogram
+provided by <code>AUCell_buildRankings</code>() allows to quickly check
+this distribution.</p>
 </blockquote>
 <p>Here we will look at a histogram showing the number of genes detected
 per cell for each sample and use that information to pick a threshold
@@ -503,7 +504,7 @@ then use the histograms to see how many cells have at least that number
 of genes detected. Remember, we want to pick a number of genes that are
 detected in most cells. If we picked a max rank higher than the number
 of genes detected in most cells, the non-detected genes that are
-randomly ordered would play an outsized role in our AUC values.</p>
+randomly ordered would play an oversized role in our AUC values.</p>
 <div id="section" class="section level3">
 <h3>5%</h3>
 <pre class="r"><code># get max rank using 1% threshold
@@ -595,28 +596,24 @@ sessionInfo()</code></pre>
 ## [1] stats4    stats     graphics  grDevices datasets  utils     methods   base     
 ## 
 ## other attached packages:
-##  [1] ggplot2_3.5.1               SingleCellExperiment_1.26.0 SummarizedExperiment_1.34.0 GenomicRanges_1.56.1       
-##  [5] GenomeInfoDb_1.40.1         MatrixGenerics_1.16.0       matrixStats_1.3.0           optparse_1.7.5             
-##  [9] GSEABase_1.66.0             graph_1.82.0                annotate_1.82.0             XML_3.99-0.17              
-## [13] AnnotationDbi_1.66.0        IRanges_2.38.1              S4Vectors_0.42.1            Biobase_2.64.0             
-## [17] BiocGenerics_0.50.0        
+##  [1] ggplot2_3.5.1               SingleCellExperiment_1.26.0 SummarizedExperiment_1.34.0 Biobase_2.64.0             
+##  [5] GenomicRanges_1.56.1        GenomeInfoDb_1.40.1         IRanges_2.38.1              S4Vectors_0.42.1           
+##  [9] BiocGenerics_0.50.0         MatrixGenerics_1.16.0       matrixStats_1.3.0          
 ## 
 ## loaded via a namespace (and not attached):
-##  [1] tidyselect_1.2.1        dplyr_1.1.4             farver_2.1.2            blob_1.2.4              Biostrings_2.72.1      
-##  [6] fastmap_1.2.0           digest_0.6.36           lifecycle_1.0.4         KEGGREST_1.44.1         RSQLite_2.3.7          
-## [11] magrittr_2.0.3          compiler_4.4.2          rlang_1.1.4             sass_0.4.9              tools_4.4.2            
-## [16] utf8_1.2.4              yaml_2.3.10             knitr_1.48              S4Arrays_1.4.1          labeling_0.4.3         
-## [21] bit_4.0.5               here_1.0.1              DelayedArray_0.30.1     abind_1.4-5             withr_3.0.0            
-## [26] purrr_1.0.2             grid_4.4.2              fansi_1.0.6             xtable_1.8-4            colorspace_2.1-1       
-## [31] scales_1.3.0            cli_3.6.3               rmarkdown_2.27          crayon_1.5.3            generics_0.1.3         
-## [36] httr_1.4.7              tzdb_0.4.0              getopt_1.20.4           DBI_1.2.3               cachem_1.1.0           
-## [41] stringr_1.5.1           zlibbioc_1.50.0         BiocManager_1.30.23     XVector_0.44.0          vctrs_0.6.5            
-## [46] Matrix_1.7-0            jsonlite_1.8.8          hms_1.1.3               patchwork_1.2.0         bit64_4.0.5            
-## [51] tidyr_1.3.1             jquerylib_0.1.4         glue_1.7.0              stringi_1.8.4           gtable_0.3.5           
-## [56] UCSC.utils_1.0.0        munsell_0.5.1           tibble_3.2.1            pillar_1.9.0            htmltools_0.5.8.1      
-## [61] GenomeInfoDbData_1.2.12 R6_2.5.1                rprojroot_2.0.4         evaluate_0.24.0         lattice_0.22-6         
-## [66] highr_0.11              readr_2.1.5             png_0.1-8               memoise_2.0.1           renv_1.0.7             
-## [71] bslib_0.8.0             SparseArray_1.4.8       xfun_0.46               pkgconfig_2.0.3</code></pre>
+##  [1] gtable_0.3.5            xfun_0.46               bslib_0.8.0             lattice_0.22-6          tzdb_0.4.0             
+##  [6] vctrs_0.6.5             tools_4.4.2             generics_0.1.3          tibble_3.2.1            fansi_1.0.6            
+## [11] highr_0.11              pkgconfig_2.0.3         Matrix_1.7-0            lifecycle_1.0.4         GenomeInfoDbData_1.2.12
+## [16] farver_2.1.2            compiler_4.4.2          stringr_1.5.1           munsell_0.5.1           htmltools_0.5.8.1      
+## [21] sass_0.4.9              yaml_2.3.10             pillar_1.9.0            crayon_1.5.3            jquerylib_0.1.4        
+## [26] DelayedArray_0.30.1     cachem_1.1.0            abind_1.4-5             tidyselect_1.2.1        digest_0.6.36          
+## [31] stringi_1.8.4           dplyr_1.1.4             purrr_1.0.2             labeling_0.4.3          rprojroot_2.0.4        
+## [36] fastmap_1.2.0           grid_4.4.2              colorspace_2.1-1        cli_3.6.3               SparseArray_1.4.8      
+## [41] magrittr_2.0.3          patchwork_1.2.0         S4Arrays_1.4.1          utf8_1.2.4              readr_2.1.5            
+## [46] withr_3.0.0             scales_1.3.0            UCSC.utils_1.0.0        rmarkdown_2.27          XVector_0.44.0         
+## [51] httr_1.4.7              hms_1.1.3               evaluate_0.24.0         knitr_1.48              rlang_1.1.4            
+## [56] glue_1.7.0              BiocManager_1.30.23     renv_1.0.7              jsonlite_1.8.8          R6_2.5.1               
+## [61] zlibbioc_1.50.0</code></pre>
 </div>
 
 

--- a/analyses/cell-type-ewings/exploratory_analysis/07-identify-max-rank-aucell.html
+++ b/analyses/cell-type-ewings/exploratory_analysis/07-identify-max-rank-aucell.html
@@ -504,7 +504,7 @@ then use the histograms to see how many cells have at least that number
 of genes detected. Remember, we want to pick a number of genes that are
 detected in most cells. If we picked a max rank higher than the number
 of genes detected in most cells, the non-detected genes that are
-randomly ordered would play an oversized role in our AUC values.</p>
+randomly ordered would play an outsized role in our AUC values.</p>
 <div id="section" class="section level3">
 <h3>5%</h3>
 <pre class="r"><code># get max rank using 1% threshold

--- a/analyses/cell-type-ewings/template_notebooks/celltype-exploration.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/celltype-exploration.Rmd
@@ -24,7 +24,7 @@ Instructions for using this guide:
 3. Update the `title` in the `yaml` section and replace the `sample_id` and `library_id` with the correct IDs in the `params` list. 
 4. Optionally, you may choose to update the choices for clustering based on the results from `evaluate-clusters.sh`. 
 All clusters used will be calculated with the Leiden algorithm and the modularity objective function. 
-To modify the nearest neighbors (default: 20) and resolution (default: 0.5) chosen use the `cluster_nn` and `cluster_res` params. 
+To modify the nearest neighbors (default: 20) and resolution (default: 0.5) chosen use the `cluster_nn` and `cluster_res` parameters. 
 5. Run through the notebook and update any sections of the notebook marked with the `{.manual-exploration}` tag. 
 6. Render the completed notebook which will produce the rendered `html` file and a TSV with cell type annotations for that library. 
 


### PR DESCRIPTION
Closes #1021 

This fixes some spelling errors found when running the spell check prior to #1007. 

Everything was pretty straight forward except I chose to keep `outsized` as a word and added it to the dictionary... Let me know if I should change that to a different word. 