### PR TITLE
Patches for cell-type-wilms-tumor-06

### DIFF
--- a/.github/workflows/run_cell-type-wilms-tumor-06.yml
+++ b/.github/workflows/run_cell-type-wilms-tumor-06.yml
@@ -55,7 +55,8 @@ jobs:
           # These samples were selected either because:
           # - they are the subset of samples explored when evaluating CNV methods, so they must be present to run the module workflow in full if that is ever specified
           # - they do not use a reference with inferCNV so we would like to test that they are properly handled
-          DOWNLOAD_FLAG: ${{ github.event_name != 'pull_request' && '--projects SCPCP000006' || '--samples SCPCS000179,SCPCS000184,SCPCS000194,SCPCS000205,SCPCS000208,SCPCS000177,SCPCS000190' }}
+          # - they have been known to cause CI failures in edge cases
+          DOWNLOAD_FLAG: ${{ github.event_name != 'pull_request' && '--projects SCPCP000006' || '--samples SCPCS000173,SCPCS000179,SCPCS000184,SCPCS000194,SCPCS000205,SCPCS000208,SCPCS000177,SCPCS000190' }}
         run: |
           ./download-data.py --test-data --format SCE ${DOWNLOAD_FLAG}
           ./download-data.py --test-data --metadata-only --projects SCPCP000006

--- a/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
+++ b/analyses/cell-type-wilms-tumor-06/00_run_workflow.sh
@@ -137,7 +137,7 @@ if [[ $RUN_EXPLORATORY -eq 1 ]]; then
 fi
 
 # Prepare gene file for inferCNV
-Rscript scripts/06a_build-geneposition.R
+Rscript scripts/06a_build-geneposition.R ${test_string}
 
 # Run infercnv for all samples with HMM i3 and using "both" as the reference, where possible
 for sample_dir in ${data_dir}/${project_id}/SCPCS*; do

--- a/analyses/cell-type-wilms-tumor-06/scripts/06a_build-geneposition.R
+++ b/analyses/cell-type-wilms-tumor-06/scripts/06a_build-geneposition.R
@@ -11,8 +11,8 @@ module_base <- file.path(repository_base, "analyses", "cell-type-wilms-tumor-06"
 reference_dir <- file.path(module_base, "results", "references")
 
 # URLs for data to download
-gtf_file_uri <- "s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.gtf.gz"
-arm_order_file_url <- "http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/cytoBand.txt.gz"
+gtf_file_url <- "https://ftp.ensembl.org/pub/release-104/gtf/homo_sapiens/Homo_sapiens.GRCh38.104.gtf.gz"
+arm_order_file_url <- "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/cytoBand.txt.gz"
 
 # Define the gene order file
 gtf_file <- file.path(reference_dir, "Homo_sapiens.GRCh38.104.gtf.gz")
@@ -25,9 +25,7 @@ gene_arm_order_file <- file.path(reference_dir, "gencode_v38_gene_pos_arm.txt")
 
 # Download files if they don't exist --------------------
 if (!file.exists(gtf_file)) {
-  system(
-    glue::glue("aws s3 cp {gtf_file_uri} {gtf_file} --no-sign-request")
-  )
+  download.file(url = gtf_file_url, destfile = gtf_file)
 }
 if (!file.exists(arm_order_file)) {
   download.file(url = arm_order_file_url, destfile = arm_order_file)
@@ -85,12 +83,14 @@ combined_df <- gene_order_df %>%
   # create chrom_arm column
   mutate(chrom_arm = glue::glue("{chrom}{arm}")) %>%
   # Define chromosome arm order
-  mutate(chrom_arm = factor(chrom_arm, levels = c(paste0("chr", rep(1:22, each = 2), c("p", "q")),
-                                                  "chrXp", "chrXq", "chrYp", "chrYq"))) %>%
+  mutate(chrom_arm = factor(chrom_arm, levels = c(
+    paste0("chr", rep(1:22, each = 2), c("p", "q")),
+    "chrXp", "chrXq", "chrYp", "chrYq"
+  ))) %>%
   # Sort genes by Chromosome arm and Start position
-  arrange(chrom_arm, gene_start)  %>%
+  arrange(chrom_arm, gene_start) %>%
   # Select only relevant column for infercnv
-  select(ensembl_id, chrom_arm, gene_start, gene_end) 
+  select(ensembl_id, chrom_arm, gene_start, gene_end)
 
 
 # Export --------------


### PR DESCRIPTION
Closes #1040 
Closes #1053 

This PR implements 1 bug fix and 1 GHA fix in the cell-type-wilms-tumor-06 module.

### Bug fix (#1040)

inferCNV was failing on a test data sample because the Bugs MCMC was not detecting any CNV regions. There is no way to check for this, since its a fully internal step within a single command to run inferCNV and the information can't be known _a priori_. To get around this in CI, I updated the chromosome regions file that we use for inferCNV when in CI. We recently updated this chromosome file to also consider `p` and `q` arms to nail down some CNVs more carefully, but this wasn't playing nicely with test data. So, in CI, we should just not consider the arms since the sample sizes get to small to run inferCNV reliably through.


### Other fix (#1053)

Recently, we had updated the reference files used to create that very chromosome regions file to ensure we're using a genome reference that matches scpca-nf. Originally in my reviews, I suggested to just grab this from our S3 bucket. But, I realized while diagnosing the other bug, this runs in CI only by accident since the GHA installed `awscli` to run `download-data.py`, but the code would fail in a standalone Docker container. So, the plan for #1053 was to add this awscli dependency into Docker. When I went to start that though, I thought that ehhh maybe that's not the move since fewer dependencies are better, and I just swapped in the Ensembl link for the same file so we avoid `awscli` altogether.