### PR TITLE
Monthly spellcheck fixes

### DIFF
--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -28,6 +28,7 @@ Bhasin
 Bioconda
 Bioconductor
 bioinformatics
+bioRxiv
 Biostars
 blastema
 blastemal
@@ -53,8 +54,10 @@ containerd
 CopyKAT
 CPM
 CRediT
+Cresswell
 Crompton
 Ctrl
+cytoband
 cxds
 demultiplexing
 dendogram
@@ -152,6 +155,7 @@ linter
 linter's
 linters
 lockfile
+LOH
 Looney
 louvain
 LSfR
@@ -171,6 +175,7 @@ microRNA
 midline
 Miniconda
 Miniforge
+misclassifying
 misidentification
 modularity
 monocyte
@@ -255,9 +260,11 @@ seq
 sina
 SingleCellExperiment
 SingleR
+SIOP
 snRNA
 socio
 Spearman
+specificities
 SSO
 stemness
 stroma
@@ -304,3 +311,4 @@ YAML
 Zappia
 Zenodo
 Zhang
+Zheng

--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -28,7 +28,6 @@ Bhasin
 Bioconda
 Bioconductor
 bioinformatics
-bioRxiv
 Biostars
 blastema
 blastemal

--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -41,6 +41,7 @@ chemotherapies
 chondrocyte
 chondrocytes
 chr
+CDH
 CLI
 Cmd
 CNA
@@ -159,6 +160,7 @@ LOH
 Looney
 louvain
 LSfR
+LTL
 macOS
 macrophage
 md
@@ -187,6 +189,7 @@ multifactor
 multinucleated
 myeloid
 natively
+NCAM
 Nextflow
 nephroblastoma
 nephron
@@ -220,6 +223,7 @@ PMID
 PNG
 podman
 podocyte
+PODXL
 Posit
 Posit's
 PowerShell
@@ -228,6 +232,7 @@ pre
 preprint
 PRs
 pseudobulk
+PTPRC
 README
 redistribution
 redistributions
@@ -300,6 +305,7 @@ vCPUs
 Visser
 vitro
 VSCodium
+VWF
 Wilms
 WIPO
 WisCon

--- a/analyses/cell-type-consensus/exploratory-notebooks/README.md
+++ b/analyses/cell-type-consensus/exploratory-notebooks/README.md
@@ -1,36 +1,36 @@
 # Exploratory notebooks
 
-This folder contains exploratory notebooks for this module. 
+This folder contains exploratory notebooks for this module.
 
-1. `01-reference-exploration.Rmd`: This notebook was used to explore possible consensus label assignments between cell types in the `PanglaoDB` and `BlueprintEncodeData` references. 
-Observations made in this notebook were used to define the set of possible consensus labels to be included in [`references/consensus-cell-type-reference.tsv`](../references/consensus-cell-type-reference.tsv). 
+1. `01-reference-exploration.Rmd`: This notebook was used to explore possible consensus label assignments between cell types in the `PanglaoDB` and `BlueprintEncodeData` references.
+Observations made in this notebook were used to define the set of possible consensus labels to be included in [`references/consensus-cell-type-reference.tsv`](../references/consensus-cell-type-reference.tsv).
 
-2. `02-explore-consensus-results.Rmd`: This notebook summarizes the consensus labels assigned to all ScPCA samples. 
-Prior to rendering this notebook results from the `cell-type-consensus` module in `OpenScPCA-nf` using the `2024-11-25` were downloaded. 
+2. `02-explore-consensus-results.Rmd`: This notebook summarizes the consensus labels assigned to all ScPCA samples.
+Prior to rendering this notebook results from the `cell-type-consensus` module in `OpenScPCA-nf` using the `2024-11-25` were downloaded.
 
-3. `03-osteosarcoma-consensus-celltypes.Rmd`: This notebook summarizes the consensus labels assigned to projects with Osteosarcoma samples. 
+3. `03-osteosarcoma-consensus-celltypes.Rmd`: This notebook summarizes the consensus labels assigned to projects with Osteosarcoma samples.
 
-4. `04-brain-and-cns-consensus-celltypes.Rmd`: This notebook summarizes the consensus labels assigned to all samples belonging to projects with Brain and CNS tumors, excluding any samples that are part of multiplexed libraries. 
+4. `04-brain-and-cns-consensus-celltypes.Rmd`: This notebook summarizes the consensus labels assigned to all samples belonging to projects with Brain and CNS tumors, excluding any samples that are part of multiplexed libraries.
 
-5. `05-marker-gene-validation.Rmd`: This notebook looks at marker gene expression of markers in [references/validation-markers.tsv](../references/validation-markers.tsv) across consensus cell types for `SCPCP000001`. 
+5. `05-marker-gene-validation.Rmd`: This notebook looks at marker gene expression of markers in [`references/validation-markers.tsv`](../references/validation-markers.tsv) across consensus cell types for `SCPCP000001`.
 
 ## Cell type validation notebooks
 
-The `cell-type-validation-notebooks` contains the rendered reports summarizing expression of cell type marker genes in the consensus cell types. 
-There is one file for each project and the reports are rendered from the template notebook in `template-notebooks/marker-gene-validation.Rmd`. 
+The `cell-type-validation-notebooks` contains the rendered reports summarizing expression of cell type marker genes in the consensus cell types.
+There is one file for each project and the reports are rendered from the template notebook in `template-notebooks/marker-gene-validation.Rmd`.
 
-To render all reports you will need to first download the results from the `cell-type-consensus` module in `OpenScPCA-nf` using the download results script from the root of this repository: 
+To render all reports you will need to first download the results from the `cell-type-consensus` module in `OpenScPCA-nf` using the download results script from the root of this repository:
 
 ```sh
 ./download-results.py --module cell-type-consensus
 ```
 
-Then you can render the reports using the `render-validation-notebooks.sh` script. 
+Then you can render the reports using the `render-validation-notebooks.sh` script.
 
 ```sh
 ./render-validation-groups.sh
 ```
 
-## Utils 
+## Utils
 
-The `utils` folder contains scripts with any functions that are used by multiple notebooks. 
+The `utils` folder contains scripts with any functions that are used by multiple notebooks.

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -675,7 +675,8 @@ We those check the repartition of CNV in samples that have been pre-treated (i.e
 do_BoxPlot_mean(df = cell_type_df_sub, group.by = "treatment", comparison = c("Upfront resection", "Resection post chemotherapy"))
 ```
 
-Our analysis suggest that there is indeed an enrichment in cells with CNV after chemotherapy, including a tendency of more *chr1q* gain samples after chemotherapy. This could explain some of the differences observed between our mean CNV profile and the one published in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
+Our analysis suggest that there is indeed an enrichment in cells with CNV after chemotherapy, including a tendency of more *chr1q* gain samples after chemotherapy. 
+This could explain some of the differences observed between our mean CNV profile and the one published in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
 
 ### Validation of second level annotation using marker genes
 

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -27,7 +27,8 @@ knitr::opts_chunk$set(
 
 ## Introduction
 
-The aim is to combine label transfer and CNV inference to annotate Wilms tumor samples in SCPCP000006. The proposed annotation will be based on the combination of:
+The aim is to combine label transfer and CNV inference to annotate Wilms tumor samples in SCPCP000006.
+The proposed annotation will be based on the combination of:
 
 - the label transfer from the fetal kidney reference (Stewart et al.), in particular the `fetal_kidney_predicted.compartment` and `fetal_kidney:predicted.cell_type`, as well as the `prediction.score` for each compartment,
 
@@ -101,12 +102,12 @@ sample_metadata_file <- file.path(repository_base, "data", "current", "SCPCP0000
 metadata <- read.table(sample_metadata_file, sep = "\t", header = TRUE)
 ```
 
-From the pre-processed and labeled `Seurat` object from `results/{sample_id}/06_infercnv_HMM-i3_{sample_id}_reference-{reference}.rds`, we will extract the following information per cell:
+From the pre-processed and labeled `Seurat` object in `results/{sample_id}/06_infercnv_HMM-i3_{sample_id}_reference-{reference}.rds`, we will extract the following per-cell information:
 
 - the predicted compartment in `fetal_kidney_predicted.compartment` and `fetal_kidney_predicted.compartment.score`
 - the predicted cell type in `fetal_kidney_predicted.cell_type` and `fetal_kidney_predicted.cell_type.score`
 - the sample identifier in `sample_id`
-- the CNV `{dupli|loss}` estimate per chromosome `{i}`, where `i \in {1-22}`, and arm `{p|q}`: `has_{dupli|loss}_chr{i}{p|q}`
+- the CNV `{dupli|loss}` estimate per chromosome `{i}`, where `i` is in `{1-22}`, and arm `{p|q}`: `has_{dupli|loss}_chr{i}{p|q}`
 - the `counts` of [markers genes](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-wilms-tumor-06#the-table-celltype_metadatacsv-contains-the-following-column-and-information)
 
 ```{r path_to_query}
@@ -324,7 +325,7 @@ At first, we like to indicate in the `first.level_annotation` if a cell is norma
 
 We only allow a bit of flexibility in terms of CNV profile for immune and endothelium cells that have a high predicted score. 
 Indeed, we know that false positive CNV can be observed in a cell type specific manner. 
-Please note that in `06_infercnv.R`, we renamed all `immune` and `endothelium` cells with a `fetal_kidney_predicted.compartment.score` \> `r params$predicted.celltype.threshold` as `normal`.
+Please note that in `06_infercnv.R`, we renamed all `immune` and `endothelium` cells with a `fetal_kidney_predicted.compartment.score` > `r params$predicted.celltype.threshold` as `normal`.
 
 The threshold used for the `predicted.score` is defined as a parameter of this notebook as `r params$predicted.celltype.threshold`. 
 The thresholds used for the identification of CNV are also defined as notebook parameters with a minimum of `r params$cnv_threshold_low` and a maximum of `r params$cnv_threshold_high`.
@@ -398,7 +399,7 @@ Wilms tumor cancer cells can be:
 - *cancer stroma*: We define as *cancer stroma* all cancer cells from the stroma compartment.
 - *blastema*: We defined as *blastema* every cancer cell that has a `fetal_kidney_predicted.cell_type == mesenchymal cell`. 
 We know that these *mesenchymal* cells are cells from the cap mesenchyme that are not expected to be in a mature kidney. 
-These blastema cells should express higher `CITED1` and/or `NCAM1`.
+These blastema cells should express higher *CITED1* and/or *NCAM1*.
 - *cancer epithelium*: We defined as *cancer epithelium* all cancer cells that are neither stroma nor blastemal cells. 
 We expect these cells to express epithelial markers. 
 Their predicted cell type should correspond to more mature kidney epithelial subunits.
@@ -707,7 +708,7 @@ They should express in some extend similar markers as normal stromal cells inclu
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000026025")
 ```
 
-*VIM* do not seem to be neither specific nor universal.
+*VIM* expression does not seem to be either specific or universal.
 
 ##### `COL6A3` expression
 
@@ -723,12 +724,12 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000154096")
 ```
 
-*THY1* do not seem to be neither specific nor universal.
+*THY1* expression does not seem to be either specific or universal.
 
 #### Blastema
 
 (\*) To the best of our knowledge, there is no Wilms tumor specific and universal (i.e. expressed by all cells in every sample) marker of blastema cells. 
-We expect however blastema cells to express higher levels of stemness markers such as `CITED1`, `SIX1/2`, `NCAM1`.
+We expect however blastema cells to express higher levels of stemness markers such as *CITED1*, *SIX1/2*, *NCAM1*.
 
 ##### `CITED1` expression
 
@@ -736,7 +737,7 @@ We expect however blastema cells to express higher levels of stemness markers su
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000125931")
 ```
 
-Blastema cells are enriched in `CITED1+` cells, but some samples do not express it at all.
+Blastema cells are enriched in *CITED1+* cells, but some samples do not express it at all.
 
 ##### `NCAM1` expression
 
@@ -744,7 +745,7 @@ Blastema cells are enriched in `CITED1+` cells, but some samples do not express 
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000149294")
 ```
 
-`NCAM1` seems to be more cancer specific and broadly expressed among samples.
+*NCAM1* seems to be more cancer specific and broadly expressed among samples.
 
 ##### `SIX2` expression
 
@@ -760,7 +761,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000039068")
 ```
 
-As expected, epithelial cells express higher expression of `CDH1`.
+As expected, epithelial cells express higher expression of *CDH1*.
 
 ##### `PODXL` expression
 
@@ -806,7 +807,7 @@ length(unique(annotations_table$scpca_sample_id))
 - Combining label transfer and CNV inference we have produced draft annotations for 35/40 Wilms tumor samples in SCPCP000006. 
 We decided not to annotate samples for which the `infercnv` couldn't be run with a normal reference, as we don't trust the results in that case and want to avoid misclassification (`SCPCS000177`, `SCPCS000180`, `SCPCS000181`, `SCPCS000190`, `SCPCS000197`).
 
-- The mean CNV profile of the Wilms tumor cohort seems reasonable in regards to the one published in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
+- The mean CNV profile of the Wilms tumor cohort seems reasonable in regards to the one published in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
 We identify some commonalities but also some divergence. 
 They can be due to technical limitation of our CNV inference but can also reflect some specificities of this cohort (e.g. pre/post treatment samples). 
 It would be really useful to compare for some sample the `infercnv` result to a ground truth such as SNP Array (to be requested).

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -29,11 +29,11 @@ knitr::opts_chunk$set(
 
 The aim is to combine label transfer and CNV inference to annotate Wilms tumor samples in SCPCP000006. The proposed annotation will be based on the combination of:
 
--   the label transfer from the fetal kidney reference (Stewart et al.), in particular the `fetal_kidney_predicted.compartment` and `fetal_kidney:predicted.cell_type`, as well as the `prediction.score` for each compartment,
+- the label transfer from the fetal kidney reference (Stewart et al.), in particular the `fetal_kidney_predicted.compartment` and `fetal_kidney:predicted.cell_type`, as well as the `prediction.score` for each compartment,
 
--   the predicted CNV calculated using intra-sample endothelial and immune cells (`--reference both`) as normal reference; no reference was used for samples with fewer than 3 predicted normal cells.
+- the predicted CNV calculated using intra-sample endothelial and immune cells (`--reference both`) as normal reference; no reference was used for samples with fewer than 3 predicted normal cells.
 
-In a second time, we will explore and validate the chosen annotation.
+We will then explore and validate the chosen annotation.
 
 We will use some of the [markers genes](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-wilms-tumor-06#the-table-celltype_metadatacsv-contains-the-following-column-and-information) to validate visually the annotations.
 
@@ -52,11 +52,9 @@ The analysis can be summarized as the following:
 
 with the defined parameters:
 
--   `pred.thr` = `r params$predicted.celltype.threshold`
-
--   `cnv.thr.lower` = `r params$cnv_threshold_low`
-
--   `cnv.thr.upper` = `r params$cnv_threshold_high`
+- `pred.thr` = `r params$predicted.celltype.threshold`
+- `cnv.thr.lower` = `r params$cnv_threshold_low`
+- `cnv.thr.upper` = `r params$cnv_threshold_high`
 
 ### Packages
 
@@ -84,7 +82,8 @@ result_dir <- file.path(module_base, "results")
 
 ### Output files
 
-The report will be saved in the `notebook` directory. The final annotation file `SCPCP000006-annotations.tsv` will be saved in the `results` directory.
+The report will be saved in the `notebook` directory. 
+The final annotation file `SCPCP000006-annotations.tsv` will be saved in the `results` directory.
 
 ```{r}
 # cell type annotation table
@@ -94,7 +93,6 @@ annotations_tsv <- file.path(result_dir, "SCPCP000006-annotations.tsv")
 ### Input files
 
 In this notebook, we are working with all of the samples in SCPCP000006.
-
 The sample metadata can be found in `sample_metadata_file` in the `data` folder.
 
 ```{r }
@@ -103,17 +101,13 @@ sample_metadata_file <- file.path(repository_base, "data", "current", "SCPCP0000
 metadata <- read.table(sample_metadata_file, sep = "\t", header = TRUE)
 ```
 
-We extracted from the pre-processed and labeled `Seurat` object from `results/{sample_id}/06_infercnv_HMM-i3_{sample_id}_reference-{reference}.rds`. the following information per cell:
+From the pre-processed and labeled `Seurat` object from `results/{sample_id}/06_infercnv_HMM-i3_{sample_id}_reference-{reference}.rds`, we will extract the following information per cell:
 
--   the predicted compartment in `fetal_kidney_predicted.compartment` and `fetal_kidney_predicted.compartment.score`
-
--   the predicted cell type in `fetal_kidney_predicted.cell_type` and `fetal_kidney_predicted.cell_type.score`
-
--   the sample identifier in `sample_id`
-
--   the CNV `{dupli|loss}` estimation per chromosome {i} and arm `{p|q}`: `has_{dupli|loss}_chr{i}{p|q}`, in 1 to 22
-
--   the `counts` of [markers genes](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-wilms-tumor-06#the-table-celltype_metadatacsv-contains-the-following-column-and-information)
+- the predicted compartment in `fetal_kidney_predicted.compartment` and `fetal_kidney_predicted.compartment.score`
+- the predicted cell type in `fetal_kidney_predicted.cell_type` and `fetal_kidney_predicted.cell_type.score`
+- the sample identifier in `sample_id`
+- the CNV `{dupli|loss}` estimation per chromosome {i} and arm `{p|q}`: `has_{dupli|loss}_chr{i}{p|q}`, in 1 to 22
+- the `counts` of [markers genes](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-wilms-tumor-06#the-table-celltype_metadatacsv-contains-the-following-column-and-information)
 
 ```{r path_to_query}
 # Extract from each Seurat object information that will be used
@@ -188,15 +182,15 @@ cell_type_df <- sample_ids |>
 
 We will also use:
 
--   the samples metadata or clinical data reported in `r file.path(repository_base, "data", "current", "SCPCP000006", "single_cell_metadata.tsv")`
+- the samples metadata or clinical data reported in `r file.path(repository_base, "data", "current", "SCPCP000006", "single_cell_metadata.tsv")`
+- the cytoband file to get the length of each chromosome arm (for plotting only)
 
-```{r }
+```{r metadata}
 # Add clinical metadata
 cell_type_df <- cell_type_df |>
   left_join(metadata, by = c("sample_id" = "scpca_sample_id"))
 ```
 
--   the cytoband file to get the length of each chromosome arm (for plotting only)
 
 ```{r input}
 # the cytoband file that will be used to extract the size of each chromosome arm for plotting only
@@ -240,9 +234,9 @@ chromosome_arms <- cytoBand |>
 
 `do_Feature_mean` shows heatmap of mean expression of a feature grouped by a metadata.
 
--   `df` is the name of the table containing metadata and feature expression (counts) per cells
--   `group.by` is the name of the metadata to group the cells
--   `feature` is the name of the gene to average the expression
+- `df` is the name of the table containing metadata and feature expression (counts) per cells
+- `group.by` is the name of the metadata to group the cells
+- `feature` is the name of the gene to average the expression
 
 ```{r fig.width=10, fig.height=4, out.width='100%'}
 do_Feature_mean <- function(df, group.by, feature) {
@@ -266,9 +260,9 @@ do_Feature_mean <- function(df, group.by, feature) {
 
 `do_BoxPlot_mean` shows boxplot of the percentage of cells with CNV in a specific chromosome arm per clinical relevant group (metadata)
 
--   `df` is the name of the table containing metadata and feature expression (counts) per cells
--   `group.by` is the name of the metadata to group the cells
--   `comparison` is a list of factors in `group.by` for which we will compare the means using an unpaired Wilcoxon test
+- `df` is the name of the table containing metadata and feature expression (counts) per cells
+- `group.by` is the name of the metadata to group the cells
+- `comparison` is a list of factors in `group.by` for which we will compare the means using an unpaired Wilcoxon test
 
 ```{r fig.width=20, fig.height=15, out.width='100%', results='asis'}
 do_BoxPlot_mean <- function(df, group.by, comparison) {
@@ -297,11 +291,19 @@ do_BoxPlot_mean <- function(df, group.by, comparison) {
 
 As done in `06_cnv_infercnv_exploration.Rmd`, we calculate single CNV score and assess its potential in identifying cells with CNV versus normal cells without CNV.
 
-We simply checked for each chromosome the cell `cnv_chr`. Would the cell have less than `r params$cnv_threshold_low` chromosome with CNV, the global `cnv_score` will be FALSE. Would the cell have more than `r params$cnv_threshold_high` chromosome with CNV, the global `cnv_score` will be TRUE. The default is set to `unknown`.
+We simply checked the `cnv_chr` for each chromosome across cells.
 
-The `infercnv` method can lead to false positive CNV. We introduced a flexibility of +`r params$cnv_threshold_high` over the `cnv_threshold` to reduce the risk of misclassification of normal cells as cancer cells.
+- If the cell has less than `r params$cnv_threshold_low` chromosome with CNV, the global `cnv_score` will be `FALSE`. 
+- If the cell has more than `r params$cnv_threshold_high` chromosome with CNV, the global `cnv_score` will be `TRUE`. 
+- The default is set to `unknown`.
 
-Please note that some cancer cell might not have any CNV. There is thus a risk of misclassifying cancer cells as normal cells. However, we cannot avoid this risk with the data and tools currently available. This is a limitation of our annotations.
+The `infercnv` method can lead to false positive CNV. 
+We introduced a flexibility of +`r params$cnv_threshold_high` over the `cnv_threshold` to reduce the risk of misclassification of normal cells as cancer cells.
+
+Please note that some cancer cell might not have any CNV. 
+There is thus a risk of misclassifying cancer cells as normal cells. 
+However, we cannot avoid this risk with the data and tools currently available. 
+This is a limitation of our annotations.
 
 ```{r fig.width=10, fig.height=10, out.width='100%', results='asis'}
 cell_type_df <- cell_type_df |>
@@ -317,11 +319,16 @@ cell_type_df <- cell_type_df |>
 
 At first, we like to indicate in the `first.level_annotation` if a cell is normal, cancer or unknown.
 
--   *normal* cells can be observe in all five compartments (`normal`,`endothelium`, `immune`, `stroma` or `fetal nephron`) and do not have CNV. We only allow a bit of flexibility in terms of CNV profile for immune and endothelium cells that have a high predicted score. Indeed, we know that false positive CNV can be observed in a cell type specific manner. Please note that in `06_infercnv.R`, we renamed all `immune` and `endothelium` cells with a `fetal_kidney_predicted.compartment.score` \> `r params$predicted.celltype.threshold` as `normal`.
+- *normal* cells can be observed in all five compartments (`normal`,`endothelium`, `immune`, `stroma` or `fetal nephron`) and do not have CNV. 
+- *cancer* cells are either from the `stroma` or `fetal nephron` compartments and must have at least few CNV
 
-The threshold used for the `predicted.score` is defined as a parameter of this notebook as `r params$predicted.celltype.threshold`. The thresholds used for the identification of CNV are also defined as notebook parameters with a minimum of `r params$cnv_threshold_low` and a maximum of `r params$cnv_threshold_high`.
+We only allow a bit of flexibility in terms of CNV profile for immune and endothelium cells that have a high predicted score. 
+Indeed, we know that false positive CNV can be observed in a cell type specific manner. 
+Please note that in `06_infercnv.R`, we renamed all `immune` and `endothelium` cells with a `fetal_kidney_predicted.compartment.score` \> `r params$predicted.celltype.threshold` as `normal`.
 
--   *cancer* cells are either from the `stroma` or `fetal nephron` compartments and must have at least few CNV
+The threshold used for the `predicted.score` is defined as a parameter of this notebook as `r params$predicted.celltype.threshold`. 
+The thresholds used for the identification of CNV are also defined as notebook parameters with a minimum of `r params$cnv_threshold_low` and a maximum of `r params$cnv_threshold_high`.
+
 
 ```{r fig.width=10, fig.height=10, out.width='100%', results='asis'}
 # Define normal cells
@@ -339,7 +346,9 @@ cell_type_df <- cell_type_df |>
   ))
 ```
 
-Using this basic strategy, we identified `r table(cell_type_df$first.level_annotation)["cancer"]` *cancer* cells, `r table(cell_type_df$first.level_annotation)["normal"]` *normal* cells. `r table(cell_type_df$first.level_annotation)["unknown"]` cells remain *unknown*
+Using this basic strategy, we identified `r table(cell_type_df$first.level_annotation)["cancer"]` *cancer* cells, `r table(cell_type_df$first.level_annotation)["normal"]` *normal* cells. 
+
+`r table(cell_type_df$first.level_annotation)["unknown"]` cells remain *unknown*.
 
 ```{r fig.width=20, fig.height=20, out.width='100%', results='asis'}
 ggplot(cell_type_df, aes(x = umap.umap_1, y = umap.umap_2, color = first.level_annotation)) +
@@ -359,15 +368,16 @@ cell_type_df |>
 
 Strikingly, 5 samples show more normal cells than cancer cells:
 
--   `SCPCS000177`
--   `SCPCS000180`
--   `SCPCS000181`
--   `SCPCS000190`
--   `SCPCS000197`
+- `SCPCS000177`
+- `SCPCS000180`
+- `SCPCS000181`
+- `SCPCS000190`
+- `SCPCS000197`
 
-These five samples do not have enough immune and endothelium cell to be used as a normal reference in `scripts/06_infercnv.R` and we previously decided to run `scripts/06_infercnv.R` without any reference for these samples. In that case, the mean expression profile over the sample is taken as the normal reference, biasing the inference of CNV.
-
-For those samples, the annotations based on `infercnv` cannot be trust. To avoid any confusion in the following steps of the analysis, we decided to force the annotation of the entire samples to `unknown`.
+These five samples do not have enough immune and endothelium cell to be used as a normal reference in `scripts/06_infercnv.R` and we previously decided to run `scripts/06_infercnv.R` without any reference for these samples. 
+Without a specified reference, the mean expression profile across the sample is taken as the normal reference, biasing the inference of CNV.
+For those samples, the annotations based on `infercnv` cannot be trusted. 
+To avoid any confusion in the following steps of the analysis, we decided to force the annotation of the entire samples to `unknown`.
 
 ```{r fig.width=10, fig.height=10, out.width='100%', results='asis'}
 cell_type_df$first.level_annotation[cell_type_df$sample_id %in% none_reference_samples] <- "unknown"
@@ -377,21 +387,21 @@ cell_type_df$first.level_annotation[cell_type_df$sample_id %in% none_reference_s
 
 #### Normal cells
 
--   Normal cells from the `fetal nephron` compartment must be normal kidney cells.
-
--   Normal cells from the `stroma` compartment must be normal stroma cells.
-
--   Immune and endothelial cells have been already identified by label transfer.
+- Normal cells from the `fetal nephron` compartment must be normal kidney cells.
+- Normal cells from the `stroma` compartment must be normal stroma cells.
+- Immune and endothelial cells have been already identified by label transfer.
 
 #### Cancer cells
 
 Wilms tumor cancer cells can be:
 
--   *cancer stroma*: We define as *cancer stroma* all cancer cells from the stroma compartment.
-
--   *blastema*,: we defined as *blastema* every cancer cell that has a `fetal_kidney_predicted.cell_type == mesenchymal cell`. We know that these *mesenchymal* cells are cells from the cap mesenchyme that are not expected to be in a mature kidney. These blastema cells should express higher `CITED1` and/or `NCAM1`.
-
--   *cancer epithelium*: we defined as *cancer epithelium* all cancer cells that are neither stroma nor blastemal cells. We expect these cells to express epithelial markers. Their predicted cell type should correspond to more mature kidney epithelial subunits.
+- *cancer stroma*: We define as *cancer stroma* all cancer cells from the stroma compartment.
+- *blastema*: We defined as *blastema* every cancer cell that has a `fetal_kidney_predicted.cell_type == mesenchymal cell`. 
+We know that these *mesenchymal* cells are cells from the cap mesenchyme that are not expected to be in a mature kidney. 
+These blastema cells should express higher `CITED1` and/or `NCAM1`.
+- *cancer epithelium*: We defined as *cancer epithelium* all cancer cells that are neither stroma nor blastemal cells. 
+We expect these cells to express epithelial markers. 
+Their predicted cell type should correspond to more mature kidney epithelial subunits.
 
 ```{r fig.width=10, fig.height=10, out.width='100%', results='asis'}
 # Define a vector of `fetal_kidney_predicted.cell_type` levels that corresponds to immune cells
@@ -459,9 +469,9 @@ ggplot(cell_type_df_sub, aes(x = umap.umap_1, y = umap.umap_2, color = second.le
 
 Per sample, the annotations in the `umap` reduction seem to make sense as we can the three main Wilms tumor components are easily distinguished:
 
--   cancer blastema
--   epithelium
--   stroma
+- cancer blastema
+- epithelium
+- stroma
 
 ### Validation cancer versus normal based on the CNV profile
 
@@ -469,11 +479,9 @@ We look for each `second.level_annotation` and `sample_id` at the proportion of 
 
 These heatmaps allow us to:
 
--   validate that mostly tumor cells do present high percentages of cells with CNV (by definition)
-
--   identify chromosome and cell types that might be more sensitive to *FALSE* positive CNV, such as the *chr6p* which is a hub for immune genes
-
--   get the repartition per sample of the CNV
+- validate that mostly tumor cells do present high percentages of cells with CNV (by definition)
+- identify chromosome and cell types that might be more sensitive to *FALSE* positive CNV, such as `chr6p` which is a hub for immune genes
+- get the repartition per sample of the CNV
 
 #### Loss on long arms
 
@@ -534,9 +542,10 @@ c(1:12, 16:20) |>
 
 ### Mean CNV profile
 
-While the above heatmaps can be informative, we have to acknowledge that there are numerous and it is difficult to get a global picture of the CNV profile of the entire dataset.
+While the above heatmaps can be informative, because there are so many of them it is difficult to get a global picture of the CNV profile of the entire dataset.
 
-Here we aim to plot a mean CNV profile across the 35 annotated samples as presented in Figure 1A of [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). This represent the mean SNP Array profile of 64 pediatric kidney cancer (including 60 Wilms tumors).
+Here we aim to plot a mean CNV profile across the 35 annotated samples as presented in Figure 1A of [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
+This represents the mean SNP Array profile of 64 pediatric kidney cancer (including 60 Wilms tumors).
 
 Here we plot for each chromosome arm (x-axis) the number of samples having a `dupli` (y-axis \> 0, in red) or a `loss` (y-axis \< 0, in blue).
 
@@ -626,17 +635,21 @@ wrap_plots(gain_profile, loss_profile, ncol = 1) + plot_layout(widths = CNV_prof
 
 Comparing with the profile in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1), we identified important CNV known to play a role in Wilms tumor, including:
 
--   *chr8q*, *chr12*, *chr13*, *chr18q* gains
-
--   *chr11q*, *chr16*, *chr17q* loss
+- *chr8q*, *chr12*, *chr13*, *chr18q* gains
+- *chr11q*, *chr16*, *chr17q* loss
 
 However, we spotted some differences:
 
--   we couldn't detect any *chr4q* loss as described in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
+- We couldn't detect any *chr4q* loss as described in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
 
--   we identified 2 losses in *chr5* and *chr6* that do not show up in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). These can be `infercnv` induced \_FALSE_positive CNV.
+- We identified 2 losses in *chr5* and *chr6* that do not show up in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
+These may be `infercnv` induced false-positive CNV.
 
-Our major concern is the pattern of the *chr1*. We do see a tendency of *chr1p* loss and *chr1q* gain but it is not as pronounced as in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). *chr1q* gain is however one of the most promising predictive marker of Wilms tumor outcome ([Nelson et al, Current Opinion in Pediatrics (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/)). It is however important to notice that the profile shown in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1) derived from SIOP samples that have been pre-treated with chemotherapy, while samples in the dataset are enriched in `upfront resection` samples that haven't been pre-treated, according to the COG protocol. So far, we do not know how the pre-operative chemotherapy impact the clonal selection of specific CNV.
+Our major concern is the pattern of the *chr1*. 
+We do see a tendency of *chr1p* loss and *chr1q* gain but it is not as pronounced as in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
+*chr1q* gain is however one of the most promising predictive marker of Wilms tumor outcome ([Nelson et al, Current Opinion in Pediatrics (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/)). 
+It is however important to notice that the profile shown in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1) derived from SIOP samples that have been pre-treated with chemotherapy, while samples in the dataset are enriched in `upfront resection` samples that haven't been pre-treated, according to the COG protocol. 
+So far, we do not know how the pre-operative chemotherapy impact the clonal selection of specific CNV.
 
 ### Mean of the percentage of cells with CNV in a specific chromosome arm per clinical relevant group
 
@@ -654,7 +667,8 @@ In our study, we validate the association of *chr1q* gain, *chr11q* loss and *ch
 
 ##### `treatment`
 
-As we don't know the effect of the treatment on the selection of cells with CNV, it is difficult to compare our CNV profile with the one in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). We those check the repartition of CNV in samples that have been pre-treated (i.e `Resection post chemotherapy`) with samples that have been removed surgically before any treatment (i.e `Upfront resection`).
+As we don't know the effect of the treatment on the selection of cells with CNV, it is difficult to compare our CNV profile with the one in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
+We those check the repartition of CNV in samples that have been pre-treated (i.e `Resection post chemotherapy`) with samples that have been removed surgically before any treatment (i.e `Upfront resection`).
 
 ```{r fig.height=15, fig.width=20, message=FALSE, warning=FALSE, out.width='100%', results='asis'}
 do_BoxPlot_mean(df = cell_type_df_sub, group.by = "treatment", comparison = c("Upfront resection", "Resection post chemotherapy"))
@@ -684,7 +698,8 @@ Endothelial cells are well annotated based on `VWF` expression.
 
 #### Stroma
 
-(\*) To the best of our knowledge, there is no Wilms tumor specific marker of stroma cells. They should express in some extend similar markers as normal stromal cells including *VIM*, *THY1* and *COL6A3*.
+(\*) To the best of our knowledge, there is no Wilms tumor specific marker of stroma cells. 
+They should express in some extend similar markers as normal stromal cells including *VIM*, *THY1* and *COL6A3*.
 
 ##### `Vimentin` expression
 
@@ -712,7 +727,8 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 
 #### Blastema
 
-(\*) To the best of our knowledge, there is no Wilms tumor specific and universal (i.e. expressed by all cells in every sample) marker of blastema cells. We expect however blastema cells to express higher levels of stemness markers such as `CITED1`, `SIX1/2`, `NCAM1`.
+(\*) To the best of our knowledge, there is no Wilms tumor specific and universal (i.e. expressed by all cells in every sample) marker of blastema cells. 
+We expect however blastema cells to express higher levels of stemness markers such as `CITED1`, `SIX1/2`, `NCAM1`.
 
 ##### `CITED1` expression
 
@@ -720,7 +736,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000125931")
 ```
 
-Blastema cells are enriched in *CITED1*+ cells, but some samples do not express it at all.
+Blastema cells are enriched in `CITED1+` cells, but some samples do not express it at all.
 
 ##### `NCAM1` expression
 
@@ -787,19 +803,28 @@ length(unique(annotations_table$scpca_sample_id))
 
 ## Conclusion
 
--   Combining label transfer and CNV inference we have produced draft annotations for 35/40 Wilms tumor samples in SCPCP000006. We decided not to annotate samples for which the `infercnv` couldn't be run with a normal reference, as we don't trust the results in that case and want to avoid misclassification (`SCPCS000177`, `SCPCS000180`, `SCPCS000181`, `SCPCS000190`, `SCPCS000197`).
+- Combining label transfer and CNV inference we have produced draft annotations for 35/40 Wilms tumor samples in SCPCP000006. 
+We decided not to annotate samples for which the `infercnv` couldn't be run with a normal reference, as we don't trust the results in that case and want to avoid misclassification (`SCPCS000177`, `SCPCS000180`, `SCPCS000181`, `SCPCS000190`, `SCPCS000197`).
 
--   The mean CNV profile of the Wilms tumor cohort seems reasonable in regards to the one published in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). We identify some commonalities but also some divergence. They can be due to technical limitation of our CNV inference but can also reflect some specificities of this cohort (e.g. pre/post treatment samples). It would be really useful to compare for some sample the `infercnv` result to a ground truth such as SNP Array (to be requested).
+- The mean CNV profile of the Wilms tumor cohort seems reasonable in regards to the one published in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
+We identify some commonalities but also some divergence. 
+They can be due to technical limitation of our CNV inference but can also reflect some specificities of this cohort (e.g. pre/post treatment samples). 
+It would be really useful to compare for some sample the `infercnv` result to a ground truth such as SNP Array (to be requested).
 
--   The heatmaps of CNV proportion and marker genes support our annotations, but signals with some marker genes are very low. Also, there is no universal marker for each entity of Wilms tumor that cover all tumor cells from all patient. This makes the validation of the annotations quite difficult.
+- The heatmaps of CNV proportion and marker genes support our annotations, but signals with some marker genes are very low. 
+Also, there is no universal marker for each entity of Wilms tumor that cover all tumor cells from all patient. 
+This makes the validation of the annotations quite difficult.
 
--   However, we could try to take the problem from the other side, and used the current annotation to perform differential expression analysis and try to find marker genes that are consistent across patient and Wilms tumor histologies.
+- However, we could try to take the problem from the other side, and used the current annotation to perform differential expression analysis and try to find marker genes that are consistent across patient and Wilms tumor histologies.
 
--   In each histology (i.e. epithelial and stroma), the distinction between cancer and non cancer cell is difficult (as expected). In this analysis, we suggested to rely on the CNV score to assess the normality of the cell. Here again, we could try to run differential expression analysis and compare epithelial (resp. stroma) cancer versus non-cancer cells across patient, aiming to find a share transcriptional program allowing the classification cancer versus normal.
+- In each histology (i.e. epithelial and stroma), the distinction between cancer and non cancer cell is difficult (as expected). 
+In this analysis, we suggested to rely on the CNV score to assess the normality of the cell. 
+Here again, we could try to run differential expression analysis and compare epithelial (resp. stroma) cancer versus non-cancer cells across patient, aiming to find a share transcriptional program allowing the classification cancer versus normal.
 
--   In our annotation, we haven't taken into account the favorable/anaplastic status of the sample. However, as anaplasia can occur in every (but do not has to) Wilms tumor histology, I am not sure how to integrate the information into the annotation.
+- In our annotation, we haven't taken into account the favorable/anaplastic status of the sample. 
+However, as anaplasia can occur in every (but do not has to) Wilms tumor histology, I am not sure how to integrate the information into the annotation.
 
--   This notebook could be finally rendered using different parameters, i.e. threshold for the CNV score and predicted score to use.
+- This notebook could be finally rendered using different parameters, i.e. threshold for the CNV score and predicted score to use.
 
 ## Session Info
 

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -545,7 +545,7 @@ c(1:12, 16:20) |>
 
 While the above heatmaps can be informative, because there are so many of them it is difficult to get a global picture of the CNV profile of the entire dataset.
 
-Here we aim to plot a mean CNV profile across the 35 annotated samples as presented in Figure 1A of [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
+Here we aim to plot a mean CNV profile across the 35 annotated samples as presented in Figure 1A of [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
 This represents the mean SNP Array profile of 64 pediatric kidney cancer (including 60 Wilms tumors).
 
 Here we plot for each chromosome arm (x-axis) the number of samples having a `dupli` (y-axis > 0, in red) or a `loss` (y-axis < 0, in blue).

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -25,18 +25,13 @@ knitr::opts_chunk$set(
 )
 ```
 
-
 ## Introduction
 
+The aim is to combine label transfer and CNV inference to annotate Wilms tumor samples in SCPCP000006. The proposed annotation will be based on the combination of:
 
-The aim is to combine label transfer and CNV inference to annotate Wilms tumor samples in SCPCP000006.
-The proposed annotation will be based on the combination of:
+-   the label transfer from the fetal kidney reference (Stewart et al.), in particular the `fetal_kidney_predicted.compartment` and `fetal_kidney:predicted.cell_type`, as well as the `prediction.score` for each compartment,
 
-- the label transfer from the fetal kidney reference (Stewart et al.), in particular the `fetal_kidney_predicted.compartment` and `fetal_kidney:predicted.cell_type`, as well as the `prediction.score` for each compartment,
-
-- the predicted CNV calculated using intra-sample endothelial and immune cells (`--reference both`) as normal reference; no reference was used for samples with fewer than 3 predicted normal cells.
-
-
+-   the predicted CNV calculated using intra-sample endothelial and immune cells (`--reference both`) as normal reference; no reference was used for samples with fewer than 3 predicted normal cells.
 
 In a second time, we will explore and validate the chosen annotation.
 
@@ -44,29 +39,26 @@ We will use some of the [markers genes](https://github.com/AlexsLemonade/OpenScP
 
 The analysis can be summarized as the following:
 
-
-| first level annotation | second level annotation | selection of the cells                                                                        | marker genes for validation | CNV validation                             |
-| ---------------------- | ----------------------- | --------------------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------ |
-| normal                 | endothelial             | `compartment == "endothelium" & predicted.score > pred.thr`                                   | `VWF`                       | no CNV                                     |
-| normal                 | immune                  | `compartment == "immune" & predicted.score > pred.thr`                                        | `PTPRC`, `CD163`, `CD68`    | no CNV                                     |
-| normal                 | kidney                  | `compartment == "fetal_nephron" & predicted.score > pred.thr & cnv_score < cnv.thr.lower`     | `CDH1`, `PODXL`, `LTL`      | no CNV                                     |
-| normal                 | stroma                  | `compartment == "stroma" & predicted.score > pred.thr & cnv_score < cnv.thr.upper`            | `VIM`                       | no CNV                                     |
-| cancer                 | stroma                  | `compartment == "stroma" & cnv_score > cnv.thr.upper`                                         | `VIM`                       | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
-| cancer                 | blastema                | `compartment == "fetal_nephron" & cell_type == "mesenchymal cell" & cnv_score > cnv.thr.upper`| `CITED1`                    | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
-| cancer                 | epithelial              | `compartment == "fetal_nephron" & cell_type != "mesenchymal cell" & cnv_score > cnv.thr.upper`| `CDH1`                      | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
-| unknown                | -                       | the rest of the cells                                                                         | -                           | -                                          |
+| first level annotation | second level annotation | selection of the cells | marker genes for validation | CNV validation |
+|----|----|----|----|----|
+| normal | endothelial | `compartment == "endothelium" & predicted.score > pred.thr` | `VWF` | no CNV |
+| normal | immune | `compartment == "immune" & predicted.score > pred.thr` | `PTPRC`, `CD163`, `CD68` | no CNV |
+| normal | kidney | `compartment == "fetal_nephron" & predicted.score > pred.thr & cnv_score < cnv.thr.lower` | `CDH1`, `PODXL`, `LTL` | no CNV |
+| normal | stroma | `compartment == "stroma" & predicted.score > pred.thr & cnv_score < cnv.thr.upper` | `VIM` | no CNV |
+| cancer | stroma | `compartment == "stroma" & cnv_score > cnv.thr.upper` | `VIM` | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
+| cancer | blastema | `compartment == "fetal_nephron" & cell_type == "mesenchymal cell" & cnv_score > cnv.thr.upper` | `CITED1` | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
+| cancer | epithelial | `compartment == "fetal_nephron" & cell_type != "mesenchymal cell" & cnv_score > cnv.thr.upper` | `CDH1` | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
+| unknown | \- | the rest of the cells | \- | \- |
 
 with the defined parameters:
 
-- `pred.thr` = `r params$predicted.celltype.threshold`
+-   `pred.thr` = `r params$predicted.celltype.threshold`
 
-- `cnv.thr.lower` = `r params$cnv_threshold_low`
+-   `cnv.thr.lower` = `r params$cnv_threshold_low`
 
-- `cnv.thr.upper` = `r params$cnv_threshold_high`
-
+-   `cnv.thr.upper` = `r params$cnv_threshold_high`
 
 ### Packages
-
 
 ```{r packages, message=FALSE, warning=FALSE}
 library(Seurat)
@@ -74,7 +66,6 @@ library(tidyverse)
 library(patchwork)
 library(DT)
 ```
-
 
 ### Base directories
 
@@ -93,8 +84,7 @@ result_dir <- file.path(module_base, "results")
 
 ### Output files
 
-The report will be saved in the `notebook` directory.
-The final annotation file `SCPCP000006-annotations.tsv` will be saved in the `results` directory.
+The report will be saved in the `notebook` directory. The final annotation file `SCPCP000006-annotations.tsv` will be saved in the `results` directory.
 
 ```{r}
 # cell type annotation table
@@ -113,23 +103,17 @@ sample_metadata_file <- file.path(repository_base, "data", "current", "SCPCP0000
 metadata <- read.table(sample_metadata_file, sep = "\t", header = TRUE)
 ```
 
-We extracted from the pre-processed and labeled `Seurat` object from `results/{sample_id}/06_infercnv_HMM-i3_{sample_id}_reference-{reference}.rds`.
-the following information per cell:
+We extracted from the pre-processed and labeled `Seurat` object from `results/{sample_id}/06_infercnv_HMM-i3_{sample_id}_reference-{reference}.rds`. the following information per cell:
 
-- the predicted compartment in `fetal_kidney_predicted.compartment` and `fetal_kidney_predicted.compartment.score`
+-   the predicted compartment in `fetal_kidney_predicted.compartment` and `fetal_kidney_predicted.compartment.score`
 
-- the predicted cell type in `fetal_kidney_predicted.cell_type` and `fetal_kidney_predicted.cell_type.score`
+-   the predicted cell type in `fetal_kidney_predicted.cell_type` and `fetal_kidney_predicted.cell_type.score`
 
+-   the sample identifier in `sample_id`
 
-- the sample identifier in `sample_id`
+-   the CNV `{dupli|loss}` estimation per chromosome {i} and arm `{p|q}`: `has_{dupli|loss}_chr{i}{p|q}`, in 1 to 22
 
-
-- the CNV `{dupli|loss}` estimation per chromosome {i} and arm `{p|q}`: 
-`has_{dupli|loss}_chr{i}{p|q}`, in 1 to 22
-
-
-- the `counts` of [markers genes](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-wilms-tumor-06#the-table-celltype_metadatacsv-contains-the-following-column-and-information)
-
+-   the `counts` of [markers genes](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-wilms-tumor-06#the-table-celltype_metadatacsv-contains-the-following-column-and-information)
 
 ```{r path_to_query}
 # Extract from each Seurat object information that will be used
@@ -202,10 +186,9 @@ cell_type_df <- sample_ids |>
   dplyr::bind_rows()
 ```
 
-
 We will also use:
 
-- the samples metadata or clinical data reported in `r file.path(repository_base, "data", "current", "SCPCP000006", "single_cell_metadata.tsv")` 
+-   the samples metadata or clinical data reported in `r file.path(repository_base, "data", "current", "SCPCP000006", "single_cell_metadata.tsv")`
 
 ```{r }
 # Add clinical metadata
@@ -213,7 +196,7 @@ cell_type_df <- cell_type_df |>
   left_join(metadata, by = c("sample_id" = "scpca_sample_id"))
 ```
 
-- the cytoband file to get the length of each chromosome arm (for plotting only)
+-   the cytoband file to get the length of each chromosome arm (for plotting only)
 
 ```{r input}
 # the cytoband file that will be used to extract the size of each chromosome arm for plotting only
@@ -251,16 +234,15 @@ chromosome_arms <- cytoBand |>
   filter(arm != "")
 ```
 
-
 ## Functions
 
 #### do_Feature_mean
 
 `do_Feature_mean` shows heatmap of mean expression of a feature grouped by a metadata.
 
-- `df` is the name of the table containing metadata and feature expression (counts) per cells
-- `group.by` is the name of the metadata to group the cells
-- `feature` is the name of the gene to average the expression
+-   `df` is the name of the table containing metadata and feature expression (counts) per cells
+-   `group.by` is the name of the metadata to group the cells
+-   `feature` is the name of the gene to average the expression
 
 ```{r fig.width=10, fig.height=4, out.width='100%'}
 do_Feature_mean <- function(df, group.by, feature) {
@@ -280,15 +262,13 @@ do_Feature_mean <- function(df, group.by, feature) {
 }
 ```
 
-
-
-#### do_BoxPlot_mean
+#### `do_BoxPlot_mean`
 
 `do_BoxPlot_mean` shows boxplot of the percentage of cells with CNV in a specific chromosome arm per clinical relevant group (metadata)
 
-- `df` is the name of the table containing metadata and feature expression (counts) per cells
-- `group.by` is the name of the metadata to group the cells
-- `comparison` is a list of factors in `group.by` for which we will compare the means using an unpaired Wilcoxon test
+-   `df` is the name of the table containing metadata and feature expression (counts) per cells
+-   `group.by` is the name of the metadata to group the cells
+-   `comparison` is a list of factors in `group.by` for which we will compare the means using an unpaired Wilcoxon test
 
 ```{r fig.width=20, fig.height=15, out.width='100%', results='asis'}
 do_BoxPlot_mean <- function(df, group.by, comparison) {
@@ -311,25 +291,17 @@ do_BoxPlot_mean <- function(df, group.by, comparison) {
 }
 ```
 
-
 ## Analysis
 
 ### Global CNV score
 
-As done in `06_cnv_infercnv_exploration.Rmd`, we calculate  single CNV score and assess its potential in identifying cells with CNV versus normal cells without CNV.
+As done in `06_cnv_infercnv_exploration.Rmd`, we calculate single CNV score and assess its potential in identifying cells with CNV versus normal cells without CNV.
 
-We simply checked for each chromosome the cell `cnv_chr`.
-Would the cell have less than `r params$cnv_threshold_low` chromosome with CNV, the global `cnv_score` will be FALSE.
-Would the cell have more than `r params$cnv_threshold_high`  chromosome with CNV, the global `cnv_score` will be TRUE.
-The default is set to `unknown`.
+We simply checked for each chromosome the cell `cnv_chr`. Would the cell have less than `r params$cnv_threshold_low` chromosome with CNV, the global `cnv_score` will be FALSE. Would the cell have more than `r params$cnv_threshold_high` chromosome with CNV, the global `cnv_score` will be TRUE. The default is set to `unknown`.
 
-The `infercnv` method can lead to false positive CNV.
-We introduced a flexibility of +`r params$cnv_threshold_high` over the `cnv_threshold` to reduce the risk of misclassification of normal cells as cancer cells.
+The `infercnv` method can lead to false positive CNV. We introduced a flexibility of +`r params$cnv_threshold_high` over the `cnv_threshold` to reduce the risk of misclassification of normal cells as cancer cells.
 
-Please note that some cancer cell might not have any CNV. 
-There is thus a risk of misclassifying cancer cells as normal cells. 
-However, we cannot avoid this risk with the data and tools currently available.
-This is a limitation of our annotations. 
+Please note that some cancer cell might not have any CNV. There is thus a risk of misclassifying cancer cells as normal cells. However, we cannot avoid this risk with the data and tools currently available. This is a limitation of our annotations.
 
 ```{r fig.width=10, fig.height=10, out.width='100%', results='asis'}
 cell_type_df <- cell_type_df |>
@@ -345,17 +317,11 @@ cell_type_df <- cell_type_df |>
 
 At first, we like to indicate in the `first.level_annotation` if a cell is normal, cancer or unknown.
 
-- _normal_ cells can be observe in all five compartments (`normal`,`endothelium`, `immune`, `stroma` or `fetal nephron`) and do not have CNV.
-We only allow a bit of flexibility in terms of CNV profile for immune and endothelium cells that have a high predicted score.
-Indeed, we know that false positive CNV can be observed in a cell type specific manner.
-Please note that in `06_infercnv.R`, we renamed all `immune` and `endothelium` cells with a `fetal_kidney_predicted.compartment.score` > `r params$predicted.celltype.threshold` as `normal`.
+-   *normal* cells can be observe in all five compartments (`normal`,`endothelium`, `immune`, `stroma` or `fetal nephron`) and do not have CNV. We only allow a bit of flexibility in terms of CNV profile for immune and endothelium cells that have a high predicted score. Indeed, we know that false positive CNV can be observed in a cell type specific manner. Please note that in `06_infercnv.R`, we renamed all `immune` and `endothelium` cells with a `fetal_kidney_predicted.compartment.score` \> `r params$predicted.celltype.threshold` as `normal`.
 
-The threshold used for the `predicted.score` is defined as a parameter of this notebook as `r params$predicted.celltype.threshold`.
-The thresholds used for the identification of CNV are also defined as notebook parameters with a minimum of `r params$cnv_threshold_low` and a maximum of `r params$cnv_threshold_high`.
+The threshold used for the `predicted.score` is defined as a parameter of this notebook as `r params$predicted.celltype.threshold`. The thresholds used for the identification of CNV are also defined as notebook parameters with a minimum of `r params$cnv_threshold_low` and a maximum of `r params$cnv_threshold_high`.
 
-- _cancer_ cells are either from the `stroma` or `fetal nephron` compartments and must have at least few CNV
-
-
+-   *cancer* cells are either from the `stroma` or `fetal nephron` compartments and must have at least few CNV
 
 ```{r fig.width=10, fig.height=10, out.width='100%', results='asis'}
 # Define normal cells
@@ -373,8 +339,7 @@ cell_type_df <- cell_type_df |>
   ))
 ```
 
-Using this basic strategy, we identified `r table(cell_type_df$first.level_annotation)["cancer"]` _cancer_ cells, `r table(cell_type_df$first.level_annotation)["normal"]` _normal_ cells.
-`r table(cell_type_df$first.level_annotation)["unknown"]` cells remain _unknown_
+Using this basic strategy, we identified `r table(cell_type_df$first.level_annotation)["cancer"]` *cancer* cells, `r table(cell_type_df$first.level_annotation)["normal"]` *normal* cells. `r table(cell_type_df$first.level_annotation)["unknown"]` cells remain *unknown*
 
 ```{r fig.width=20, fig.height=20, out.width='100%', results='asis'}
 ggplot(cell_type_df, aes(x = umap.umap_1, y = umap.umap_2, color = first.level_annotation)) +
@@ -394,47 +359,39 @@ cell_type_df |>
 
 Strikingly, 5 samples show more normal cells than cancer cells:
 
-- `SCPCS000177`
-- `SCPCS000180`
-- `SCPCS000181`
-- `SCPCS000190`
-- `SCPCS000197`
+-   `SCPCS000177`
+-   `SCPCS000180`
+-   `SCPCS000181`
+-   `SCPCS000190`
+-   `SCPCS000197`
 
-These five samples do not have enough immune and endothelium cell to be used as a normal reference in `scripts/06_infercnv.R` and we previously decided to run `scripts/06_infercnv.R` without any reference for these samples.
-In that case, the mean expression profile over the sample is taken as the normal reference, biasing the inference of CNV. 
+These five samples do not have enough immune and endothelium cell to be used as a normal reference in `scripts/06_infercnv.R` and we previously decided to run `scripts/06_infercnv.R` without any reference for these samples. In that case, the mean expression profile over the sample is taken as the normal reference, biasing the inference of CNV.
 
-For those samples, the annotations based on `infercnv` cannot be trust.
-To avoid any confusion in the following steps of the analysis, we decided to force the annotation of the entire samples to `unknown`.
+For those samples, the annotations based on `infercnv` cannot be trust. To avoid any confusion in the following steps of the analysis, we decided to force the annotation of the entire samples to `unknown`.
 
 ```{r fig.width=10, fig.height=10, out.width='100%', results='asis'}
 cell_type_df$first.level_annotation[cell_type_df$sample_id %in% none_reference_samples] <- "unknown"
 ```
 
-
 ### Second level annotation
 
 #### Normal cells
 
-- Normal cells from the `fetal nephron` compartment must be normal kidney cells.
+-   Normal cells from the `fetal nephron` compartment must be normal kidney cells.
 
-- Normal cells from the `stroma` compartment must be normal stroma cells.
+-   Normal cells from the `stroma` compartment must be normal stroma cells.
 
-- Immune and endothelial cells have been already identified by label transfer.
+-   Immune and endothelial cells have been already identified by label transfer.
 
 #### Cancer cells
 
 Wilms tumor cancer cells can be:
 
-- _cancer stroma_: We define as _cancer stroma_ all cancer cells from the stroma compartment.
+-   *cancer stroma*: We define as *cancer stroma* all cancer cells from the stroma compartment.
 
+-   *blastema*,: we defined as *blastema* every cancer cell that has a `fetal_kidney_predicted.cell_type == mesenchymal cell`. We know that these *mesenchymal* cells are cells from the cap mesenchyme that are not expected to be in a mature kidney. These blastema cells should express higher `CITED1` and/or `NCAM1`.
 
-- _blastema_,: we defined as _blastema_ every cancer cell that has a `fetal_kidney_predicted.cell_type == mesenchymal cell`.
-We know that these _mesenchymal_ cells are cells from the cap mesenchyme that are not expected to be in a mature kidney.
-These blastema cells should express higher _CITED1_ and/or _NCAM1_.
-
-- _cancer epithelium_: we defined as _cancer epithelium_ all cancer cells that are neither stroma nor blastemal cells.
-We expect these cells to express epithelial markers.
-Their predicted cell type should correspond to more mature kidney epithelial subunits.
+-   *cancer epithelium*: we defined as *cancer epithelium* all cancer cells that are neither stroma nor blastemal cells. We expect these cells to express epithelial markers. Their predicted cell type should correspond to more mature kidney epithelial subunits.
 
 ```{r fig.width=10, fig.height=10, out.width='100%', results='asis'}
 # Define a vector of `fetal_kidney_predicted.cell_type` levels that corresponds to immune cells
@@ -479,8 +436,6 @@ cell_type_df <- cell_type_df |>
   ))
 ```
 
-
-
 #### `Second.level_annotation` of cancer and normal cells - `umap` reduction
 
 ```{r fig.width=20, fig.height=20, out.width='100%', results='asis'}
@@ -490,7 +445,6 @@ ggplot(cell_type_df, aes(x = umap.umap_1, y = umap.umap_2, color = second.level_
   theme_bw() +
   theme(text = element_text(size = 22))
 ```
-
 
 #### `Second.level_annotation` of cancer and normal cells without `unknown` - `umap` reduction
 
@@ -503,13 +457,11 @@ ggplot(cell_type_df_sub, aes(x = umap.umap_1, y = umap.umap_2, color = second.le
   theme(text = element_text(size = 22))
 ```
 
-
 Per sample, the annotations in the `umap` reduction seem to make sense as we can the three main Wilms tumor components are easily distinguished:
 
-- cancer blastema
-- epithelium
-- stroma
-
+-   cancer blastema
+-   epithelium
+-   stroma
 
 ### Validation cancer versus normal based on the CNV profile
 
@@ -517,11 +469,11 @@ We look for each `second.level_annotation` and `sample_id` at the proportion of 
 
 These heatmaps allow us to:
 
-- validate that mostly tumor cells do present high percentages of cells with CNV (by definition)
+-   validate that mostly tumor cells do present high percentages of cells with CNV (by definition)
 
-- identify chromosome and cell types that might be more sensitive to _FALSE_ positive CNV, such as the _chr6p_ which is a hub for immune genes
+-   identify chromosome and cell types that might be more sensitive to *FALSE* positive CNV, such as the *chr6p* which is a hub for immune genes
 
-- get the repartition per sample of the CNV
+-   get the repartition per sample of the CNV
 
 #### Loss on long arms
 
@@ -582,14 +534,13 @@ c(1:12, 16:20) |>
 
 ### Mean CNV profile
 
-While the above heatmaps can be informative, we have to acknowledge that there are numerous and it is difficult to get a global picture of the CNV profile of the entire dataset. 
+While the above heatmaps can be informative, we have to acknowledge that there are numerous and it is difficult to get a global picture of the CNV profile of the entire dataset.
 
-Here we aim to plot a mean CNV profile across the 35 annotated samples as presented in Figure 1A of [Cresswell et al, BioRXiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). This represent the mean SNP Array profile of 64 pediatric kidney cancer (including 60 Wilms tumors).
+Here we aim to plot a mean CNV profile across the 35 annotated samples as presented in Figure 1A of [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). This represent the mean SNP Array profile of 64 pediatric kidney cancer (including 60 Wilms tumors).
 
-Here we plot for each chromosome arm (x-axis) the number of samples having a `dupli` (y-axis > 0, in red) or a `loss` (y-axis < 0, in blue).
+Here we plot for each chromosome arm (x-axis) the number of samples having a `dupli` (y-axis \> 0, in red) or a `loss` (y-axis \< 0, in blue).
 
-For a sample, a CNV is defined as `clonal` (opaque) if detected in more than 70% of the cells;
-and `subclonal` (transparent) when detected in at least 10% of the cells. 
+For a sample, a CNV is defined as `clonal` (opaque) if detected in more than 70% of the cells; and `subclonal` (transparent) when detected in at least 10% of the cells.
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 # Here we define the vector of ordered chromosomes arms that will be used for plotting
@@ -673,57 +624,43 @@ gain_profile <- wrap_plots(gain_profile, nrow = 1, widths = chromosome_arms$Size
 wrap_plots(gain_profile, loss_profile, ncol = 1) + plot_layout(widths = CNV_profile_gain$Size)
 ```
 
-Comparing with the profile in [Cresswell et al, BioRXiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1), we identified important CNV known to play a role in Wilms tumor, including:
+Comparing with the profile in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1), we identified important CNV known to play a role in Wilms tumor, including:
 
-- _chr8q_, _chr12_, _chr13_, _chr18q_ gains
+-   *chr8q*, *chr12*, *chr13*, *chr18q* gains
 
-- _chr11q_, _chr16_, _chr17q_ loss
+-   *chr11q*, *chr16*, *chr17q* loss
 
 However, we spotted some differences:
 
-- we couldn't detect any _chr4q_ loss as described in [Cresswell et al, BioRXiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
+-   we couldn't detect any *chr4q* loss as described in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
 
-- we identified 2 losses in _chr5_ and _chr6_ that do not show up in [Cresswell et al, BioRXiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
-These can be `infercnv` induced _FALSE_positive CNV. 
+-   we identified 2 losses in *chr5* and *chr6* that do not show up in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). These can be `infercnv` induced \_FALSE_positive CNV.
 
-Our major concern is the pattern of the _chr1_. 
-We do see a tendency of _chr1p_ loss and _chr1q_ gain but it is not as pronounced as in [Cresswell et al, BioRXiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
-_chr1q_ gain is however one of the most promising predictive marker of Wilms tumor outcome ([Nelson et al, Curr Opin Pediatr (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/)).
-It is however important to notice that the profile shown in [Cresswell et al, BioRXiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1) derived from SIOP samples that have been pre-treated with chemotherapy, while samples in the dataset are enriched in `upfront resection` samples that haven't been pre-treated, according to the COG protocol. 
-So far, we do not know how the pre-operative chemotherapy impact the clonal selection of specific CNV. 
-
+Our major concern is the pattern of the *chr1*. We do see a tendency of *chr1p* loss and *chr1q* gain but it is not as pronounced as in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). *chr1q* gain is however one of the most promising predictive marker of Wilms tumor outcome ([Nelson et al, Current Opinion in Pediatrics (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/)). It is however important to notice that the profile shown in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1) derived from SIOP samples that have been pre-treated with chemotherapy, while samples in the dataset are enriched in `upfront resection` samples that haven't been pre-treated, according to the COG protocol. So far, we do not know how the pre-operative chemotherapy impact the clonal selection of specific CNV.
 
 ### Mean of the percentage of cells with CNV in a specific chromosome arm per clinical relevant group
 
 #### `vital_status`
 
-As described in [Nelson et al, Curr Opin Pediatr (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/), 
-[Phelps et al, Children (2018)](https://pmc.ncbi.nlm.nih.gov/articles/PMC6262554/) and 
-[Zheng et al, Front. Oncol (2023)](https://www.frontiersin.org/journals/oncology/articles/10.3389/fonc.2023.1137346/full), 
-LOH at _chr1p_, _chr11p_ and _chr16q_ as well as _chr1q_ gain are prognostic factors.
+As described in [Nelson et al, Current Opinions in Pediatrics (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/), [Phelps et al, Children (2018)](https://pmc.ncbi.nlm.nih.gov/articles/PMC6262554/) and [Zheng et al, Frontiers in Oncology (2023)](https://www.frontiersin.org/journals/oncology/articles/10.3389/fonc.2023.1137346/full), LOH at *chr1p*, *chr11p* and *chr16q* as well as *chr1q* gain are prognostic factors.
 
-Here we aim to see if we identify CNV associated with poorer prognosis. 
+Here we aim to see if we identify CNV associated with poorer prognosis.
 
 ```{r fig.height=15, fig.width=20, message=FALSE, warning=FALSE, out.width='100%', results='asis'}
 do_BoxPlot_mean(df = cell_type_df_sub, group.by = "vital_status", comparison = c("Alive", "Expired"))
 ```
 
-In our study, we validate the association of _chr1q_ gain, _chr11q_ loss and _chr14q_ loss with poorer prognosis.
+In our study, we validate the association of *chr1q* gain, *chr11q* loss and *chr14q* loss with poorer prognosis.
 
 ##### `treatment`
 
-As we don't know the effect of the treatment on the selection of cells with CNV, it is difficult to compare our CNV profile with the one in [Cresswell et al, BioRXiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
-We those check the repartition of CNV in samples that have been pre-treated (i.e `Resection post chemotherapy`) with samples that have been removed surgically before any treatment (i.e `Upfront resection`).
-
+As we don't know the effect of the treatment on the selection of cells with CNV, it is difficult to compare our CNV profile with the one in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). We those check the repartition of CNV in samples that have been pre-treated (i.e `Resection post chemotherapy`) with samples that have been removed surgically before any treatment (i.e `Upfront resection`).
 
 ```{r fig.height=15, fig.width=20, message=FALSE, warning=FALSE, out.width='100%', results='asis'}
 do_BoxPlot_mean(df = cell_type_df_sub, group.by = "treatment", comparison = c("Upfront resection", "Resection post chemotherapy"))
 ```
 
-Our analysis suggest that there is indeed an enrichment in cells with CNV after chemotherapy, 
-including a tendency of more _chr1q_ gain samples after chemotherapy. 
-This could explain some of the differences observed between our mean CNV profile and the one published in [Cresswell et al, BioRXiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
-
+Our analysis suggest that there is indeed an enrichment in cells with CNV after chemotherapy, including a tendency of more *chr1q* gain samples after chemotherapy. This could explain some of the differences observed between our mean CNV profile and the one published in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
 
 ### Validation of second level annotation using marker genes
 
@@ -735,7 +672,7 @@ Finally, we aim to validate the `second level annotation` using marker genes.
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000081237")
 ```
 
-Immune cells are well annotated based on _PTPRC_ expression.
+Immune cells are well annotated based on `PTPRC` expression.
 
 #### Endothelium, `VWF` expression
 
@@ -743,14 +680,11 @@ Immune cells are well annotated based on _PTPRC_ expression.
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000110799")
 ```
 
-Endothelial cells are well annotated based on _VWF_ expression.
+Endothelial cells are well annotated based on `VWF` expression.
 
+#### Stroma
 
-#### Stroma 
-
-(*) To the best of our knowledges, there is no Wilms tumor specific marker of stroma cells.
-They should express in some extend similar markers as normal stromal cells including _VIM_, _THY1_ and _COL6A3_.
-
+(\*) To the best of our knowledge, there is no Wilms tumor specific marker of stroma cells. They should express in some extend similar markers as normal stromal cells including *VIM*, *THY1* and *COL6A3*.
 
 ##### `Vimentin` expression
 
@@ -758,8 +692,7 @@ They should express in some extend similar markers as normal stromal cells inclu
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000026025")
 ```
 
-_VIM_ do not seem to be neither specific nor universal.
-
+*VIM* do not seem to be neither specific nor universal.
 
 ##### `COL6A3` expression
 
@@ -767,9 +700,7 @@ _VIM_ do not seem to be neither specific nor universal.
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000163359")
 ```
 
-_COL6A3_ expression is higher in Wilms tumor stroma cells and expressed across a wider range of samples. 
-
-
+*COL6A3* expression is higher in Wilms tumor stroma cells and expressed across a wider range of samples.
 
 ##### `THY1` expression
 
@@ -777,13 +708,11 @@ _COL6A3_ expression is higher in Wilms tumor stroma cells and expressed across a
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000154096")
 ```
 
-_THY1_ do not seem to be neither specific nor universal.
+*THY1* do not seem to be neither specific nor universal.
 
+#### Blastema
 
-#### Blastema 
-
-(*) To the best of our knowledges, there is no Wilms tumor specific and universel (i.e. expressed by all cells in every sample) marker of blastema cells.
-We expect however blastema cells to express higher levels of stemness markers such as _CITED1_, _SIX1/2_, _NCAM1_.
+(\*) To the best of our knowledge, there is no Wilms tumor specific and universal (i.e. expressed by all cells in every sample) marker of blastema cells. We expect however blastema cells to express higher levels of stemness markers such as `CITED1`, `SIX1/2`, `NCAM1`.
 
 ##### `CITED1` expression
 
@@ -791,8 +720,7 @@ We expect however blastema cells to express higher levels of stemness markers su
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000125931")
 ```
 
-Blastema cells are enriched in _CITED1_+ cells, but some samples do not express it at all. 
-
+Blastema cells are enriched in *CITED1*+ cells, but some samples do not express it at all.
 
 ##### `NCAM1` expression
 
@@ -800,7 +728,7 @@ Blastema cells are enriched in _CITED1_+ cells, but some samples do not express 
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000149294")
 ```
 
-_NCAM1_ seems to be more cancer specific and broadly expressed among samples.
+`NCAM1` seems to be more cancer specific and broadly expressed among samples.
 
 ##### `SIX2` expression
 
@@ -816,17 +744,13 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000039068")
 ```
 
-As expected, epithelial cells express higher expression of _CDH1_.
-
+As expected, epithelial cells express higher expression of `CDH1`.
 
 ##### `PODXL` expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000128567")
 ```
-
-
-
 
 ## Create annotation table for export
 
@@ -855,38 +779,27 @@ annotations_table <- cell_type_df |>
 write_tsv(annotations_table, annotations_tsv)
 ```
 
-
 Confirm how many samples we have annotations for:
+
 ```{r}
 length(unique(annotations_table$scpca_sample_id))
 ```
 
 ## Conclusion
 
-- Combining label transfer and CNV inference we have produced draft annotations for 35/40 Wilms tumor samples in SCPCP000006.
-We decided not to annotate samples for which the `infercnv` couldn't be run with a normal reference, as we don't trust the results in that case and want to avoid misclassification (`SCPCS000177`, `SCPCS000180`, `SCPCS000181`, `SCPCS000190`, `SCPCS000197`).
+-   Combining label transfer and CNV inference we have produced draft annotations for 35/40 Wilms tumor samples in SCPCP000006. We decided not to annotate samples for which the `infercnv` couldn't be run with a normal reference, as we don't trust the results in that case and want to avoid misclassification (`SCPCS000177`, `SCPCS000180`, `SCPCS000181`, `SCPCS000190`, `SCPCS000197`).
 
-- The mean CNV profile of the Wilms tumor cohort seems reasonable in regards to the one published in [Cresswell et al, BioRXiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
-We identify some commonalities but also some divergence. 
-They can be due to technical limitation of our CNV inference but can also reflect some specificities of this cohort (e.g. pre/post treatment samples).
-It would be really useful to compare for some sample the `infercnv` result to a ground truth such as SNP Array (to be requested). 
+-   The mean CNV profile of the Wilms tumor cohort seems reasonable in regards to the one published in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). We identify some commonalities but also some divergence. They can be due to technical limitation of our CNV inference but can also reflect some specificities of this cohort (e.g. pre/post treatment samples). It would be really useful to compare for some sample the `infercnv` result to a ground truth such as SNP Array (to be requested).
 
+-   The heatmaps of CNV proportion and marker genes support our annotations, but signals with some marker genes are very low. Also, there is no universal marker for each entity of Wilms tumor that cover all tumor cells from all patient. This makes the validation of the annotations quite difficult.
 
+-   However, we could try to take the problem from the other side, and used the current annotation to perform differential expression analysis and try to find marker genes that are consistent across patient and Wilms tumor histologies.
 
-- The heatmaps of CNV proportion and marker genes support our annotations, but signals with some marker genes are very low.
-Also, there is no universal marker for each entity of Wilms tumor that cover all tumor cells from all patient.
-This makes the validation of the annotations quite difficult.
+-   In each histology (i.e. epithelial and stroma), the distinction between cancer and non cancer cell is difficult (as expected). In this analysis, we suggested to rely on the CNV score to assess the normality of the cell. Here again, we could try to run differential expression analysis and compare epithelial (resp. stroma) cancer versus non-cancer cells across patient, aiming to find a share transcriptional program allowing the classification cancer versus normal.
 
-- However, we could try to take the problem from the other side, and used the current annotation to perform differential expression analysis and try to find marker genes that are consistent across patient and Wilms tumor histologies.
+-   In our annotation, we haven't taken into account the favorable/anaplastic status of the sample. However, as anaplasia can occur in every (but do not has to) Wilms tumor histology, I am not sure how to integrate the information into the annotation.
 
-- In each histology (i.e. epithelial and stroma), the distinction between cancer and non cancer cell is difficult (as expected).
-In this analysis, we suggested to rely on the CNV score to assess the normality of the cell.
-Here again, we could try to run differential expression analysis and compare epithelial (resp. stroma) cancer versus non-cancer cells across patient, aiming to find a share transcriptional program allowing the classification cancer versus normal.
-
-- In our annotation, we haven't taken into account the favorable/anaplastic status of the sample.
-However, as anaplasia can occur in every (but do not has to) Wilms tumor histology, I am not sure how to integrate the information into the annotation.
-
-- This notebook could be finally rendered using different parameters, i.e. threshold for the CNV score and predicted score to use.
+-   This notebook could be finally rendered using different parameters, i.e. threshold for the CNV score and predicted score to use.
 
 ## Session Info
 

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -106,7 +106,7 @@ From the pre-processed and labeled `Seurat` object from `results/{sample_id}/06_
 - the predicted compartment in `fetal_kidney_predicted.compartment` and `fetal_kidney_predicted.compartment.score`
 - the predicted cell type in `fetal_kidney_predicted.cell_type` and `fetal_kidney_predicted.cell_type.score`
 - the sample identifier in `sample_id`
-- the CNV `{dupli|loss}` estimation per chromosome {i} and arm `{p|q}`: `has_{dupli|loss}_chr{i}{p|q}`, in 1 to 22
+- the CNV `{dupli|loss}` estimate per chromosome `{i}`, where `i \in {1-22}`, and arm `{p|q}`: `has_{dupli|loss}_chr{i}{p|q}`
 - the `counts` of [markers genes](https://github.com/AlexsLemonade/OpenScPCA-analysis/tree/main/analyses/cell-type-wilms-tumor-06#the-table-celltype_metadatacsv-contains-the-following-column-and-information)
 
 ```{r path_to_query}

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -548,7 +548,7 @@ While the above heatmaps can be informative, because there are so many of them i
 Here we aim to plot a mean CNV profile across the 35 annotated samples as presented in Figure 1A of [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
 This represents the mean SNP Array profile of 64 pediatric kidney cancer (including 60 Wilms tumors).
 
-Here we plot for each chromosome arm (x-axis) the number of samples having a `dupli` (y-axis \> 0, in red) or a `loss` (y-axis \< 0, in blue).
+Here we plot for each chromosome arm (x-axis) the number of samples having a `dupli` (y-axis > 0, in red) or a `loss` (y-axis < 0, in blue).
 
 For a sample, a CNV is defined as `clonal` (opaque) if detected in more than 70% of the cells; and `subclonal` (transparent) when detected in at least 10% of the cells.
 
@@ -634,29 +634,29 @@ gain_profile <- wrap_plots(gain_profile, nrow = 1, widths = chromosome_arms$Size
 wrap_plots(gain_profile, loss_profile, ncol = 1) + plot_layout(widths = CNV_profile_gain$Size)
 ```
 
-Comparing with the profile in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1), we identified important CNV known to play a role in Wilms tumor, including:
+Comparing with the profile in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1), we identified important CNV known to play a role in Wilms tumor, including:
 
 - *chr8q*, *chr12*, *chr13*, *chr18q* gains
 - *chr11q*, *chr16*, *chr17q* loss
 
 However, we spotted some differences:
 
-- We couldn't detect any *chr4q* loss as described in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
+- We couldn't detect any *chr4q* loss as described in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
 
-- We identified 2 losses in *chr5* and *chr6* that do not show up in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
+- We identified 2 losses in *chr5* and *chr6* that do not show up in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
 These may be `infercnv` induced false-positive CNV.
 
 Our major concern is the pattern of the *chr1*. 
-We do see a tendency of *chr1p* loss and *chr1q* gain but it is not as pronounced as in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
-*chr1q* gain is however one of the most promising predictive marker of Wilms tumor outcome ([Nelson et al, Current Opinion in Pediatrics (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/)). 
-It is however important to notice that the profile shown in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1) derived from SIOP samples that have been pre-treated with chemotherapy, while samples in the dataset are enriched in `upfront resection` samples that haven't been pre-treated, according to the COG protocol. 
+We do see a tendency of *chr1p* loss and *chr1q* gain but it is not as pronounced as in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
+*chr1q* gain is however one of the most promising predictive marker of Wilms tumor outcome ([Nelson et al. (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/)).
+It is however important to notice that the profile shown in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1) derived from SIOP samples that have been pre-treated with chemotherapy, while samples in the dataset are enriched in `upfront resection` samples that haven't been pre-treated, according to the COG protocol.
 So far, we do not know how the pre-operative chemotherapy impact the clonal selection of specific CNV.
 
 ### Mean of the percentage of cells with CNV in a specific chromosome arm per clinical relevant group
 
 #### `vital_status`
 
-As described in [Nelson et al, Current Opinions in Pediatrics (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/), [Phelps et al, Children (2018)](https://pmc.ncbi.nlm.nih.gov/articles/PMC6262554/) and [Zheng et al, Frontiers in Oncology (2023)](https://www.frontiersin.org/journals/oncology/articles/10.3389/fonc.2023.1137346/full), LOH at *chr1p*, *chr11p* and *chr16q* as well as *chr1q* gain are prognostic factors.
+As described in [Nelson et al. (2020)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7919941/), [Phelps et al. (2018)](https://pmc.ncbi.nlm.nih.gov/articles/PMC6262554/) and [Zheng et al. (2023)](https://www.frontiersin.org/journals/oncology/articles/10.3389/fonc.2023.1137346/full), LOH at *chr1p*, *chr11p* and *chr16q* as well as *chr1q* gain are prognostic factors.
 
 Here we aim to see if we identify CNV associated with poorer prognosis.
 
@@ -668,14 +668,14 @@ In our study, we validate the association of *chr1q* gain, *chr11q* loss and *ch
 
 ##### `treatment`
 
-As we don't know the effect of the treatment on the selection of cells with CNV, it is difficult to compare our CNV profile with the one in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1). 
+As we don't know the effect of the treatment on the selection of cells with CNV, it is difficult to compare our CNV profile with the one in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
 We those check the repartition of CNV in samples that have been pre-treated (i.e `Resection post chemotherapy`) with samples that have been removed surgically before any treatment (i.e `Upfront resection`).
 
 ```{r fig.height=15, fig.width=20, message=FALSE, warning=FALSE, out.width='100%', results='asis'}
 do_BoxPlot_mean(df = cell_type_df_sub, group.by = "treatment", comparison = c("Upfront resection", "Resection post chemotherapy"))
 ```
 
-Our analysis suggest that there is indeed an enrichment in cells with CNV after chemotherapy, including a tendency of more *chr1q* gain samples after chemotherapy. This could explain some of the differences observed between our mean CNV profile and the one published in [Cresswell et al, bioRxiv (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
+Our analysis suggest that there is indeed an enrichment in cells with CNV after chemotherapy, including a tendency of more *chr1q* gain samples after chemotherapy. This could explain some of the differences observed between our mean CNV profile and the one published in [Cresswell et al. (2024)](https://www.biorxiv.org/content/10.1101/2024.09.04.610994v1).
 
 ### Validation of second level annotation using marker genes
 
@@ -687,7 +687,7 @@ Finally, we aim to validate the `second level annotation` using marker genes.
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000081237")
 ```
 
-Immune cells are well annotated based on `PTPRC` expression.
+Immune cells are well annotated based on *PTPRC* expression.
 
 #### Endothelium, `VWF` expression
 
@@ -695,7 +695,7 @@ Immune cells are well annotated based on `PTPRC` expression.
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000110799")
 ```
 
-Endothelial cells are well annotated based on `VWF` expression.
+Endothelial cells are well annotated based on *VWF* expression.
 
 #### Stroma
 

--- a/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
+++ b/analyses/cell-type-wilms-tumor-06/notebook/07_combined_annotation_across_samples_exploration.Rmd
@@ -42,13 +42,13 @@ The analysis can be summarized as the following:
 
 | first level annotation | second level annotation | selection of the cells | marker genes for validation | CNV validation |
 |----|----|----|----|----|
-| normal | endothelial | `compartment == "endothelium" & predicted.score > pred.thr` | `VWF` | no CNV |
-| normal | immune | `compartment == "immune" & predicted.score > pred.thr` | `PTPRC`, `CD163`, `CD68` | no CNV |
-| normal | kidney | `compartment == "fetal_nephron" & predicted.score > pred.thr & cnv_score < cnv.thr.lower` | `CDH1`, `PODXL`, `LTL` | no CNV |
-| normal | stroma | `compartment == "stroma" & predicted.score > pred.thr & cnv_score < cnv.thr.upper` | `VIM` | no CNV |
-| cancer | stroma | `compartment == "stroma" & cnv_score > cnv.thr.upper` | `VIM` | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
-| cancer | blastema | `compartment == "fetal_nephron" & cell_type == "mesenchymal cell" & cnv_score > cnv.thr.upper` | `CITED1` | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
-| cancer | epithelial | `compartment == "fetal_nephron" & cell_type != "mesenchymal cell" & cnv_score > cnv.thr.upper` | `CDH1` | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
+| normal | endothelial | `compartment == "endothelium" & predicted.score > pred.thr` | *VWF* | no CNV |
+| normal | immune | `compartment == "immune" & predicted.score > pred.thr` | *PTPRC*, *CD163*, *CD68* | no CNV |
+| normal | kidney | `compartment == "fetal_nephron" & predicted.score > pred.thr & cnv_score < cnv.thr.lower` | *CDH1*, *PODXL*, *LTL* | no CNV |
+| normal | stroma | `compartment == "stroma" & predicted.score > pred.thr & cnv_score < cnv.thr.upper` | *VIM* | no CNV |
+| cancer | stroma | `compartment == "stroma" & cnv_score > cnv.thr.upper` | *VIM* | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
+| cancer | blastema | `compartment == "fetal_nephron" & cell_type == "mesenchymal cell" & cnv_score > cnv.thr.upper` | *CITED1* | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
+| cancer | epithelial | `compartment == "fetal_nephron" & cell_type != "mesenchymal cell" & cnv_score > cnv.thr.upper` | *CDH1* | `proportion_cnv_chr: 1, 4, 11, 16, 17, 18` |
 | unknown | \- | the rest of the cells | \- | \- |
 
 with the defined parameters:
@@ -292,7 +292,7 @@ do_BoxPlot_mean <- function(df, group.by, comparison) {
 
 As done in `06_cnv_infercnv_exploration.Rmd`, we calculate single CNV score and assess its potential in identifying cells with CNV versus normal cells without CNV.
 
-We simply checked the `cnv_chr` for each chromosome across cells.
+For each cell, we checked the level of CNV for each chromosome.
 
 - If the cell has less than `r params$cnv_threshold_low` chromosome with CNV, the global `cnv_score` will be `FALSE`. 
 - If the cell has more than `r params$cnv_threshold_high` chromosome with CNV, the global `cnv_score` will be `TRUE`. 
@@ -481,7 +481,7 @@ We look for each `second.level_annotation` and `sample_id` at the proportion of 
 These heatmaps allow us to:
 
 - validate that mostly tumor cells do present high percentages of cells with CNV (by definition)
-- identify chromosome and cell types that might be more sensitive to *FALSE* positive CNV, such as `chr6p` which is a hub for immune genes
+- identify chromosome and cell types that might be more sensitive to *FALSE* positive CNV, such as *chr6p* which is a hub for immune genes
 - get the repartition per sample of the CNV
 
 #### Loss on long arms
@@ -681,7 +681,7 @@ Our analysis suggest that there is indeed an enrichment in cells with CNV after 
 
 Finally, we aim to validate the `second level annotation` using marker genes.
 
-#### Immune, `PTPRC` expression
+#### Immune, *PTPRC* expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000081237")
@@ -689,7 +689,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 
 Immune cells are well annotated based on *PTPRC* expression.
 
-#### Endothelium, `VWF` expression
+#### Endothelium, *VWF* expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000110799")
@@ -710,7 +710,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 
 *VIM* expression does not seem to be either specific or universal.
 
-##### `COL6A3` expression
+##### *COL6A3* expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000163359")
@@ -718,7 +718,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 
 *COL6A3* expression is higher in Wilms tumor stroma cells and expressed across a wider range of samples.
 
-##### `THY1` expression
+##### **THY1* expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000154096")
@@ -731,7 +731,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 (\*) To the best of our knowledge, there is no Wilms tumor specific and universal (i.e. expressed by all cells in every sample) marker of blastema cells. 
 We expect however blastema cells to express higher levels of stemness markers such as *CITED1*, *SIX1/2*, *NCAM1*.
 
-##### `CITED1` expression
+##### *CITED1* expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000125931")
@@ -739,7 +739,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 
 Blastema cells are enriched in *CITED1+* cells, but some samples do not express it at all.
 
-##### `NCAM1` expression
+##### *NCAM1* expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000149294")
@@ -747,7 +747,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 
 *NCAM1* seems to be more cancer specific and broadly expressed among samples.
 
-##### `SIX2` expression
+##### *SIX2* expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000170577")
@@ -755,7 +755,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 
 #### Epithelium
 
-##### `CDH1` expression
+##### *CDH1* expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000039068")
@@ -763,7 +763,7 @@ do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature 
 
 As expected, epithelial cells express higher expression of *CDH1*.
 
-##### `PODXL` expression
+##### *PODXL* expression
 
 ```{r fig.width=20, fig.height=5, out.width='100%', results='asis'}
 do_Feature_mean(cell_type_df_sub, group.by = "second.level_annotation", feature = "ENSG00000128567")


### PR DESCRIPTION
Closes #1074 

This PR fixes typos, and re-renders the relevant notebook where typos were fixed. VS Code ate up some whitespace here, so recommended to turn that off for review.