### PR TITLE
Update changelog to include v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This workflow is now present in `OpenScPCA-nf`, and results will be made availab
 
 New FAQs covering how to work with ScPCA data as `Seurat` objects and using gene symbols instead of Ensembl IDs have been added to the [OpenScPCA documentation](https://openscpca.readthedocs.io/en/latest/troubleshooting-faq/faq/). 
 
+`Rcpp` packages were updated for compatibility. 
+
 ## v0.2.0
 
 This release adds the first set of community-contributed analyses to the repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This workflow is now present in `OpenScPCA-nf`, and results will be made availab
 
 New FAQs covering how to work with ScPCA data as `Seurat` objects and using gene symbols instead of Ensembl IDs have been added to the [OpenScPCA documentation](https://openscpca.readthedocs.io/en/latest/troubleshooting-faq/faq/). 
 
-`Rcpp` packages were updated for compatibility. 
+`Rcpp` package versions within modules were updated for compatibility. 
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Add new release notes in reverse numerical order (newest first) below this comme
 You may want to add temporary notes here for tracking as features are added, before a new release is ready.
 -->
 
+## v0.2.1
+
+This release includes minor updates to the following modules: 
+
+- `cell-type-ewings`
+- `cell-type-consensus`
+
+In particular, the workflow for assigning consensus cell types has been created in `cell-type-consensus` module. 
+This workflow is now present in `OpenScPCA-nf`, and results will be made available to all contributors. 
+
+New FAQs covering how to work with ScPCA data as `Seurat` objects and using gene symbols instead of Ensembl IDs have been added to the [OpenScPCA documentation](https://openscpca.readthedocs.io/en/latest/troubleshooting-faq/faq/). 
+
 ## v0.2.0
 
 This release adds the first set of community-contributed analyses to the repository.


### PR DESCRIPTION
Related to #1007 

Here I added a changelog entry for v0.2.1. There isn't a lot to report since this only includes some minor updates to the consensus and Ewing module. I mentioned that this version of the consensus module has been ported over to OpenScPCA-nf, is that okay? 

I also mentioned the addition of the Seurat and gene symbol FAQs, since I think those are relevant changes for contributors to know about. 