### PR TITLE
Save gene expression for validation markers when assigning consensus labels

### DIFF
--- a/analyses/cell-type-consensus/README.md
+++ b/analyses/cell-type-consensus/README.md
@@ -50,12 +50,12 @@ These files were obtained using the `download-data.py` script:
 ./download-data.py
 ```
 
-This script also requires three reference files, `blueprint-mapped-ontologies.tsv`, `panglao-cell-type-ontologies.tsv` and `consensus-cell-type-reference.tsv`. 
+This script also requires four reference files, `blueprint-mapped-ontologies.tsv`, `panglao-cell-type-ontologies.tsv`, `consensus-cell-type-reference.tsv`, and `validation-markers.tsv`. 
 See [Creating a reference for consensus cell types](#creating-a-reference-for-consensus-cell-types) and the [README.md in the references directory](./references/README.md) to learn more about the content of these files. 
 
 ### Output files
 
-Running the `assign-consensus-celltypes.sh` script will generate a single TSV file for each library. 
+Running the `assign-consensus-celltypes.sh` script will generate two TSV files for each library. 
 Output files will be in `results/cell-type-consensus` and organized as follows: 
 
 ```
@@ -63,7 +63,9 @@ results
 └── cell-type-consensus
     └── <project id>
         └── <sample id>
-            └── <library id>_consensus-cell-type-assignments.tsv.gz
+            ├── <library id>_consensus-cell-type-assignments.tsv.gz
+            └── <library id>_marker-gene-expression.tsv.gz
+
 ```
 
 The `<library id>_consensus-cell-type-assignments.tsv.gz` file contains cell type annotations for all cells in a single library with the following columns: 
@@ -83,6 +85,18 @@ The `<library id>_consensus-cell-type-assignments.tsv.gz` file contains cell typ
 | `blueprint_annotation_cl` | Name associated with the cell type ontology term in `singler_celltype_ontology` |
 | `consensus_ontology` | Cell type ontology term assigned as the consensus cell type | 
 | `consensus_annotation` | Name associated with the assigned consensus cell type in `consensus_ontology` | 
+
+
+The `<library id>_marker-gene-expression.tsv.gz` file contains the `logcounts` for all marker genes in [`references/validation-markers.tsv`](./references/validation-markers.tsv). 
+Only genes that are expressed in the library are included in the output. 
+
+| | | 
+| --- | --- | 
+| `library_id` | ScPCA library id | 
+| `barcodes` | cell barcode | 
+| `ensembl_gene_id` | Ensembl gene identifier for marker gene | 
+| `gene_symbol` | Gene symbol for marker gene | 
+| `gene_expression` | Gene expression for marker gene obtained from the `logcounts` assay | 
 
 ## Software requirements
 

--- a/analyses/cell-type-consensus/README.md
+++ b/analyses/cell-type-consensus/README.md
@@ -96,7 +96,7 @@ Only genes that are expressed in the library are included in the output.
 | `barcodes` | cell barcode | 
 | `ensembl_gene_id` | Ensembl gene identifier for marker gene | 
 | `gene_symbol` | Gene symbol for marker gene | 
-| `gene_expression` | Gene expression for marker gene obtained from the `logcounts` assay | 
+| `logcounts` | Gene expression for marker gene obtained from the `logcounts` assay | 
 
 ## Software requirements
 

--- a/analyses/cell-type-consensus/README.md
+++ b/analyses/cell-type-consensus/README.md
@@ -95,7 +95,6 @@ Only genes that are expressed in the library are included in the output.
 | `library_id` | ScPCA library id | 
 | `barcodes` | cell barcode | 
 | `ensembl_gene_id` | Ensembl gene identifier for marker gene | 
-| `gene_symbol` | Gene symbol for marker gene | 
 | `logcounts` | Gene expression for marker gene obtained from the `logcounts` assay | 
 
 ## Software requirements

--- a/analyses/cell-type-consensus/assign-consensus-celltypes.sh
+++ b/analyses/cell-type-consensus/assign-consensus-celltypes.sh
@@ -25,6 +25,9 @@ blueprint_ref_file="references/blueprint-mapped-ontologies.tsv"
 panglao_ref_file="references/panglao-cell-type-ontologies.tsv"
 consensus_ref_file="references/consensus-cell-type-reference.tsv"
 
+# marker gene file to use for validation 
+validation_markers_file="references/validation-markers.tsv"
+
 for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
 
   # grab sample id
@@ -40,8 +43,9 @@ for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
     # define library ID
     library_id=$(basename $sce_file | sed 's/_processed.rds$//')
 
-    # define output file 
-    output_file="${sample_results_dir}/${library_id}_consensus-cell-type-assignments.tsv.gz"
+    # define output files
+    consensus_output_file="${sample_results_dir}/${library_id}_consensus-cell-type-assignments.tsv.gz"
+    gene_exp_output_file="${sample_results_dir}/${library_id}_marker-gene-expression.tsv.gz"
     
     echo "Assigning cell types for ${library_id}"
     Rscript scripts/04-assign-consensus-celltypes.R \
@@ -49,7 +53,9 @@ for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
       --blueprint_ref_file $blueprint_ref_file\
       --panglao_ref_file $panglao_ref_file \
       --consensus_ref_file $consensus_ref_file \
-      --output_file $output_file
+      --marker_gene_file $validation_markers_file \
+      --consensus_output_file $consensus_output_file \
+      --gene_exp_output_file $gene_exp_output_file
 
   done 
 

--- a/analyses/cell-type-consensus/cell-type-consensus.Rproj
+++ b/analyses/cell-type-consensus/cell-type-consensus.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 4457211a-2ce6-497c-a0db-39d705b7138b
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/analyses/cell-type-consensus/renv.lock
+++ b/analyses/cell-type-consensus/renv.lock
@@ -76,6 +76,13 @@
       ],
       "Hash": "07a8b7f7a8a23998324a40eab02a44e7"
     },
+    "BH": {
+      "Package": "BH",
+      "Version": "1.87.0-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "468d9a03ba57f22ebde50060fd13ba9f"
+    },
     "Biobase": {
       "Package": "Biobase",
       "Version": "2.66.0",
@@ -132,6 +139,25 @@
         "utils"
       ],
       "Hash": "3aec5928ca10897d7a0a1205aae64627"
+    },
+    "BiocParallel": {
+      "Package": "BiocParallel",
+      "Version": "1.38.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "BH",
+        "R",
+        "codetools",
+        "cpp11",
+        "futile.logger",
+        "methods",
+        "parallel",
+        "snow",
+        "stats",
+        "utils"
+      ],
+      "Hash": "7b6e79f86e3d1c23f62c5e2052e848d4"
     },
     "BiocVersion": {
       "Package": "BiocVersion",
@@ -809,6 +835,21 @@
       ],
       "Hash": "73361f44874bfcecf54f7ba9238612d1"
     },
+    "beachmat": {
+      "Package": "beachmat",
+      "Version": "2.20.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "BiocGenerics",
+        "DelayedArray",
+        "Matrix",
+        "Rcpp",
+        "SparseArray",
+        "methods"
+      ],
+      "Hash": "10e94b1bce9070632a40c6b873f8b2d4"
+    },
     "bit": {
       "Package": "bit",
       "Version": "4.5.0.1",
@@ -936,6 +977,16 @@
         "utils"
       ],
       "Hash": "3f038e5ac7f41d4ac41ce658c85e3042"
+    },
+    "codetools": {
+      "Package": "codetools",
+      "Version": "0.2-20",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "61e097f35917d342622f21cdc79c256e"
     },
     "colorspace": {
       "Package": "colorspace",
@@ -1150,6 +1201,16 @@
       ],
       "Hash": "1a0a9a3d5083d0d573c4214576f1e690"
     },
+    "formatR": {
+      "Package": "formatR",
+      "Version": "1.14",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "63cb26d12517c7863f5abb006c5e0f25"
+    },
     "fs": {
       "Package": "fs",
       "Version": "1.6.5",
@@ -1160,6 +1221,29 @@
         "methods"
       ],
       "Hash": "7f48af39fa27711ea5fbd183b399920d"
+    },
+    "futile.logger": {
+      "Package": "futile.logger",
+      "Version": "1.4.3",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "futile.options",
+        "lambda.r",
+        "utils"
+      ],
+      "Hash": "99f0ace8c05ec7d3683d27083c4f1e7e"
+    },
+    "futile.options": {
+      "Package": "futile.options",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "0d9bf02413ddc2bbe8da9ce369dcdd2b"
     },
     "generics": {
       "Package": "generics",
@@ -1500,6 +1584,17 @@
         "stats"
       ],
       "Hash": "b64ec208ac5bc1852b285f665d6368b3"
+    },
+    "lambda.r": {
+      "Package": "lambda.r",
+      "Version": "1.2.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "formatR"
+      ],
+      "Hash": "b1e925c4b9ffeb901bacf812cbe9a6ad"
     },
     "later": {
       "Package": "later",
@@ -2071,6 +2166,31 @@
       ],
       "Hash": "c19df082ba346b0ffa6f833e92de34d1"
     },
+    "scuttle": {
+      "Package": "scuttle",
+      "Version": "1.16.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.20",
+      "Requirements": [
+        "BiocGenerics",
+        "BiocParallel",
+        "DelayedArray",
+        "GenomicRanges",
+        "Matrix",
+        "MatrixGenerics",
+        "Rcpp",
+        "S4Arrays",
+        "S4Vectors",
+        "SingleCellExperiment",
+        "SparseArray",
+        "SummarizedExperiment",
+        "beachmat",
+        "methods",
+        "stats",
+        "utils"
+      ],
+      "Hash": "6c56872e965b466591cb077382eb7b70"
+    },
     "shiny": {
       "Package": "shiny",
       "Version": "1.9.1",
@@ -2103,6 +2223,17 @@
         "xtable"
       ],
       "Hash": "6a293995a66e12c48d13aa1f957d09c7"
+    },
+    "snow": {
+      "Package": "snow",
+      "Version": "0.4-4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "40b74690debd20c57d93d8c246b305d4"
     },
     "sourcetools": {
       "Package": "sourcetools",

--- a/analyses/cell-type-consensus/renv.lock
+++ b/analyses/cell-type-consensus/renv.lock
@@ -173,13 +173,6 @@
       "Repository": "CRAN",
       "Encoding": "UTF-8"
     },
-    "BH": {
-      "Package": "BH",
-      "Version": "1.87.0-1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "468d9a03ba57f22ebde50060fd13ba9f"
-    },
     "Biobase": {
       "Package": "Biobase",
       "Version": "2.66.0",
@@ -413,25 +406,6 @@
       "NeedsCompilation": "yes",
       "Author": "Martin Morgan [aut, cre], Jiefei Wang [aut], Valerie Obenchain [aut], Michel Lang [aut], Ryan Thompson [aut], Nitesh Turaga [aut], Aaron Lun [ctb], Henrik Bengtsson [ctb], Madelyn Carlson [ctb] (Translated 'Random Numbers' vignette from Sweave to RMarkdown / HTML.), Phylis Atieno [ctb] (Translated 'Introduction to BiocParallel' vignette from Sweave to Rmarkdown / HTML.), Sergio Oller [ctb] (Improved bpmapply() efficiency., <https://orcid.org/0000-0002-8994-1549>)",
       "Maintainer": "Martin Morgan <mtmorgan.bioc@gmail.com>"
-    },
-    "BiocParallel": {
-      "Package": "BiocParallel",
-      "Version": "1.38.0",
-      "Source": "Bioconductor",
-      "Repository": "Bioconductor 3.19",
-      "Requirements": [
-        "BH",
-        "R",
-        "codetools",
-        "cpp11",
-        "futile.logger",
-        "methods",
-        "parallel",
-        "snow",
-        "stats",
-        "utils"
-      ],
-      "Hash": "7b6e79f86e3d1c23f62c5e2052e848d4"
     },
     "BiocVersion": {
       "Package": "BiocVersion",
@@ -2307,21 +2281,6 @@
       "Author": "Aaron Lun [aut, cre], Hervé Pagès [aut], Mike Smith [aut]",
       "Maintainer": "Aaron Lun <infinite.monkeys.with.keyboards@gmail.com>"
     },
-    "beachmat": {
-      "Package": "beachmat",
-      "Version": "2.20.0",
-      "Source": "Bioconductor",
-      "Repository": "Bioconductor 3.19",
-      "Requirements": [
-        "BiocGenerics",
-        "DelayedArray",
-        "Matrix",
-        "Rcpp",
-        "SparseArray",
-        "methods"
-      ],
-      "Hash": "10e94b1bce9070632a40c6b873f8b2d4"
-    },
     "bit": {
       "Package": "bit",
       "Version": "4.5.0.1",
@@ -2680,16 +2639,6 @@
       "License": "GPL",
       "NeedsCompilation": "no",
       "Repository": "CRAN"
-    },
-    "codetools": {
-      "Package": "codetools",
-      "Version": "0.2-20",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "61e097f35917d342622f21cdc79c256e"
     },
     "colorspace": {
       "Package": "colorspace",
@@ -3334,16 +3283,6 @@
       "Maintainer": "Yihui Xie <xie@yihui.name>",
       "Repository": "CRAN"
     },
-    "formatR": {
-      "Package": "formatR",
-      "Version": "1.14",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "63cb26d12517c7863f5abb006c5e0f25"
-    },
     "fs": {
       "Package": "fs",
       "Version": "1.6.5",
@@ -3435,29 +3374,6 @@
       "NeedsCompilation": "no",
       "Repository": "CRAN",
       "Encoding": "UTF-8"
-    },
-    "futile.logger": {
-      "Package": "futile.logger",
-      "Version": "1.4.3",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "futile.options",
-        "lambda.r",
-        "utils"
-      ],
-      "Hash": "99f0ace8c05ec7d3683d27083c4f1e7e"
-    },
-    "futile.options": {
-      "Package": "futile.options",
-      "Version": "1.0.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "0d9bf02413ddc2bbe8da9ce369dcdd2b"
     },
     "generics": {
       "Package": "generics",
@@ -4414,17 +4330,6 @@
       "NeedsCompilation": "no",
       "Repository": "CRAN",
       "Encoding": "UTF-8"
-    },
-    "lambda.r": {
-      "Package": "lambda.r",
-      "Version": "1.2.4",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "formatR"
-      ],
-      "Hash": "b1e925c4b9ffeb901bacf812cbe9a6ad"
     },
     "later": {
       "Package": "later",
@@ -6012,31 +5917,6 @@
       "Author": "Aaron Lun [aut, cre], Davis McCarthy [aut]",
       "Maintainer": "Aaron Lun <infinite.monkeys.with.keyboards@gmail.com>"
     },
-    "scuttle": {
-      "Package": "scuttle",
-      "Version": "1.16.0",
-      "Source": "Bioconductor",
-      "Repository": "Bioconductor 3.20",
-      "Requirements": [
-        "BiocGenerics",
-        "BiocParallel",
-        "DelayedArray",
-        "GenomicRanges",
-        "Matrix",
-        "MatrixGenerics",
-        "Rcpp",
-        "S4Arrays",
-        "S4Vectors",
-        "SingleCellExperiment",
-        "SparseArray",
-        "SummarizedExperiment",
-        "beachmat",
-        "methods",
-        "stats",
-        "utils"
-      ],
-      "Hash": "6c56872e965b466591cb077382eb7b70"
-    },
     "shiny": {
       "Package": "shiny",
       "Version": "1.9.1",
@@ -6127,17 +6007,6 @@
       "NeedsCompilation": "no",
       "Repository": "CRAN",
       "Encoding": "UTF-8"
-    },
-    "snow": {
-      "Package": "snow",
-      "Version": "0.4-4",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "utils"
-      ],
-      "Hash": "40b74690debd20c57d93d8c246b305d4"
     },
     "sourcetools": {
       "Package": "sourcetools",

--- a/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
+++ b/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
@@ -226,7 +226,6 @@ if(length(expressed_markers) == 0)(
     barcodes = rownames(sce),
     library_id = library_id, 
     ensembl_gene_id = NA,
-    gene_symbol = NA,
     gene_expression = NA, 
     validation_group_annotation = NA,
     validation_group_ontology = NA

--- a/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
+++ b/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
@@ -238,14 +238,12 @@ if(length(expressed_markers) == 0)(
     sce, 
     features = expressed_markers, 
     assay.type = "logcounts",
+    use.coldata = "barcodes",
     use.dimred = FALSE
   ) |>
     tidyr::pivot_longer(starts_with("ENSG"), names_to = "ensembl_gene_id", values_to = "logcounts") |> 
-    # only pull out relevant columns
-    dplyr::select(barcodes, ensembl_gene_id, logcounts) |> 
     # add library id column
-    dplyr::mutate(library_id = library_id) |> 
-    dplyr::relocate(library_id, .before = 0)
+    dplyr::mutate(library_id = library_id, .before = 0)
   
 }
 

--- a/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
+++ b/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
@@ -20,7 +20,6 @@
 # library_id
 # barcodes
 # ensembl_gene_id
-# gene_symbol
 # gene_expression
 
 library(optparse)
@@ -240,10 +239,14 @@ if(length(expressed_markers) == 0)(
     sce, 
     features = expressed_markers, 
     assay.type = "logcounts",
-    use.coldata = c("libary_id", "barcodes"),
     use.dimred = FALSE
   ) |>
-  tidyr::pivot_longer(starts_with("ENSG"), names_to = "ensembl_gene_id", values_to = "logcounts")
+    tidyr::pivot_longer(starts_with("ENSG"), names_to = "ensembl_gene_id", values_to = "logcounts") |> 
+    # only pull out relevant columns
+    dplyr::select(barcodes, ensembl_gene_id, logcounts) |> 
+    # add library id column
+    dplyr::mutate(library_id = library_id) |> 
+    dplyr::relocate(library_id, .before = 0)
   
 }
 

--- a/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
+++ b/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
@@ -13,6 +13,16 @@
 # consensus_annotation: human readable name associated with the consensus label
 # consensus_ontology: CL ontology term for the consensus cell type
 
+# optionally, an additional TSV file containing the expression for a set of marker genes is saved
+# the `logcounts` for all genes in `ensembl_gene_id` column of the `marker_gene_file` will be saved to the output file
+
+# output TSV columns
+# library_id
+# barcodes
+# ensembl_gene_id
+# gene_symbol
+# gene_expression
+
 library(optparse)
 
 option_list <- list(
@@ -37,9 +47,21 @@ option_list <- list(
     help = "Path to file containing the reference for assigning consensus cell type labels"
   ),
   make_option(
-    opt_str = c("--output_file"),
+    opt_str = c("--marker_gene_file"),
     type = "character",
-    help = "Path to file where combined TSV file will be saved.
+    help = "Path to file containing a table of marker genes.
+     The logcounts for all genes in the `ensembl_gene_id` column that are expressed in the input SCE will be saved." 
+  ),
+  make_option(
+    opt_str = c("--consensus_output_file"),
+    type = "character",
+    help = "Path to file where TSV file containing consensus cell types will be saved.
+      File name must end in either `.tsv` or `.tsv.gz` to save a compressed TSV file"
+  ),
+  make_option(
+    opt_str = c("--gene_exp_output_file"),
+    type = "character",
+    help = "Path to file where TSV file containing marker gene expression will be saved.
       File name must end in either `.tsv` or `.tsv.gz` to save a compressed TSV file"
   )
 )
@@ -55,13 +77,23 @@ stopifnot(
   "blueprint reference file does not exist" = file.exists(opt$blueprint_ref_file),
   "panglao reference file does not exist" = file.exists(opt$panglao_ref_file),
   "cell type consensus reference file does not exist" = file.exists(opt$consensus_ref_file),
-  "output file must end in `.tsv` or `.tsv.gz`" = stringr::str_ends(opt$output_file, "\\.tsv|\\.tsv\\.gz")
+  "marker gene file does not exist" = file.exists(opt$marker_gene_file),
+  "consensus output file must end in `.tsv` or `.tsv.gz`" = stringr::str_ends(opt$consensus_output_file, "\\.tsv|\\.tsv\\.gz"),
+  "gene expression output file must end in `.tsv` or `.tsv.gz`" = stringr::str_ends(opt$gene_exp_output_file, "\\.tsv|\\.tsv\\.gz")
 )
 
 # load SCE
 suppressPackageStartupMessages({
   library(SingleCellExperiment)
 })
+
+# read in file
+markers_df <- readr::read_tsv(opt$marker_gene_file)
+
+#check that ensembl gene id is present
+stopifnot(
+  "ensembl_gene_id column is missing from marker gene file" = "ensembl_gene_id" %in% colnames(markers_df)
+)
 
 # Extract colData --------------------------------------------------------------
 
@@ -147,7 +179,7 @@ consensus_ref_df <- readr::read_tsv(opt$consensus_ref_file) |>
 # grab blueprint ref 
 blueprint_df <- readr::read_tsv(opt$blueprint_ref_file)
 
-# Create combined TSV ----------------------------------------------------------
+# Create consensus TSV ---------------------------------------------------------
 
 all_assignments_df <- celltype_df |> 
   # add columns for panglao ontology and consensus
@@ -169,4 +201,55 @@ all_assignments_df <- celltype_df |>
   dplyr::mutate(consensus_annotation = dplyr::if_else(is.na(consensus_annotation) & (sample_type != "cell line"), "Unknown", consensus_annotation))
 
 # export file
-readr::write_tsv(all_assignments_df, opt$output_file)
+readr::write_tsv(all_assignments_df, opt$consensus_output_file)
+
+# Save gene expression file ----------------------------------------------------
+
+
+# list of all marker genes
+all_markers <- markers_df |> 
+  dplyr::pull(ensembl_gene_id) |> 
+  unique()
+
+# we only care about if that gene is expressed otherwise we wont' waste memory and include it
+expressed_genes <- rowData(sce) |> 
+  as.data.frame() |>
+  dplyr::filter(detected > 0) |> 
+  dplyr::pull(gene_ids)
+
+# get markers that are expressed
+expressed_markers <- intersect(all_markers, expressed_genes)
+
+# if no markers are found, fill in columns with NA
+if(length(expressed_markers) == 0)(
+  
+  gene_exp_df <- data.frame(
+    barcodes = rownames(sce),
+    library_id = library_id, 
+    ensembl_gene_id = NA,
+    gene_symbol = NA,
+    gene_expression = NA, 
+    validation_group_annotation = NA,
+    validation_group_ontology = NA
+  )
+  
+) else {
+  
+  # get logcounts from sce for expressed genes 
+  gene_exp_df <- logcounts(sce[expressed_markers, ]) |> 
+    as.matrix() |> # need this before converting to a dataframe
+    t() |> 
+    as.data.frame() |> 
+    tibble::rownames_to_column("barcodes") |> 
+    # collapse expression into one column
+    tidyr::pivot_longer(!barcodes, names_to = "ensembl_gene_id", values_to = "gene_expression") |> 
+    # add in library id and make it the first column
+    dplyr::mutate(
+      library_id = library_id
+    ) |> 
+    dplyr::relocate(library_id, .before = 0)
+  
+}
+
+# export the file 
+readr::write_tsv(gene_exp_df, opt$gene_exp_output_file)

--- a/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
+++ b/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
@@ -13,7 +13,7 @@
 # consensus_annotation: human readable name associated with the consensus label
 # consensus_ontology: CL ontology term for the consensus cell type
 
-# optionally, an additional TSV file containing the expression for a set of marker genes is saved
+# An additional TSV file containing the expression for a set of marker genes is saved
 # the `logcounts` for all genes in `ensembl_gene_id` column of the `marker_gene_file` will be saved to the output file
 
 # output TSV columns

--- a/analyses/cell-type-consensus/scripts/README.md
+++ b/analyses/cell-type-consensus/scripts/README.md
@@ -19,6 +19,7 @@ If the combination is not included in the reference file, then no consensus cell
 
 5. `04-assign-consensus-celltypes.R`: This script is used to grab the existing cell type annotations from the `colData` of an individual processed SCE object and assign the appropriate consensus cell type based on the `singler_celltype_ontology` (`BlueprintEncodeData`) and the `cellassign_celltype_ontology` (`PanglaoDB`). 
 All annotations, including the consensus annotation, are then saved to a TSV file. 
+An additional TSV file containing the gene expression for all marker genes found in `references/validation-markers.tsv` will also be saved. 
 
 6. `00-download-cellmarker-ref.sh`: This script is used to download the [marker genes for all Human tissues from `CellMarker2.0`](http://117.50.127.228/CellMarker/CellMarker_download.html). 
 This file will be stored in `references/Cell_markers_Human.xlsx`. 


### PR DESCRIPTION
### Purpose/implementation Section
#### Please link to the GitHub issue that this pull request addresses.

Towards #1033 

#### What is the goal of this pull request?

Before I can actually make any plots to validate marker gene expression in assigned cell types, I need to be able to get the gene expression for all of the genes in [validation-markers.tsv](https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/main/analyses/cell-type-consensus/references/validation-markers.tsv) across all samples. 

#### Briefly describe the general approach you took to achieve this goal.

I thought the quickest way to do this was to modify the existing workflow for assigning consensus cell types to also output a file with the `logcounts` for all the marker genes. Then I can read in all of the individual files to create a larger data frame that I can use to create the validation plots just like we do for the consensus cell type assignments.

- I modified the existing script for assigning consensus cell types to also take as input a marker gene file. Now both the consensus output TSV is saved along with the gene expression TSV. I originally had this as a separate script, but the most time consuming part is reading in the SCE object and I felt it was silly to have to read in the SCE object twice for every library?
- The output TSV file has a columns for library ID, barcodes, ensemble id, gene symbol, and gene expression, where gene expression is from the `logcounts `of the SCE. Note that I do not include the other columns from the `validation-markers.tsv`, such as the validation annotation and ontology. This is because many marker genes are present multiple times and I don't think we need to store information for a given gene more than once. 
- All genes in `validation-markers.tsv` that are also expressed in the SCE object are included in the output. 

#### If known, do you anticipate filing additional pull requests to complete this analysis module?

Yes. 
I plan on running this through a couple of projects and then moving to a notebook where I'll read in the gene expression TSVs and consensus TSVs and create the validation plots mentioned in #1033. 

### Results

#### What is the name of your results bucket on S3?

I haven't actually run this through more than just one project, but once approved, I plan to run it through a few projects and use that to get started on making the plots. At that point, I'll add results to S3 when appropriate.  

#### What types of results does your code produce (e.g., table, figure)?

TSV file with columns for library ID, barcodes, ensemble id, gene symbol, and gene expression, where gene expression is from the `logcounts `of the SCE. 

#### What is your summary of the results?

Coming next! 


### Provide directions for reviewers

#### Are there particularly areas you'd like reviewers to have a close look at?

Are we okay with this happening within the same script that saves the consensus labels?

### Author checklists

_Check all those that apply._
_Note that you may find it easier to check off these items after the pull request is actually filed._


#### Analysis module and review

- [ ] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [x] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [ ] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [x] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
