### PR TITLE
Add neuron to consensus cell type reference

### DIFF
--- a/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv
+++ b/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv
@@ -289,6 +289,26 @@ CL:0000359	vascular associated smooth muscle cell	Pulmonary vascular smooth musc
 CL:0000359	vascular associated smooth muscle cell	Vascular smooth muscle cells	CL:0000187	muscle cell	CL:0000187	muscle cell
 CL:0002068	Purkinje myocyte	Purkinje fiber cells	CL:0000187	muscle cell	CL:0000187	muscle cell
 CL:0000136	adipocyte	Adipocytes	CL:0000136	adipocyte	CL:0000136	adipocyte
+CL:0000109	adrenergic neuron	Adrenergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000108	cholinergic neuron	Cholinergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000166	chromaffin cell	Chromaffin cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000700	dopaminergic neuron	Dopaminergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0007011	enteric neuron	Enteric neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:1001509	glycinergic neuron	Glycinergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000099	interneuron	Interneurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000100	motor neuron	Motor neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000165	neuroendocrine cell	Neuroendocrine cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000540	neuron	Neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0008025	noradrenergic neuron	Noradrenergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000210	photoreceptor cell	Photoreceptor cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000740	retinal ganglion cell	Retinal ganglion cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000850	serotonergic neuron	Serotonergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:4023169	trigeminal neuron	Trigeminal neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000695	Cajal-Retzius cell	Cajal-Retzius cells	CL:0000540	neuron	CL:0000540	neuron
+CL:0000617	GABAergic neuron	GABAergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000679	glutamatergic neuron	Glutaminergic neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000121	Purkinje cell	Purkinje neurons	CL:0000540	neuron	CL:0000540	neuron
+CL:0000598	pyramidal neuron	Pyramidal cells	CL:0000540	neuron	CL:0000540	neuron
 CL:0000650	mesangial cell	Mesangial cells	CL:0000669	pericyte	CL:0000669	pericyte
 CL:0000669	pericyte	Pericytes	CL:0000669	pericyte	CL:0000669	pericyte
 CL:0000127	astrocyte	Astrocytes	CL:0000127	astrocyte	CL:0000127	astrocyte

--- a/analyses/cell-type-consensus/scripts/03-prepare-consensus-reference.R
+++ b/analyses/cell-type-consensus/scripts/03-prepare-consensus-reference.R
@@ -105,7 +105,7 @@ consensus_labels_df <- lca_df |>
   # everything with more than 1 lca gets removed with the exception of HSCs
   dplyr::filter(total_lca <=1 | cl_annotation == "hematopoietic precursor cell") |> 
   # keep everything with total descendants < 170 except for neuron and epithelial cell when blueprint calls it as epithelial 
-  dplyr::filter(total_descendants <= 170 | cl_annotation %in% c("neuron", "epithelial cell") & blueprint_annotation_cl == "epithelial cell") |> 
+  dplyr::filter(total_descendants <= 170 | cl_annotation == "neuron" | (cl_annotation == "epithelial cell" & blueprint_annotation_cl == "epithelial cell")) |> 
   # get rid of terms that have low number of descendants but are still too broad 
   dplyr::filter(!(cl_annotation %in% c("bone cell", "lining cell", "blood cell", "progenitor cell", "supporting cell"))) |> 
   dplyr::select(


### PR DESCRIPTION
As I was starting to work on #1033 and going through all the cell types in the consensus reference, I noticed that we didn't have `neuron` as an option, which we had previously decided we wanted to keep. Going back through the code it looks like I had an error in how I was selecting neuron. This PR makes that fix and updates the reference. 

Note that we will need to update the link to this file in [`OpenScPCA-nf`](https://github.com/AlexsLemonade/OpenScPCA-nf/blob/3725aca5b701a8a517a97ed9d3b0cdc04def3f5c/config/module_params.config#L13) and re-run this module.