### PR TITLE
Fix cell-type-wilms-tumor-06 in CI, attempt 1

### DIFF
--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -50,8 +50,10 @@ notebook_template_dir="notebook_template"
 notebook_dir="notebook"
 
 # Define test data string to use with 06_infercnv.R
+# Also, if testing, override the cell type threshold to use a larger population of normal cells
 if [[ $TESTING -eq 1 ]]; then
   test_string="--testing"
+  predicted_celltype_threshold=0.95
 else
   test_string=""
 fi
@@ -138,6 +140,9 @@ fi
 
 # Prepare gene file for inferCNV
 Rscript scripts/06a_build-geneposition.R
+
+# Prepare normal reference for inferCNV
+Rscript scripts/06b_build-normal_reference.R
 
 # Run infercnv for all samples with HMM i3 and using "both" as the reference, where possible
 for sample_dir in ${data_dir}/${project_id}/SCPCS*; do

--- a/analyses/cell-type-wilms-tumor-06/scripts/06_infercnv.R
+++ b/analyses/cell-type-wilms-tumor-06/scripts/06_infercnv.R
@@ -59,8 +59,8 @@ option_list <- list(
   ),
   make_option(
     opt_str = c("--seed"),
-    type = "character",
-    default = "12345",
+    type = "integer",
+    default = 12345,
     help = "Random seed to set"
   )
 )
@@ -179,7 +179,7 @@ if (opts$HMM == "no") {
 dir.create(output_dir, recursive = TRUE)
 
 # retrieve the gene order file created in `06a_build-geneposition.R`
-gene_arm_order_file <- file.path(module_base, "results","references", 'gencode_v38_gene_pos_arm.txt')
+gene_arm_order_file <- file.path(module_base, "results", "references", "gencode_v38_gene_pos_arm.txt")
 
 # Run infercnv ------------------------------------------------------------------
 # create inferCNV object and run method


### PR DESCRIPTION
Towards #1040 

The most recent full run of `cell-type-wilms-tumor-06` has been failing. I cannot reproduce the bug locally, including within the Docker container, but I caught some items that either _might_ be the culprit, or can help point us in the right direction which I'm addressing here:

- First, we had a seed bug in the inferCNV script where the seed was character instead of integer. 
- Second, we have a slightly more stringent threshold now for identifying normal cells to use in the inferCNV reference. I bumped this to a much less stringent threshold to use during testing only.
- Third, unrelated to bug, I noticed a script was accidentally missing from CI, so I added it!

