### PR TITLE
Add template to explore ewings inferCNV results

### DIFF
--- a/analyses/infercnv-consensus-cell-type/README.md
+++ b/analyses/infercnv-consensus-cell-type/README.md
@@ -1,4 +1,4 @@
-# infercnv-consensus-cell-type
+# `infercnv-consensus-cell-type`
 
 ## Description
 

--- a/analyses/infercnv-consensus-cell-type/exploratory-notebooks/README.md
+++ b/analyses/infercnv-consensus-cell-type/exploratory-notebooks/README.md
@@ -1,3 +1,3 @@
-This directory contains explotory notehebooks that are not specifically run in the analysis pipeline.
+This directory contains exploratory notebooks that are not specifically run in the analysis pipeline.
 
 * `01_ewings-consensus-cell-types.Rmd` explores the distribution of immune cells across samples in `SCPCP000015` to determine approaches for creating a pooled normal reference

--- a/analyses/infercnv-consensus-cell-type/references/README.md
+++ b/analyses/infercnv-consensus-cell-type/references/README.md
@@ -15,7 +15,7 @@ Normal references for use with `inferCNV` are formatted as SCE files and are exp
 * Reference SCEs should contain at least:
   * A raw counts matrix
   * Column names (cell ids) formatted as `{library_id}-{barcode}`
-  * A colData column `consensus_annotation` recording each cell's consensus annotation
+  * A `colData` column `consensus_annotation` recording each cell's consensus annotation
 
 
 The `normal-references/` directory contains the following references for each given project:

--- a/analyses/infercnv-consensus-cell-type/renv.lock
+++ b/analyses/infercnv-consensus-cell-type/renv.lock
@@ -414,6 +414,53 @@
       "NeedsCompilation": "yes",
       "Author": "Hervé Pagès [aut, cre], Aaron Lun [ctb], Peter Hickey [ctb]"
     },
+    "DelayedMatrixStats": {
+      "Package": "DelayedMatrixStats",
+      "Version": "1.26.0",
+      "Source": "Bioconductor",
+      "Type": "Package",
+      "Title": "Functions that Apply to Rows and Columns of 'DelayedMatrix' Objects",
+      "Date": "2024-04-23",
+      "Authors@R": "c(person(\"Peter\", \"Hickey\", role = c(\"aut\", \"cre\"), email = \"peter.hickey@gmail.com\", comment = c(ORCID = \"0000-0002-8153-6258\")), person(\"Hervé\", \"Pagès\", role = \"ctb\", email = \"hpages.on.github@gmail.com\"), person(\"Aaron\", \"Lun\", role = \"ctb\", email = \"infinite.monkeys.with.keyboards@gmail.com\"))",
+      "Description": "A port of the 'matrixStats' API for use with DelayedMatrix objects  from the 'DelayedArray' package. High-performing functions operating on rows  and columns of DelayedMatrix objects, e.g. col / rowMedians(),  col / rowRanks(), and col / rowSds(). Functions optimized per data type and  for subsetted calculations such that both memory usage and processing time is  minimized.",
+      "License": "MIT + file LICENSE",
+      "Encoding": "UTF-8",
+      "Roxygen": "list(markdown = TRUE)",
+      "RoxygenNote": "7.3.1",
+      "Depends": [
+        "MatrixGenerics (>= 1.15.1)",
+        "DelayedArray (>= 0.27.10)"
+      ],
+      "Imports": [
+        "methods",
+        "sparseMatrixStats (>= 1.13.2)",
+        "Matrix (>= 1.5-0)",
+        "S4Vectors (>= 0.17.5)",
+        "IRanges (>= 2.25.10)"
+      ],
+      "Suggests": [
+        "testthat",
+        "knitr",
+        "rmarkdown",
+        "BiocStyle",
+        "microbenchmark",
+        "profmem",
+        "HDF5Array",
+        "matrixStats (>= 1.0.0)"
+      ],
+      "VignetteBuilder": "knitr",
+      "URL": "https://github.com/PeteHaitch/DelayedMatrixStats",
+      "BugReports": "https://github.com/PeteHaitch/DelayedMatrixStats/issues",
+      "biocViews": "Infrastructure, DataRepresentation, Software",
+      "git_url": "https://git.bioconductor.org/packages/DelayedMatrixStats",
+      "git_branch": "RELEASE_3_19",
+      "git_last_commit": "5774778",
+      "git_last_commit_date": "2024-04-30",
+      "Repository": "Bioconductor 3.19",
+      "NeedsCompilation": "no",
+      "Author": "Peter Hickey [aut, cre] (<https://orcid.org/0000-0002-8153-6258>), Hervé Pagès [ctb], Aaron Lun [ctb]",
+      "Maintainer": "Peter Hickey <peter.hickey@gmail.com>"
+    },
     "FNN": {
       "Package": "FNN",
       "Version": "1.1.4.1",
@@ -2125,6 +2172,51 @@
       "Repository": "RSPM",
       "Encoding": "UTF-8"
     },
+    "beachmat": {
+      "Package": "beachmat",
+      "Version": "2.20.0",
+      "Source": "Bioconductor",
+      "Date": "2024-03-28",
+      "Title": "Compiling Bioconductor to Handle Each Matrix Type",
+      "Encoding": "UTF-8",
+      "Authors@R": "c(person(\"Aaron\", \"Lun\", role = c(\"aut\", \"cre\"), email = \"infinite.monkeys.with.keyboards@gmail.com\"), person(\"Hervé\", \"Pagès\", role=\"aut\"), person(\"Mike\", \"Smith\", role=\"aut\"))",
+      "Imports": [
+        "methods",
+        "DelayedArray (>= 0.27.2)",
+        "SparseArray",
+        "BiocGenerics",
+        "Matrix",
+        "Rcpp"
+      ],
+      "Suggests": [
+        "testthat",
+        "BiocStyle",
+        "knitr",
+        "rmarkdown",
+        "rcmdcheck",
+        "BiocParallel",
+        "HDF5Array"
+      ],
+      "LinkingTo": [
+        "Rcpp"
+      ],
+      "biocViews": "DataRepresentation, DataImport, Infrastructure",
+      "Description": "Provides a consistent C++ class interface for reading from a variety of commonly used matrix types.  Ordinary matrices and several sparse/dense Matrix classes are directly supported,  along with a subset of the delayed operations implemented in the DelayedArray package. All other matrix-like objects are supported by calling back into R.",
+      "License": "GPL-3",
+      "NeedsCompilation": "yes",
+      "VignetteBuilder": "knitr",
+      "SystemRequirements": "C++17",
+      "URL": "https://github.com/tatami-inc/beachmat",
+      "BugReports": "https://github.com/tatami-inc/beachmat/issues",
+      "RoxygenNote": "7.3.1",
+      "git_url": "https://git.bioconductor.org/packages/beachmat",
+      "git_branch": "RELEASE_3_19",
+      "git_last_commit": "fe0b119",
+      "git_last_commit_date": "2024-04-30",
+      "Repository": "Bioconductor 3.19",
+      "Author": "Aaron Lun [aut, cre], Hervé Pagès [aut], Mike Smith [aut]",
+      "Maintainer": "Aaron Lun <infinite.monkeys.with.keyboards@gmail.com>"
+    },
     "bit": {
       "Package": "bit",
       "Version": "4.6.0",
@@ -3363,6 +3455,48 @@
       "Author": "Richard Iannone [aut, cre] (<https://orcid.org/0000-0003-3925-190X>), Christophe Dervieux [ctb] (<https://orcid.org/0000-0003-4474-2498>), Winston Chang [ctb], Dave Gandy [ctb, cph] (Font-Awesome font), Posit Software, PBC [cph, fnd]",
       "Maintainer": "Richard Iannone <rich@posit.co>",
       "Repository": "RSPM"
+    },
+    "forcats": {
+      "Package": "forcats",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Title": "Tools for Working with Categorical Variables (Factors)",
+      "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@rstudio.com\", role = c(\"aut\", \"cre\")), person(\"RStudio\", role = c(\"cph\", \"fnd\")) )",
+      "Description": "Helpers for reordering factor levels (including moving specified levels to front, ordering by first appearance, reversing, and randomly shuffling), and tools for modifying factor levels (including collapsing rare levels into other, 'anonymising', and manually 'recoding').",
+      "License": "MIT + file LICENSE",
+      "URL": "https://forcats.tidyverse.org/, https://github.com/tidyverse/forcats",
+      "BugReports": "https://github.com/tidyverse/forcats/issues",
+      "Depends": [
+        "R (>= 3.4)"
+      ],
+      "Imports": [
+        "cli (>= 3.4.0)",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "rlang (>= 1.0.0)",
+        "tibble"
+      ],
+      "Suggests": [
+        "covr",
+        "dplyr",
+        "ggplot2",
+        "knitr",
+        "readr",
+        "rmarkdown",
+        "testthat (>= 3.0.0)",
+        "withr"
+      ],
+      "VignetteBuilder": "knitr",
+      "Config/Needs/website": "tidyverse/tidytemplate",
+      "Config/testthat/edition": "3",
+      "Encoding": "UTF-8",
+      "LazyData": "true",
+      "RoxygenNote": "7.2.3",
+      "NeedsCompilation": "no",
+      "Author": "Hadley Wickham [aut, cre], RStudio [cph, fnd]",
+      "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
+      "Repository": "CRAN"
     },
     "foreach": {
       "Package": "foreach",
@@ -6711,6 +6845,59 @@
       "Maintainer": "Saket Choudhary <schoudhary@nygenome.org>",
       "Repository": "RSPM"
     },
+    "scuttle": {
+      "Package": "scuttle",
+      "Version": "1.14.0",
+      "Source": "Bioconductor",
+      "Type": "Package",
+      "Authors@R": "c( person(\"Aaron\", \"Lun\", role = c(\"aut\", \"cre\"), email=\"infinite.monkeys.with.keyboards@gmail.com\"), person(\"Davis\", \"McCarthy\", role=\"aut\") )",
+      "Date": "2024-03-05",
+      "License": "GPL-3",
+      "Title": "Single-Cell RNA-Seq Analysis Utilities",
+      "Description": "Provides basic utility functions for performing single-cell analyses, focusing on simple normalization, quality control and data transformations. Also provides some helper functions to assist development of other packages.",
+      "Depends": [
+        "SingleCellExperiment"
+      ],
+      "Imports": [
+        "methods",
+        "utils",
+        "stats",
+        "Matrix",
+        "Rcpp",
+        "BiocGenerics",
+        "S4Vectors",
+        "BiocParallel",
+        "GenomicRanges",
+        "SummarizedExperiment",
+        "DelayedArray",
+        "DelayedMatrixStats",
+        "beachmat"
+      ],
+      "Suggests": [
+        "BiocStyle",
+        "knitr",
+        "scRNAseq",
+        "rmarkdown",
+        "testthat",
+        "scran"
+      ],
+      "VignetteBuilder": "knitr",
+      "biocViews": "ImmunoOncology, SingleCell, RNASeq, QualityControl, Preprocessing, Normalization, Transcriptomics, GeneExpression, Sequencing, Software, DataImport",
+      "LinkingTo": [
+        "Rcpp",
+        "beachmat"
+      ],
+      "SystemRequirements": "C++11",
+      "RoxygenNote": "7.2.3",
+      "NeedsCompilation": "yes",
+      "git_url": "https://git.bioconductor.org/packages/scuttle",
+      "git_branch": "RELEASE_3_19",
+      "git_last_commit": "7e2bcae",
+      "git_last_commit_date": "2024-04-30",
+      "Repository": "Bioconductor 3.19",
+      "Author": "Aaron Lun [aut, cre], Davis McCarthy [aut]",
+      "Maintainer": "Aaron Lun <infinite.monkeys.with.keyboards@gmail.com>"
+    },
     "shiny": {
       "Package": "shiny",
       "Version": "1.10.0",
@@ -6940,6 +7127,50 @@
       "Maintainer": "Reinhard Furrer <reinhard.furrer@math.uzh.ch>",
       "Repository": "CRAN",
       "Encoding": "UTF-8"
+    },
+    "sparseMatrixStats": {
+      "Package": "sparseMatrixStats",
+      "Version": "1.16.0",
+      "Source": "Bioconductor",
+      "Type": "Package",
+      "Title": "Summary Statistics for Rows and Columns of Sparse Matrices",
+      "Authors@R": "person(\"Constantin\", \"Ahlmann-Eltze\", email = \"artjom31415@googlemail.com\",  role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-3762-068X\"))",
+      "Description": "High performance functions for row and column operations on sparse matrices. For example: col / rowMeans2, col / rowMedians, col / rowVars etc. Currently, the optimizations are limited to data in the column sparse format.  This package is inspired by the matrixStats package by Henrik Bengtsson.",
+      "License": "MIT + file LICENSE",
+      "Encoding": "UTF-8",
+      "RoxygenNote": "7.3.1",
+      "LinkingTo": [
+        "Rcpp"
+      ],
+      "Imports": [
+        "Rcpp",
+        "Matrix",
+        "matrixStats (>= 0.60.0)",
+        "methods"
+      ],
+      "Depends": [
+        "MatrixGenerics (>= 1.5.3)"
+      ],
+      "Suggests": [
+        "testthat (>= 2.1.0)",
+        "knitr",
+        "bench",
+        "rmarkdown",
+        "BiocStyle"
+      ],
+      "SystemRequirements": "C++11",
+      "VignetteBuilder": "knitr",
+      "URL": "https://github.com/const-ae/sparseMatrixStats",
+      "BugReports": "https://github.com/const-ae/sparseMatrixStats/issues",
+      "biocViews": "Infrastructure, Software, DataRepresentation",
+      "git_url": "https://git.bioconductor.org/packages/sparseMatrixStats",
+      "git_branch": "RELEASE_3_19",
+      "git_last_commit": "2ad650c",
+      "git_last_commit_date": "2024-04-30",
+      "Repository": "Bioconductor 3.19",
+      "NeedsCompilation": "yes",
+      "Author": "Constantin Ahlmann-Eltze [aut, cre] (<https://orcid.org/0000-0002-3762-068X>)",
+      "Maintainer": "Constantin Ahlmann-Eltze <artjom31415@googlemail.com>"
     },
     "spatstat.data": {
       "Package": "spatstat.data",

--- a/analyses/infercnv-consensus-cell-type/run-analysis.sh
+++ b/analyses/infercnv-consensus-cell-type/run-analysis.sh
@@ -12,6 +12,9 @@ set -euo pipefail
 module_dir=$(dirname "${BASH_SOURCE[0]}")
 cd ${module_dir}
 
+# By default, use 4 cores
+threads=4
+
 # Define directories and file paths
 data_dir="../../data/current"
 script_dir="scripts"
@@ -69,12 +72,16 @@ for sample_id in $sample_ids; do
         Rscript ${script_dir}/01_run-infercnv.R \
             --sce_file $sce_file \
             --reference_file $immune_ref_file \
-            --output_dir $sample_results_dir/ref-all-immune/
+            --output_dir $sample_results_dir/ref-all-immune \
+            --hmm_model "i3" \
+            --threads $threads
 
         Rscript ${script_dir}/01_run-infercnv.R \
             --sce_file $sce_file \
             --reference_file $immune_subset_ref_file \
-            --output_dir $sample_results_dir/ref-subset-immune/
+            --output_dir $sample_results_dir/ref-subset-immune \
+            --hmm_model "i3" \
+            --threads $threads
 
     done
 done

--- a/analyses/infercnv-consensus-cell-type/run-analysis.sh
+++ b/analyses/infercnv-consensus-cell-type/run-analysis.sh
@@ -73,14 +73,14 @@ for sample_id in $sample_ids; do
             --sce_file $sce_file \
             --reference_file $immune_ref_file \
             --output_dir $sample_results_dir/ref-all-immune \
-            --hmm_model "i3" \
+            --hmm_model "i6" \
             --threads $threads
 
         Rscript ${script_dir}/01_run-infercnv.R \
             --sce_file $sce_file \
             --reference_file $immune_subset_ref_file \
             --output_dir $sample_results_dir/ref-subset-immune \
-            --hmm_model "i3" \
+            --hmm_model "i6" \
             --threads $threads
 
     done

--- a/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
@@ -145,6 +145,12 @@ library_id <- metadata(sce)$library_id
 # organize scratch by library id
 scratch_dir <- file.path(opts$scratch_dir, library_id)
 
+# if scratch_dir exists, we need to remove it to prevent conflicts from previous inferCNV runs
+if (dir.exists(scratch_dir)) {
+  fs::dir_delete(scratch_dir)
+}
+
+
 # ensure directories we need exist
 fs::dir_create(c(
   opts$output_dir,

--- a/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
@@ -40,8 +40,8 @@ option_list <- list(
   make_option(
     opt_str = c("--hmm_model"),
     type = "character",
-    default = "i3",
-    help = "The HMM model to use with inferCNV, either 'i3' or 'i6'. Default is i3."
+    default = "i6",
+    help = "The HMM model to use with inferCNV, either 'i3' or 'i6'. Default is i6."
   ),
   make_option(
     opt_str = c("--skip_hmm"),

--- a/analyses/infercnv-consensus-cell-type/scripts/README.md
+++ b/analyses/infercnv-consensus-cell-type/scripts/README.md
@@ -12,4 +12,4 @@ These SCE objects should contain at least:
 
 * A raw counts matrix
 * Column names (cell ids) formatted as `{library_id}-{barcode}`
-* A colData column `consensus_annotation` recording each cell's consensus annotation
+* A `colData` column `consensus_annotation` recording each cell's consensus annotation

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/README.md
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/README.md
@@ -1,0 +1,4 @@
+This directory contains template notebooks meant to be run across libraries.
+
+* `ewings-infercnv-results.Rmd` explores results from running `inferCNV` on Ewing sarcoma samples from `SCPCP000015`
+

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
@@ -14,11 +14,20 @@ params:
 
 ## Introduction
 
-Here, we have run `inferCNV` with the following settings:
+This notebook explores `inferCNV` results run on library `params$library_id` from `SCPCP000015`.
+`inferCNV` was run with two different normal references:
 
-* With two references, `all-immune` and `subset-immune`
-  * The former contains all consensus immune cells, _excluding_ any which were also identified as tumor in the `cell-type-ewings` analysis module
-  * The latter is a subset of those immune cells considering only macrophage and T-cell cell types.
+* `all-immune`: All consensus immune cells across `SCPCP000015` libraries, _excluding_ any which were also identified as tumor in the `cell-type-ewings` analysis module
+* `subset-immnune`: A subset of `all-immune`, considering only macrophage and T-cell cell types
+
+`inferCNV` was run with the following settings:
+
+* We used the `i3` HMM which has improved run times relative to their `i6` HMM
+* We used the default `analysis_mode = "subclusters"`, which allows the HMM to call CNVs at the level of clusters rather than whole samples or individual cells
+* We used the following clustering parameters:
+  * Leiden clustering run on PCA (not the expression matrix)
+  * `k=20` nearest neighbors with a `resolution` parameter of 1 and using the `modularity` objective function 
+
 
 ## Setup
 
@@ -32,14 +41,14 @@ library(patchwork)
 # Set default ggplot theme, customized for UMAPs
 theme_set(theme_bw())
 
-
-#   theme(
-#     plot.margin = margin(rep(20, 4)),
-#     axis.text = element_blank(),
-#     axis.ticks = element_blank(),
-#     panel.grid = element_blank(),
-#     aspect.ratio = 1
-#   )
+umap_theme <- list(
+  coord_fixed(),
+  theme_classic(),
+  theme(
+    axis.ticks = element_blank(),
+    axis.text = element_blank()
+  )
+)
 ```
 
 ### Paths
@@ -63,13 +72,11 @@ data_dir <- file.path(repository_base, "data", "current")
 
 #### Input and output files
 
-Set paths to input and output directories and files in the chunk below.
-
 ```{r paths}
-# cnv validations
+# TSV with expected Ewing CNVs
 validation_tsv <- file.path(ref_dir, "cnv-validation.tsv")
 
-# references themselves so we know which cells belong to reference
+# References themselves so we know which cells belong to reference
 immune_ref_sce_file <- file.path(ref_dir, "normal-references", "SCPCP000015", "ref-all-immune.rds")
 subset_ref_sce_file <- file.path(ref_dir, "normal-references", "SCPCP000015", "ref-subset-immune.rds")
 
@@ -79,7 +86,7 @@ immune_png <- file.path(infercnv_immune_dir, glue::glue("{params$library_id}_inf
 subset_hmm_tsv <- file.path(infercnv_subset_dir, glue::glue("{params$library_id}_cnv-metadata.tsv"))
 subset_png <- file.path(infercnv_subset_dir, glue::glue("{params$library_id}_infercnv.png"))
 
-# cell types
+# ewings and consensus cell types
 ewings_tsv <- file.path(
   data_dir,
   "results",
@@ -98,17 +105,11 @@ sce_file <- file.path(
 )
 ```
 
-
-- we also need to read in the cnv-validations.tsv
-
-- section 1: what are the cnvs that they detected? do this from the hmm output at least
-- section 2: what is the relationship between consensus cell types and the cnvs? is there one?
-- section 3: what are the clusters? how big are they? what is their relationship to the cnv scores? do we want to show them on a UMAP?
-
 ### Read in data
 
 ```{r message = FALSE}
-validation_df <- readr::read_tsv(validation_tsv)
+validation_df <- readr::read_tsv(validation_tsv) |>
+  dplyr::filter(diagnosis == "Ewing sarcoma")
 
 celltype_df <- readr::read_tsv(ewings_tsv) |>
   dplyr::select(barcodes, consensus_annotation, ewing_annotation)
@@ -133,20 +134,8 @@ infercnv_df <- readr::read_tsv(immune_hmm_tsv) |>
     is_subset_reference = barcodes %in% subset_ref_barcodes
   )
 
-# Separate normal reference from query cells
-# cnv_query_df <- infercnv_df |>
-#  dplyr::filter(
-#    stringr::str_starts(cell_id, params$library_id)
-#  ) |>
-#  dplyr::mutate(
-#    barcodes = stringr::str_remove(cell_id, glue::glue("{params$library_id}-"))
-#  )
-# cnv_reference_df <- dplyr::anti_join(infercnv_df, cnv_query_df)
-
 # Read SCE and create data frame with full results
-sce <- readr::read_rds(sce_file)
-
-cnv_df <- sce |>
+cnv_df <- readr::read_rds(sce_file) |>
   scuttle::makePerCellDF(use.dimred = "UMAP") |>
   # replace UMAP.1 with UMAP1
   dplyr::rename_with(
@@ -155,18 +144,12 @@ cnv_df <- sce |>
   # add in hmm results
   dplyr::left_join(infercnv_df, by = "barcodes") |>
   # add in cell type results
-  dplyr::left_join(celltype_df)
-
-rm(sce)
-
-# remove MT and GL chromosomes
-chr_columns_to_keep <- which(
-  !stringr::str_detect(
-    names(cnv_df),
-    "chrMT|chrGL000219.1|chrGL000194.1"
+  dplyr::left_join(celltype_df) |>
+  # remove MT and GL chromosomes
+  dplyr::select(
+    -contains("chrMT"),
+    -contains("chrGL")
   )
-)
-cnv_df <- cnv_df[, chr_columns_to_keep]
 ```
 
 
@@ -184,30 +167,23 @@ Below, we show the `inferCNV` heatmaps from the `immune-all` and `immune-subset`
 
 
 
-## Distributions of CNVs per cell
+## Distribution of CNVs per cell
 
-First, the total number of chromosomes with CNVs, with the goal of comparing reference to query cells.
-We hope for a bimodal distribution where reference cells are near zero, and higher values for putative tumor cells in the query set.
+This section contains figures showing the total number of CNVs detected per cell. 
 
+### CNVs in reference vs query cells
+
+The figures below compare the number of CNVs per cell between reference and query cells. 
+Ideally, we'll see a bimodal distribution where reference cells are at/near zero, and there is a peak of higher values which may represent tumor cells.
+In the density plots below, distributions are colored based on whether the cells are in the reference or not (aka, query cells).
 
 ```{r}
 # grab any columns that have has_cnv
 has_cnv_cols <- names(cnv_df)[stringr::str_starts(names(cnv_df), "has_cnv")]
 
 per_cell_cnv_df <- cnv_df |>
-  dplyr::mutate(total_cnv_per_cell = rowSums(dplyr::across(has_cnv_cols))) |>
-  dplyr::select(
-    barcodes,
-    UMAP1,
-    UMAP2,
-    infercnv_cluster = subcluster,
-    total_cnv_per_cell,
-    consensus_annotation,
-    ewing_annotation,
-    normal_reference,
-    is_immune_reference,
-    is_subset_reference
-  )
+  dplyr::mutate(total_cnv_per_cell = rowSums(dplyr::across(dplyr::all_of(has_cnv_cols)))) |>
+  dplyr::rename(infercnv_cluster = subcluster)
 ```
 
 
@@ -238,7 +214,12 @@ wrap_plots(all_plot, subset_plot, guides = "collect") +
   plot_annotation(title = "Total CNVs per cell") &
   theme(legend.position = "bottom")
 ```
-Now, let's look at this total CNV per cell but across cell types, using our two sets:
+
+### CNVs across cell types
+
+Next, we'll look at the per-cell distributions of CNVs across cell types.
+Specifically, we'll look at both the cell types from the `cell-type-consensus` module and the `cell-type-ewings` module separately.
+Ideally, we'll see that Unknown cells from `cell-type-consensus` and cells labeled as tumor in `cell-type-ewings` will have relatively higher CNV scores compared to other cell types.
 
 ```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}
 consensus_violin <- ggplot(per_cell_cnv_df) +
@@ -272,42 +253,24 @@ wrap_plots(consensus_violin, ewings_violin, ncol = 1, guides = "collect") +
 
 ## UMAPs
 
+Next, we'll visualize the total CNV counts as a UMAP.
+
+First, as a guide, let's look at the top 10 `cell-type-ewings` cell types.
 
 
-```{r fig.width = 10, fig.height = 5}
-### UMAPs of the cell types as a guide ####
-# TODO: colors could be more matched but may not be worth it?
-
-ewings_umap <- per_cell_cnv_df |>
+```{r}
+per_cell_cnv_df |>
   # arbitrary filtering, this is just data
   dplyr::filter(normal_reference == "all-immune") |>
   ggplot() +
   aes(x = UMAP1, y = UMAP2, color = forcats::fct_lump(ewing_annotation, 8)) +
   geom_point(size = 0.1, alpha = 0.3) +
   facet_wrap(vars(normal_reference)) +
-  labs(
-    title = "Ewings cell type",
-    color = "annotation"
-  ) +
-  guides(color = guide_legend(override.aes = list(size = 2, alpha = 1)))
-
-consensus_umap <- per_cell_cnv_df |>
-  # arbitrary filtering, this is just data
-  dplyr::filter(normal_reference == "all-immune") |>
-  ggplot() +
-  aes(x = UMAP1, y = UMAP2, color = forcats::fct_lump(consensus_annotation, 8)) +
-  geom_point(size = 0.1, alpha = 0.3) +
-  facet_wrap(vars(normal_reference)) +
-  labs(
-    title = "Consensus cell type",
-    color = "annotation"
-  ) +
-  guides(color = guide_legend(override.aes = list(size = 2, alpha = 1)))
-
-
-wrap_plots(ewings_umap, consensus_umap)
+  labs(color = "annotation") +
+  guides(color = guide_legend(override.aes = list(size = 2, alpha = 1))) +
+  umap_theme
 ```
-
+Next, the total CNVs per cell; ideally, higher values will overlap with regions in the UMAP containing putative tumor cells.
 
 ```{r fig.width=10}
 ggplot(per_cell_cnv_df) +
@@ -315,14 +278,23 @@ ggplot(per_cell_cnv_df) +
   geom_point(size = 0.1, alpha = 0.3) +
   scale_color_viridis_c() +
   facet_wrap(vars(normal_reference)) +
-  labs(title = "Total CNV per cell")
+  labs(title = "Total CNV per cell") +
+  umap_theme
+```
+
+## Clusters
+
+Part of `inferCNV`'s algorithm involves clustering the data, and poor clusters have the potential to lead to inaccurate inferences of CNV. 
+To see whether we'd like to further tune the clustering parameters, we'll get a size of some of their properties here:
 
 
+How many cells are there per cluster?
+Clusters labeled `reference_` contain only normal reference cells, and clusters labeled `unknown_` contain the query cells.
 
+```{r}
 cells_per_cluster <- per_cell_cnv_df |>
   dplyr::count(infercnv_cluster, normal_reference)
 
-# How many cells per cluster?
 ggplot(cells_per_cluster) +
   aes(
     x = infercnv_cluster, # keep in default order so "reference" and "unknown" are grouped
@@ -334,8 +306,10 @@ ggplot(cells_per_cluster) +
     scales = "free_x"
   ) +
   theme(axis.text.x = element_text(angle = 45, hjust = 1))
+```
 
 
+```{r}
 # How many CNV per cell per cluster?
 ggplot(per_cell_cnv_df) +
   aes(x = infercnv_cluster, y = total_cnv_per_cell) +
@@ -351,7 +325,60 @@ ggplot(per_cell_cnv_df) +
 
 ## CNV across chromosomes
 
+We want to look across chrs now, specifically:
 
+```{r}
+validation_df
+```
+
+```{r}
+cnv_validation_df <- per_cell_cnv_df |>
+  dplyr::select(
+    barcodes,
+    infercnv_cluster,
+    total_cnv_per_cell,
+    normal_reference,
+    is_immune_reference,
+    is_subset_reference,
+    all_of(
+      c(
+        glue::glue("proportion_scaled_cnv_chr{1:22}"),
+        glue::glue("proportion_scaled_loss_chr{1:22}"),
+        glue::glue("proportion_scaled_dupli_chr{1:22}")
+      )
+    )
+  ) |>
+  tidyr::pivot_longer(
+    starts_with("proportion_scaled_"),
+    names_to = "cnv_type_raw",
+    values_to = "proportion"
+  ) |>
+  dplyr::mutate(cnv_type_raw = stringr::str_remove(cnv_type_raw, "^proportion_scaled_")) |>
+  tidyr::separate(cnv_type_raw, into = c("cnv_type", "chr")) |>
+  dplyr::mutate(chr = stringr::str_remove(chr, "^chr"), chr = as.numeric(chr))
+```
+
+```{r}
+cnv_validation_df |>
+  dplyr::filter(normal_reference == "subset-immune") |>
+  ggplot() +
+  aes(
+    x = proportion,
+    color = is_subset_reference
+  ) +
+  geom_density() +
+  facet_wrap(vars(chr))
+
+
+cnv_validation_df |>
+  dplyr::group_by(
+    normal_reference,
+    cnv_type,
+    chr
+  ) |>
+  dplyr::summarize(median_proportion = median(proportion)) |>
+  dplyr::arrange(cnv_type)
+```
 
 ## Session Info
 

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
@@ -1,0 +1,361 @@
+---
+title: "`r glue::glue('Initial inferCNV results for {params$library_id}')`"
+author: "Stephanie J. Spielman"
+date: "`r Sys.Date()`"
+output:
+  html_notebook:
+    toc: true
+    toc_depth: 3
+params:
+  sample_id: SCPCS000490
+  library_id: SCPCL000822
+---
+
+
+## Introduction
+
+Here, we have run `inferCNV` with the following settings:
+
+* With two references, `all-immune` and `subset-immune`
+  * The former contains all consensus immune cells, _excluding_ any which were also identified as tumor in the `cell-type-ewings` analysis module
+  * The latter is a subset of those immune cells considering only macrophage and T-cell cell types.
+
+## Setup
+
+```{r}
+options(readr.show_col_types = FALSE)
+
+library(SingleCellExperiment)
+library(ggplot2)
+library(patchwork)
+
+# Set default ggplot theme, customized for UMAPs
+theme_set(theme_bw())
+
+
+#   theme(
+#     plot.margin = margin(rep(20, 4)),
+#     axis.text = element_blank(),
+#     axis.ticks = element_blank(),
+#     panel.grid = element_blank(),
+#     aspect.ratio = 1
+#   )
+```
+
+### Paths
+
+#### Base directories
+
+```{r base paths}
+# The base path for the OpenScPCA repository, found by its (hidden) .git directory
+repository_base <- rprojroot::find_root(rprojroot::is_git_root)
+
+# InferCNV directories
+analysis_dir <- file.path(repository_base, "analyses", "infercnv-consensus-cell-type")
+ref_dir <- file.path(analysis_dir, "references")
+infercnv_dir <- file.path(analysis_dir, "results", "SCPCP000015", params$sample_id)
+infercnv_immune_dir <- file.path(infercnv_dir, "ref-all-immune")
+infercnv_subset_dir <- file.path(infercnv_dir, "ref-subset-immune")
+
+# OpenScpCA data and results directories
+data_dir <- file.path(repository_base, "data", "current")
+```
+
+#### Input and output files
+
+Set paths to input and output directories and files in the chunk below.
+
+```{r paths}
+# cnv validations
+validation_tsv <- file.path(ref_dir, "cnv-validation.tsv")
+
+# references themselves so we know which cells belong to reference
+immune_ref_sce_file <- file.path(ref_dir, "normal-references", "SCPCP000015", "ref-all-immune.rds")
+subset_ref_sce_file <- file.path(ref_dir, "normal-references", "SCPCP000015", "ref-subset-immune.rds")
+
+# input infercnv files from both references, "all-immune" and "subset-immune"
+immune_hmm_tsv <- file.path(infercnv_immune_dir, glue::glue("{params$library_id}_cnv-metadata.tsv"))
+immune_png <- file.path(infercnv_immune_dir, glue::glue("{params$library_id}_infercnv.png"))
+subset_hmm_tsv <- file.path(infercnv_subset_dir, glue::glue("{params$library_id}_cnv-metadata.tsv"))
+subset_png <- file.path(infercnv_subset_dir, glue::glue("{params$library_id}_infercnv.png"))
+
+# cell types
+ewings_tsv <- file.path(
+  data_dir,
+  "results",
+  "cell-type-ewings",
+  "SCPCP000015",
+  params$sample_id,
+  glue::glue("{params$library_id}_ewing-celltype-assignments.tsv")
+)
+
+# processed sce file
+sce_file <- file.path(
+  data_dir,
+  "SCPCP000015",
+  params$sample_id,
+  glue::glue("{params$library_id}_processed.rds")
+)
+```
+
+
+- we also need to read in the cnv-validations.tsv
+
+- section 1: what are the cnvs that they detected? do this from the hmm output at least
+- section 2: what is the relationship between consensus cell types and the cnvs? is there one?
+- section 3: what are the clusters? how big are they? what is their relationship to the cnv scores? do we want to show them on a UMAP?
+
+### Read in data
+
+```{r message = FALSE}
+validation_df <- readr::read_tsv(validation_tsv)
+
+celltype_df <- readr::read_tsv(ewings_tsv) |>
+  dplyr::select(barcodes, consensus_annotation, ewing_annotation)
+
+immune_ref_barcodes <- readr::read_rds(immune_ref_sce_file) |>
+  colnames() |>
+  stringr::str_split_i("-", 2)
+subset_ref_barcodes <- readr::read_rds(subset_ref_sce_file) |>
+  colnames() |>
+  stringr::str_split_i("-", 2)
+
+# note these tsvs already have an indicator column for the reference
+# the `subcluster` contains the inferCNV-calculated clusters
+infercnv_df <- readr::read_tsv(immune_hmm_tsv) |>
+  dplyr::bind_rows(
+    readr::read_tsv(subset_hmm_tsv)
+  ) |>
+  dplyr::mutate(
+    barcodes = stringr::str_remove(cell_id, glue::glue("{params$library_id}-")),
+    # add indicator columns for whether the cell is reference or query
+    is_immune_reference = barcodes %in% immune_ref_barcodes,
+    is_subset_reference = barcodes %in% subset_ref_barcodes
+  )
+
+# Separate normal reference from query cells
+# cnv_query_df <- infercnv_df |>
+#  dplyr::filter(
+#    stringr::str_starts(cell_id, params$library_id)
+#  ) |>
+#  dplyr::mutate(
+#    barcodes = stringr::str_remove(cell_id, glue::glue("{params$library_id}-"))
+#  )
+# cnv_reference_df <- dplyr::anti_join(infercnv_df, cnv_query_df)
+
+# Read SCE and create data frame with full results
+sce <- readr::read_rds(sce_file)
+
+cnv_df <- sce |>
+  scuttle::makePerCellDF(use.dimred = "UMAP") |>
+  # replace UMAP.1 with UMAP1
+  dplyr::rename_with(
+    \(x) stringr::str_replace(x, "^UMAP\\.", "UMAP")
+  ) |>
+  # add in hmm results
+  dplyr::left_join(infercnv_df, by = "barcodes") |>
+  # add in cell type results
+  dplyr::left_join(celltype_df)
+
+rm(sce)
+
+# remove MT and GL chromosomes
+chr_columns_to_keep <- which(
+  !stringr::str_detect(
+    names(cnv_df),
+    "chrMT|chrGL000219.1|chrGL000194.1"
+  )
+)
+cnv_df <- cnv_df[, chr_columns_to_keep]
+```
+
+
+## InferCNV Heatmaps
+
+Below, we show the `inferCNV` heatmaps from the `immune-all` and `immune-subset` normal references for this library.
+
+### Reference with all immune cells
+
+![InferCNV heatmap with immune-all reference](`r immune_png`)
+
+### Reference with a subset of immune cells 
+
+![InferCNV heatmap with immune-subset reference](`r immune_png`)
+
+
+
+## Distributions of CNVs per cell
+
+First, the total number of chromosomes with CNVs, with the goal of comparing reference to query cells.
+We hope for a bimodal distribution where reference cells are near zero, and higher values for putative tumor cells in the query set.
+
+
+```{r}
+# grab any columns that have has_cnv
+has_cnv_cols <- names(cnv_df)[stringr::str_starts(names(cnv_df), "has_cnv")]
+
+per_cell_cnv_df <- cnv_df |>
+  dplyr::mutate(total_cnv_per_cell = rowSums(dplyr::across(has_cnv_cols))) |>
+  dplyr::select(
+    barcodes,
+    UMAP1,
+    UMAP2,
+    infercnv_cluster = subcluster,
+    total_cnv_per_cell,
+    consensus_annotation,
+    ewing_annotation,
+    normal_reference,
+    is_immune_reference,
+    is_subset_reference
+  )
+```
+
+
+```{r fig.width = 10, fig.height = 5}
+all_plot <- per_cell_cnv_df |>
+  dplyr::filter(normal_reference == "all-immune") |>
+  dplyr::rename(in_reference = is_immune_reference) |>
+  ggplot() +
+  aes(x = total_cnv_per_cell, fill = in_reference) +
+  geom_density(alpha = 0.5) +
+  labs(
+    title = "Immune-all reference"
+  ) +
+  theme(legend.position = "bottom")
+
+subset_plot <- per_cell_cnv_df |>
+  dplyr::filter(normal_reference == "subset-immune") |>
+  dplyr::rename(in_reference = is_subset_reference) |>
+  ggplot() +
+  aes(x = total_cnv_per_cell, fill = in_reference) +
+  geom_density(alpha = 0.5) +
+  labs(
+    title = "Immune-subset reference"
+  ) +
+  theme(legend.position = "bottom")
+
+wrap_plots(all_plot, subset_plot, guides = "collect") +
+  plot_annotation(title = "Total CNVs per cell") &
+  theme(legend.position = "bottom")
+```
+Now, let's look at this total CNV per cell but across cell types, using our two sets:
+
+```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}
+consensus_violin <- ggplot(per_cell_cnv_df) +
+  aes(
+    x = consensus_annotation,
+    y = total_cnv_per_cell,
+    fill = normal_reference
+  ) +
+  geom_violin(scale = "width") +
+  scale_fill_brewer(palette = "Pastel2") +
+  labs(title = "Annotations from cell-type-consensus") +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+
+ewings_violin <- ggplot(per_cell_cnv_df) +
+  aes(
+    x = ewing_annotation,
+    y = total_cnv_per_cell,
+    fill = normal_reference
+  ) +
+  geom_violin(scale = "width") +
+  scale_fill_brewer(palette = "Pastel2") +
+  labs(title = "Annotations from cell-type-ewings") +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+
+wrap_plots(consensus_violin, ewings_violin, ncol = 1, guides = "collect") +
+  plot_annotation(title = "CNV scores across cell types") &
+  theme(legend.position = "bottom")
+```
+
+
+
+## UMAPs
+
+
+
+```{r fig.width = 10, fig.height = 5}
+### UMAPs of the cell types as a guide ####
+# TODO: colors could be more matched but may not be worth it?
+
+ewings_umap <- per_cell_cnv_df |>
+  # arbitrary filtering, this is just data
+  dplyr::filter(normal_reference == "all-immune") |>
+  ggplot() +
+  aes(x = UMAP1, y = UMAP2, color = forcats::fct_lump(ewing_annotation, 8)) +
+  geom_point(size = 0.1, alpha = 0.3) +
+  facet_wrap(vars(normal_reference)) +
+  labs(
+    title = "Ewings cell type",
+    color = "annotation"
+  ) +
+  guides(color = guide_legend(override.aes = list(size = 2, alpha = 1)))
+
+consensus_umap <- per_cell_cnv_df |>
+  # arbitrary filtering, this is just data
+  dplyr::filter(normal_reference == "all-immune") |>
+  ggplot() +
+  aes(x = UMAP1, y = UMAP2, color = forcats::fct_lump(consensus_annotation, 8)) +
+  geom_point(size = 0.1, alpha = 0.3) +
+  facet_wrap(vars(normal_reference)) +
+  labs(
+    title = "Consensus cell type",
+    color = "annotation"
+  ) +
+  guides(color = guide_legend(override.aes = list(size = 2, alpha = 1)))
+
+
+wrap_plots(ewings_umap, consensus_umap)
+```
+
+
+```{r fig.width=10}
+ggplot(per_cell_cnv_df) +
+  aes(x = UMAP1, y = UMAP2, color = total_cnv_per_cell) +
+  geom_point(size = 0.1, alpha = 0.3) +
+  scale_color_viridis_c() +
+  facet_wrap(vars(normal_reference)) +
+  labs(title = "Total CNV per cell")
+
+
+
+cells_per_cluster <- per_cell_cnv_df |>
+  dplyr::count(infercnv_cluster, normal_reference)
+
+# How many cells per cluster?
+ggplot(cells_per_cluster) +
+  aes(
+    x = infercnv_cluster, # keep in default order so "reference" and "unknown" are grouped
+    y = n
+  ) +
+  geom_col() +
+  facet_wrap(
+    vars(normal_reference),
+    scales = "free_x"
+  ) +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+
+
+# How many CNV per cell per cluster?
+ggplot(per_cell_cnv_df) +
+  aes(x = infercnv_cluster, y = total_cnv_per_cell) +
+  geom_point(size = 2) +
+  facet_wrap(
+    vars(normal_reference),
+    scales = "free_x"
+  ) +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+```
+
+
+
+## CNV across chromosomes
+
+
+
+## Session Info
+
+```{r session info}
+# record the versions of the packages used in this analysis and other environment information
+sessionInfo()
+```

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
@@ -23,7 +23,7 @@ This notebook explores `inferCNV` results run on library `params$library_id` fro
 
 `inferCNV` was run with the following settings:
 
-* We used the `i3` HMM which has improved run times relative to the `i6` HMM.
+* We used the `i6` HMM
 * We used the default `analysis_mode = "subclusters"`, which allows the HMM to call CNVs at the level of clusters rather than whole samples or individual cells
 * We used the following clustering parameters:
   * Leiden clustering run on PCA (not the expression matrix)
@@ -303,51 +303,6 @@ ggplot(has_cnv_df) +
   facet_wrap(vars(normal_reference)) +
   labs(title = "Total CNV per cell") +
   umap_theme
-```
-
-## Compare references directly
-
-We can also look at CNV predictions directly between references using a point-density scatterplot, with the Spearman correlation shown:
-
-```{r, fig.height=6}
-compare_refs <- has_cnv_df |>
-  dplyr::filter(library_id == params$library_id) |>
-  dplyr::select(
-    barcodes, normal_reference, total_cnv_per_cell
-  ) |>
-  tidyr::pivot_wider(
-    names_from = normal_reference,
-    values_from = total_cnv_per_cell
-  ) |>
-  # color points this way rather than binning to ensure small bins aren't left out
-  dplyr::add_count(`all-immune`, `subset-immune`)
-
-# Determine max limit for axes
-max_axis <- max(has_cnv_df$total_cnv_per_cell)
-axis_breaks <- 1:max_axis
-
-# Calculate in spearman correlation coefficient to include in plot
-rho <- cor(compare_refs$`all-immune`, compare_refs$`subset-immune`, method = "spearman") |>
-  round(2)
-
-ggplot(compare_refs) +
-  aes(
-    x = `all-immune`,
-    y = `subset-immune`,
-    color = n
-  ) +
-  geom_point(size = 5) +
-  geom_abline(color = "red") +
-  scale_color_viridis_c() +
-  coord_equal() +
-  scale_x_continuous(limits = c(0, max_axis), breaks = 1:max_axis) +
-  scale_y_continuous(limits = c(0, max_axis), breaks = 1:max_axis) +
-  labs(
-    title = "Per-cell CNVs between normal references",
-    subtitle = glue::glue("rho = {rho}"),
-    color = "Number of cells"
-  ) +
-  theme(legend.position = "bottom")
 ```
 
 ## Clusters

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
@@ -113,9 +113,6 @@ sce_file <- file.path(
 validation_df <- readr::read_tsv(validation_tsv) |>
   dplyr::filter(diagnosis == "Ewing sarcoma")
 
-celltype_df <- readr::read_tsv(ewings_tsv) |>
-  dplyr::select(barcodes, consensus_annotation, ewing_annotation)
-
 immune_ref_barcodes <- readr::read_rds(immune_ref_sce_file) |>
   colnames() |>
   stringr::str_split_i("-", 2)
@@ -131,13 +128,19 @@ infercnv_df <- readr::read_tsv(immune_hmm_tsv) |>
   ) |>
   tidyr::separate(cell_id, into = c("library_id", "barcodes"))
 
-# Read SCE and save UMAP coordinates
+# Read SCE and save UMAP coordinates and cell types
 umap_df <- readr::read_rds(sce_file) |>
   scuttle::makePerCellDF(use.dimred = "UMAP") |>
   dplyr::select(
     barcodes,
     UMAP1 = UMAP.1,
     UMAP2 = UMAP.2
+  ) |>
+  # TODO: We currently are bringing in cell types from separate files, but in the next
+  # data release they will be in the SCE objects
+  dplyr::inner_join(
+    readr::read_tsv(ewings_tsv) |>
+      dplyr::select(barcodes, consensus_annotation, ewing_annotation)
   )
 ```
 
@@ -194,9 +197,15 @@ has_cnv_df <- infercnv_df |>
     immune_reference_cell = barcodes %in% immune_ref_barcodes,
     subset_reference_cell = barcodes %in% subset_ref_barcodes
   ) |>
-  # join in other data
-  dplyr::left_join(celltype_df) |>
-  dplyr::left_join(umap_df)
+  # join in SCE information
+  dplyr::left_join(umap_df) |>
+  # finally, bring back in cluster and library information
+  dplyr::left_join(
+    infercnv_df |>
+      dplyr::select(barcodes, library_id, subcluster, normal_reference) |>
+      unique(),
+    by = c("barcodes", "normal_reference")
+  )
 ```
 
 
@@ -234,9 +243,9 @@ Ideally, we'll see that Unknown cells from `cell-type-consensus` and cells label
 In addition, comparing distributions between `all-immune` and `subset-immune` may be helpful to identify the optimal normal reference strategy.
 
 ```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}
-# drop NAs from reference cells from other libraries
+# drop cells from other libraries
 query_has_cnv_df <- has_cnv_df |>
-  tidyr::drop_na(ewing_annotation, consensus_annotation)
+  dplyr::filter(library_id == params$library_id)
 
 consensus_violin <- ggplot(query_has_cnv_df) +
   aes(
@@ -274,14 +283,10 @@ Next, we'll visualize the total CNV counts as a UMAP.
 First, as a guide to interpret the UMAP, let's color by the top 10 `cell-type-ewings` cell types.
 
 ```{r, fig.width = 6}
-query_has_cnv_df |>
-  # arbitrary filtering, this is just data
-  dplyr::filter(normal_reference == "all-immune") |>
-  ggplot() +
+ggplot(umap_df) +
   aes(x = UMAP1, y = UMAP2, color = forcats::fct_lump(ewing_annotation, 8)) +
   geom_point(size = 0.1, alpha = 0.3) +
-  facet_wrap(vars(normal_reference)) +
-  labs(color = "annotation") +
+  labs(color = "ewings annotation") +
   guides(color = guide_legend(override.aes = list(size = 2, alpha = 1))) +
   umap_theme
 ```
@@ -306,12 +311,6 @@ We can also look at CNV predictions directly between references using a point-de
 
 ```{r, fig.height=6}
 compare_refs <- has_cnv_df |>
-  # bring in library_id so we can only include those cells.
-  dplyr::inner_join(
-    infercnv_df |>
-      dplyr::select(barcodes, library_id) |>
-      unique()
-  ) |>
   dplyr::filter(library_id == params$library_id) |>
   dplyr::select(
     barcodes, normal_reference, total_cnv_per_cell
@@ -360,16 +359,7 @@ First, how many cells are there per cluster?
 Clusters labeled `reference_` contain only normal reference cells, and clusters labeled `unknown_` contain the query cells.
 
 ```{r, fig.width = 10}
-# bring in cluster and library information
-cluster_cnv_df <- has_cnv_df |>
-  dplyr::inner_join(
-    infercnv_df |>
-      dplyr::select(barcodes, library_id, subcluster, normal_reference) |>
-      unique(),
-    by = c("barcodes", "normal_reference")
-  )
-
-ggplot(cluster_cnv_df) +
+ggplot(has_cnv_df) +
   # keep in default order so "reference" and "unknown" are grouped
   aes(x = subcluster) +
   geom_bar() +
@@ -385,10 +375,7 @@ Is there a trend for which cell types tend to show up in which cluster?
 We'll plot this for both the consensus and ewing annotations, considering only the top 7 cell types for visual ease.
 
 ```{r fig.width=12}
-cluster_cnv_df |>
-  # remove cells from other libraries
-  dplyr::filter(library_id == params$library_id) |>
-  ggplot() +
+ggplot(query_has_cnv_df) +
   aes(x = subcluster, fill = forcats::fct_lump(consensus_annotation, 7)) +
   geom_bar() +
   scale_fill_brewer(palette = "Dark2") +
@@ -404,10 +391,7 @@ cluster_cnv_df |>
 ```
 
 ```{r fig.width=12}
-cluster_cnv_df |>
-  # remove cells from other libraries
-  dplyr::filter(library_id == params$library_id) |>
-  ggplot() +
+ggplot(query_has_cnv_df) +
   aes(x = subcluster, fill = forcats::fct_lump(ewing_annotation, 7)) +
   geom_bar() +
   scale_fill_brewer(palette = "Set1") +
@@ -426,7 +410,7 @@ Let's also look more specifically at the `reference` clusters, where we might ex
 Do originating libraries cluster together?
 
 ```{r fig.width=10}
-all_reference_clusters <- cluster_cnv_df |>
+all_reference_clusters <- has_cnv_df |>
   dplyr::filter(
     normal_reference == "all-immune",
     immune_reference_cell
@@ -438,7 +422,7 @@ all_plot <- ggplot(all_reference_clusters) +
   theme(legend.position = "bottom")
 
 
-subset_reference_clusters <- cluster_cnv_df |>
+subset_reference_clusters <- has_cnv_df |>
   # bring in library_id
   dplyr::inner_join(
     infercnv_df |>
@@ -465,7 +449,7 @@ We expect a single value here, because with `analysis_mode = "subclusters"` (the
 
 ```{r}
 # How many CNV per cell per cluster?
-ggplot(cluster_cnv_df) +
+ggplot(has_cnv_df) +
   aes(x = subcluster, y = total_cnv_per_cell) +
   geom_point(size = 2) +
   facet_wrap(

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
@@ -6,6 +6,7 @@ output:
   html_notebook:
     toc: true
     toc_depth: 3
+    code_folding: hide
 params:
   sample_id: SCPCS000490
   library_id: SCPCL000822
@@ -34,9 +35,11 @@ This notebook explores `inferCNV` results run on library `params$library_id` fro
 ```{r}
 options(readr.show_col_types = FALSE)
 
-library(SingleCellExperiment)
-library(ggplot2)
-library(patchwork)
+suppressPackageStartupMessages({
+  library(SingleCellExperiment)
+  library(ggplot2)
+  library(patchwork)
+})
 
 theme_set(theme_bw())
 
@@ -175,7 +178,6 @@ has_cnv_df <- infercnv_df |>
   dplyr::select(
     barcodes,
     normal_reference,
-    subcluster,
     starts_with("has_cnv_")
   ) |>
   tidyr::pivot_longer(
@@ -186,6 +188,7 @@ has_cnv_df <- infercnv_df |>
   # sum all values for each cell, but separately for each run of inferCNV (aka each normal reference)
   dplyr::group_by(barcodes, normal_reference) |>
   dplyr::summarize(total_cnv_per_cell = sum(cnv)) |>
+  dplyr::ungroup() |>
   # add indicator columns for whether the cell is reference or query
   dplyr::mutate(
     immune_reference_cell = barcodes %in% immune_ref_barcodes,
@@ -270,7 +273,7 @@ Next, we'll visualize the total CNV counts as a UMAP.
 
 First, as a guide to interpret the UMAP, let's color by the top 10 `cell-type-ewings` cell types.
 
-```{r}
+```{r, fig.width = 6}
 query_has_cnv_df |>
   # arbitrary filtering, this is just data
   dplyr::filter(normal_reference == "all-immune") |>
@@ -282,21 +285,10 @@ query_has_cnv_df |>
   guides(color = guide_legend(override.aes = list(size = 2, alpha = 1))) +
   umap_theme
 ```
+
 Next, the total CNVs per cell; ideally, higher values will overlap with regions in the UMAP containing putative tumor cells.
 
 ```{r fig.width=10, warning = FALSE}
-# add clusters into data frame
-has_cnv_df <- infercnv_df |>
-  dplyr::select(
-    barcodes,
-    normal_reference,
-    infercnv_cluster = subcluster
-  ) |>
-  dplyr::inner_join(
-    has_cnv_df,
-    by = c("barcodes", "normal_reference")
-  )
-
 # noting we expect warnings with this plot since there's no UMAP coordinates
 # for cells from other libraries in the reference
 ggplot(has_cnv_df) +
@@ -312,7 +304,7 @@ ggplot(has_cnv_df) +
 
 We can also look at CNV predictions directly between references using a point-density scatterplot, with the Spearman correlation shown:
 
-```{r}
+```{r, fig.height=6}
 compare_refs <- has_cnv_df |>
   # bring in library_id so we can only include those cells.
   dplyr::inner_join(
@@ -367,10 +359,19 @@ To see whether we'd like to further tune the clustering parameters, we'll get a 
 First, how many cells are there per cluster?
 Clusters labeled `reference_` contain only normal reference cells, and clusters labeled `unknown_` contain the query cells.
 
-```{r}
-ggplot(has_cnv_df) +
+```{r, fig.width = 10}
+# bring in cluster and library information
+cluster_cnv_df <- has_cnv_df |>
+  dplyr::inner_join(
+    infercnv_df |>
+      dplyr::select(barcodes, library_id, subcluster, normal_reference) |>
+      unique(),
+    by = c("barcodes", "normal_reference")
+  )
+
+ggplot(cluster_cnv_df) +
   # keep in default order so "reference" and "unknown" are grouped
-  aes(x = infercnv_cluster) +
+  aes(x = subcluster) +
   geom_bar() +
   facet_wrap(
     vars(normal_reference),
@@ -384,8 +385,11 @@ Is there a trend for which cell types tend to show up in which cluster?
 We'll plot this for both the consensus and ewing annotations, considering only the top 7 cell types for visual ease.
 
 ```{r fig.width=12}
-ggplot(query_has_cnv_df) +
-  aes(x = infercnv_cluster, fill = forcats::fct_lump(consensus_annotation, 7)) +
+cluster_cnv_df |>
+  # remove cells from other libraries
+  dplyr::filter(library_id == params$library_id) |>
+  ggplot() +
+  aes(x = subcluster, fill = forcats::fct_lump(consensus_annotation, 7)) +
   geom_bar() +
   scale_fill_brewer(palette = "Dark2") +
   facet_wrap(
@@ -400,8 +404,11 @@ ggplot(query_has_cnv_df) +
 ```
 
 ```{r fig.width=12}
-ggplot(query_has_cnv_df) +
-  aes(x = infercnv_cluster, fill = forcats::fct_lump(ewing_annotation, 7)) +
+cluster_cnv_df |>
+  # remove cells from other libraries
+  dplyr::filter(library_id == params$library_id) |>
+  ggplot() +
+  aes(x = subcluster, fill = forcats::fct_lump(ewing_annotation, 7)) +
   geom_bar() +
   scale_fill_brewer(palette = "Set1") +
   facet_wrap(
@@ -419,25 +426,19 @@ Let's also look more specifically at the `reference` clusters, where we might ex
 Do originating libraries cluster together?
 
 ```{r fig.width=10}
-all_reference_clusters <- has_cnv_df |>
-  # bring in library_id
-  dplyr::inner_join(
-    infercnv_df |>
-      dplyr::select(barcodes, library_id) |>
-      unique()
-  ) |>
+all_reference_clusters <- cluster_cnv_df |>
   dplyr::filter(
     normal_reference == "all-immune",
     immune_reference_cell
   )
 all_plot <- ggplot(all_reference_clusters) +
-  aes(x = infercnv_cluster, fill = library_id) +
+  aes(x = subcluster, fill = library_id) +
   geom_bar() +
   labs("All immune reference") +
   theme(legend.position = "bottom")
 
 
-subset_reference_clusters <- has_cnv_df |>
+subset_reference_clusters <- cluster_cnv_df |>
   # bring in library_id
   dplyr::inner_join(
     infercnv_df |>
@@ -449,7 +450,7 @@ subset_reference_clusters <- has_cnv_df |>
     subset_reference_cell
   )
 subset_plot <- ggplot(subset_reference_clusters) +
-  aes(x = infercnv_cluster, fill = library_id) +
+  aes(x = subcluster, fill = library_id) +
   geom_bar() +
   labs("Subset immune reference") +
   theme(legend.position = "bottom")
@@ -459,15 +460,13 @@ wrap_plots(all_plot, subset_plot, guides = "collect") &
 ```
 
 
-
 How many CNVs were inferred per cluster?
 We expect a single value here, because with `analysis_mode = "subclusters"` (the `inferCNV` default), CNV parameters are estimated per cluster.
 
-
 ```{r}
 # How many CNV per cell per cluster?
-ggplot(per_cell_cnv_df) +
-  aes(x = infercnv_cluster, y = total_cnv_per_cell) +
+ggplot(cluster_cnv_df) +
+  aes(x = subcluster, y = total_cnv_per_cell) +
   geom_point(size = 2) +
   facet_wrap(
     vars(normal_reference),
@@ -479,59 +478,70 @@ ggplot(per_cell_cnv_df) +
 
 ## CNV across chromosomes
 
-Now, we'll look at CNVs across chromosomes, including specific CNVs we expect to see in Ewing sarcoma:
+Now, we'll look at CNVs across chromosomes, specifically considering the `proportion_scaled_cnv_` output from the HMM.
+
+Again, these are the specific CNVs we expect to see in Ewing sarcoma:
 
 ```{r}
 validation_df
 ```
 
 ```{r}
+# First, construct data frame with proportion_scaled_ instead of has_cnv
 cnv_validation_df <- infercnv_df |>
   dplyr::select(
     barcodes,
-    infercnv_cluster,
-    total_cnv_per_cell,
+    library_id,
     normal_reference,
-    is_immune_reference,
-    is_subset_reference,
-    all_of(
-      c(
-        glue::glue("proportion_scaled_cnv_chr{1:22}"),
-        glue::glue("proportion_scaled_loss_chr{1:22}"),
-        glue::glue("proportion_scaled_dupli_chr{1:22}")
-      )
-    )
+    starts_with("proportion_scaled_")
   ) |>
+  # tidy up
   tidyr::pivot_longer(
     starts_with("proportion_scaled_"),
     names_to = "cnv_type_raw",
     values_to = "proportion"
   ) |>
+  # more tidying
   dplyr::mutate(cnv_type_raw = stringr::str_remove(cnv_type_raw, "^proportion_scaled_")) |>
-  tidyr::separate(cnv_type_raw, into = c("cnv_type", "chr")) |>
-  dplyr::mutate(chr = stringr::str_remove(chr, "^chr"), chr = as.numeric(chr))
+  tidyr::separate(cnv_type_raw, sep = "_", into = c("cnv_type", "chr")) |>
+  # remove extra chromosomes and cells not in this library, and then can make chr numeric
+  dplyr::filter(
+    !stringr::str_starts(chr, "chrMT"),
+    !stringr::str_starts(chr, "chrGL"),
+    library_id == params$library_id
+  ) |>
+  dplyr::mutate(
+    chr = stringr::str_remove(chr, "^chr"),
+    chr = as.numeric(chr)
+  )
 ```
 
-```{r}
+We'll make density plots of the predicted CNV events across chromosomes, for each of the two normal references:
+
+
+```{r fig.height=8, fig.width=8}
+cnv_validation_df |>
+  dplyr::filter(normal_reference == "all-immune") |>
+  ggplot() +
+  aes(
+    x = proportion,
+    color = cnv_type
+  ) +
+  geom_density() +
+  facet_wrap(vars(chr)) +
+  ggtitle("All immune reference")
+
+
 cnv_validation_df |>
   dplyr::filter(normal_reference == "subset-immune") |>
   ggplot() +
   aes(
     x = proportion,
-    color = is_subset_reference
+    color = cnv_type
   ) +
   geom_density() +
-  facet_wrap(vars(chr))
-
-
-cnv_validation_df |>
-  dplyr::group_by(
-    normal_reference,
-    cnv_type,
-    chr
-  ) |>
-  dplyr::summarize(median_proportion = median(proportion)) |>
-  dplyr::arrange(cnv_type)
+  facet_wrap(vars(chr)) +
+  ggtitle("Subset immune reference")
 ```
 
 ## Session Info

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
@@ -18,11 +18,11 @@ This notebook explores `inferCNV` results run on library `params$library_id` fro
 `inferCNV` was run with two different normal references:
 
 * `all-immune`: All consensus immune cells across `SCPCP000015` libraries, _excluding_ any which were also identified as tumor in the `cell-type-ewings` analysis module
-* `subset-immnune`: A subset of `all-immune`, considering only macrophage and T-cell cell types
+* `subset-immune`: A subset of `all-immune`, considering only macrophage and T-cell cell types
 
 `inferCNV` was run with the following settings:
 
-* We used the `i3` HMM which has improved run times relative to their `i6` HMM
+* We used the `i3` HMM which has improved run times relative to the `i6` HMM.
 * We used the default `analysis_mode = "subclusters"`, which allows the HMM to call CNVs at the level of clusters rather than whole samples or individual cells
 * We used the following clustering parameters:
   * Leiden clustering run on PCA (not the expression matrix)
@@ -38,7 +38,6 @@ library(SingleCellExperiment)
 library(ggplot2)
 library(patchwork)
 
-# Set default ggplot theme, customized for UMAPs
 theme_set(theme_bw())
 
 umap_theme <- list(
@@ -144,6 +143,12 @@ umap_df <- readr::read_rds(sce_file) |>
 
 Below, we show the `inferCNV` heatmaps from the `immune-all` and `immune-subset` normal references for this library.
 
+To help contextualize these, here is the table of known CNVs in Ewing sarcoma we'll use for validation:
+
+```{r}
+validation_df
+```
+
 ### Reference with all immune cells
 
 ![InferCNV heatmap with immune-all reference](`r immune_png`)
@@ -179,7 +184,7 @@ has_cnv_df <- infercnv_df |>
     values_to = "cnv"
   ) |>
   # sum all values for each cell, but separately for each run of inferCNV (aka each normal reference)
-  dplyr::group_by(barcodes, cell_id, normal_reference) |>
+  dplyr::group_by(barcodes, normal_reference) |>
   dplyr::summarize(total_cnv_per_cell = sum(cnv)) |>
   # add indicator columns for whether the cell is reference or query
   dplyr::mutate(
@@ -263,8 +268,7 @@ wrap_plots(consensus_violin, ewings_violin, ncol = 1, guides = "collect") +
 
 Next, we'll visualize the total CNV counts as a UMAP.
 
-First, as a guide, let's look at the top 10 `cell-type-ewings` cell types.
-
+First, as a guide to interpret the UMAP, let's color by the top 10 `cell-type-ewings` cell types.
 
 ```{r}
 query_has_cnv_df |>
@@ -302,6 +306,57 @@ ggplot(has_cnv_df) +
   facet_wrap(vars(normal_reference)) +
   labs(title = "Total CNV per cell") +
   umap_theme
+```
+
+## Compare references directly
+
+We can also look at CNV predictions directly between references using a point-density scatterplot, with the Spearman correlation shown:
+
+```{r}
+compare_refs <- has_cnv_df |>
+  # bring in library_id so we can only include those cells.
+  dplyr::inner_join(
+    infercnv_df |>
+      dplyr::select(barcodes, library_id) |>
+      unique()
+  ) |>
+  dplyr::filter(library_id == params$library_id) |>
+  dplyr::select(
+    barcodes, normal_reference, total_cnv_per_cell
+  ) |>
+  tidyr::pivot_wider(
+    names_from = normal_reference,
+    values_from = total_cnv_per_cell
+  ) |>
+  # color points this way rather than binning to ensure small bins aren't left out
+  dplyr::add_count(`all-immune`, `subset-immune`)
+
+# Determine max limit for axes
+max_axis <- max(has_cnv_df$total_cnv_per_cell)
+axis_breaks <- 1:max_axis
+
+# Calculate in spearman correlation coefficient to include in plot
+rho <- cor(compare_refs$`all-immune`, compare_refs$`subset-immune`, method = "spearman") |>
+  round(2)
+
+ggplot(compare_refs) +
+  aes(
+    x = `all-immune`,
+    y = `subset-immune`,
+    color = n
+  ) +
+  geom_point(size = 5) +
+  geom_abline(color = "red") +
+  scale_color_viridis_c() +
+  coord_equal() +
+  scale_x_continuous(limits = c(0, max_axis), breaks = 1:max_axis) +
+  scale_y_continuous(limits = c(0, max_axis), breaks = 1:max_axis) +
+  labs(
+    title = "Per-cell CNVs between normal references",
+    subtitle = glue::glue("rho = {rho}"),
+    color = "Number of cells"
+  ) +
+  theme(legend.position = "bottom")
 ```
 
 ## Clusters
@@ -405,9 +460,6 @@ wrap_plots(all_plot, subset_plot, guides = "collect") &
 
 
 
-
-
-
 How many CNVs were inferred per cluster?
 We expect a single value here, because with `analysis_mode = "subclusters"` (the `inferCNV` default), CNV parameters are estimated per cluster.
 
@@ -423,7 +475,6 @@ ggplot(per_cell_cnv_df) +
   ) +
   theme(axis.text.x = element_text(angle = 45, hjust = 1))
 ```
-
 
 
 ## CNV across chromosomes

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
@@ -127,28 +127,15 @@ infercnv_df <- readr::read_tsv(immune_hmm_tsv) |>
   dplyr::bind_rows(
     readr::read_tsv(subset_hmm_tsv)
   ) |>
-  dplyr::mutate(
-    barcodes = stringr::str_remove(cell_id, glue::glue("{params$library_id}-")),
-    # add indicator columns for whether the cell is reference or query
-    is_immune_reference = barcodes %in% immune_ref_barcodes,
-    is_subset_reference = barcodes %in% subset_ref_barcodes
-  )
+  tidyr::separate(cell_id, into = c("library_id", "barcodes"))
 
-# Read SCE and create data frame with full results
-cnv_df <- readr::read_rds(sce_file) |>
+# Read SCE and save UMAP coordinates
+umap_df <- readr::read_rds(sce_file) |>
   scuttle::makePerCellDF(use.dimred = "UMAP") |>
-  # replace UMAP.1 with UMAP1
-  dplyr::rename_with(
-    \(x) stringr::str_replace(x, "^UMAP\\.", "UMAP")
-  ) |>
-  # add in hmm results
-  dplyr::left_join(infercnv_df, by = "barcodes") |>
-  # add in cell type results
-  dplyr::left_join(celltype_df) |>
-  # remove MT and GL chromosomes
   dplyr::select(
-    -contains("chrMT"),
-    -contains("chrGL")
+    barcodes,
+    UMAP1 = UMAP.1,
+    UMAP2 = UMAP.2
   )
 ```
 
@@ -163,7 +150,7 @@ Below, we show the `inferCNV` heatmaps from the `immune-all` and `immune-subset`
 
 ### Reference with a subset of immune cells 
 
-![InferCNV heatmap with immune-subset reference](`r immune_png`)
+![InferCNV heatmap with immune-subset reference](`r subset_png`)
 
 
 
@@ -178,51 +165,72 @@ Ideally, we'll see a bimodal distribution where reference cells are at/near zero
 In the density plots below, distributions are colored based on whether the cells are in the reference or not (aka, query cells).
 
 ```{r}
-# grab any columns that have has_cnv
-has_cnv_cols <- names(cnv_df)[stringr::str_starts(names(cnv_df), "has_cnv")]
-
-per_cell_cnv_df <- cnv_df |>
-  dplyr::mutate(total_cnv_per_cell = rowSums(dplyr::across(dplyr::all_of(has_cnv_cols)))) |>
-  dplyr::rename(infercnv_cluster = subcluster)
+# First, construct data frame of total `has_cnv` counts, with other variables needed for plots
+has_cnv_df <- infercnv_df |>
+  dplyr::select(
+    barcodes,
+    normal_reference,
+    subcluster,
+    starts_with("has_cnv_")
+  ) |>
+  tidyr::pivot_longer(
+    starts_with("has_cnv_"),
+    names_to = "chr",
+    values_to = "cnv"
+  ) |>
+  # sum all values for each cell, but separately for each run of inferCNV (aka each normal reference)
+  dplyr::group_by(barcodes, cell_id, normal_reference) |>
+  dplyr::summarize(total_cnv_per_cell = sum(cnv)) |>
+  # add indicator columns for whether the cell is reference or query
+  dplyr::mutate(
+    immune_reference_cell = barcodes %in% immune_ref_barcodes,
+    subset_reference_cell = barcodes %in% subset_ref_barcodes
+  ) |>
+  # join in other data
+  dplyr::left_join(celltype_df) |>
+  dplyr::left_join(umap_df)
 ```
 
 
 ```{r fig.width = 10, fig.height = 5}
-all_plot <- per_cell_cnv_df |>
+all_plot <- has_cnv_df |>
   dplyr::filter(normal_reference == "all-immune") |>
-  dplyr::rename(in_reference = is_immune_reference) |>
   ggplot() +
-  aes(x = total_cnv_per_cell, fill = in_reference) +
+  aes(x = total_cnv_per_cell, fill = immune_reference_cell) +
   geom_density(alpha = 0.5) +
   labs(
     title = "Immune-all reference"
   ) +
   theme(legend.position = "bottom")
 
-subset_plot <- per_cell_cnv_df |>
+subset_plot <- has_cnv_df |>
   dplyr::filter(normal_reference == "subset-immune") |>
-  dplyr::rename(in_reference = is_subset_reference) |>
   ggplot() +
-  aes(x = total_cnv_per_cell, fill = in_reference) +
+  aes(x = total_cnv_per_cell, fill = subset_reference_cell) +
   geom_density(alpha = 0.5) +
   labs(
     title = "Immune-subset reference"
   ) +
   theme(legend.position = "bottom")
 
-wrap_plots(all_plot, subset_plot, guides = "collect") +
-  plot_annotation(title = "Total CNVs per cell") &
-  theme(legend.position = "bottom")
+wrap_plots(all_plot, subset_plot) +
+  plot_annotation(title = "Total CNVs per cell")
 ```
 
 ### CNVs across cell types
 
 Next, we'll look at the per-cell distributions of CNVs across cell types.
 Specifically, we'll look at both the cell types from the `cell-type-consensus` module and the `cell-type-ewings` module separately.
+
 Ideally, we'll see that Unknown cells from `cell-type-consensus` and cells labeled as tumor in `cell-type-ewings` will have relatively higher CNV scores compared to other cell types.
+In addition, comparing distributions between `all-immune` and `subset-immune` may be helpful to identify the optimal normal reference strategy.
 
 ```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}
-consensus_violin <- ggplot(per_cell_cnv_df) +
+# drop NAs from reference cells from other libraries
+query_has_cnv_df <- has_cnv_df |>
+  tidyr::drop_na(ewing_annotation, consensus_annotation)
+
+consensus_violin <- ggplot(query_has_cnv_df) +
   aes(
     x = consensus_annotation,
     y = total_cnv_per_cell,
@@ -233,7 +241,7 @@ consensus_violin <- ggplot(per_cell_cnv_df) +
   labs(title = "Annotations from cell-type-consensus") +
   theme(axis.text.x = element_text(angle = 45, hjust = 1))
 
-ewings_violin <- ggplot(per_cell_cnv_df) +
+ewings_violin <- ggplot(query_has_cnv_df) +
   aes(
     x = ewing_annotation,
     y = total_cnv_per_cell,
@@ -259,7 +267,7 @@ First, as a guide, let's look at the top 10 `cell-type-ewings` cell types.
 
 
 ```{r}
-per_cell_cnv_df |>
+query_has_cnv_df |>
   # arbitrary filtering, this is just data
   dplyr::filter(normal_reference == "all-immune") |>
   ggplot() +
@@ -272,8 +280,22 @@ per_cell_cnv_df |>
 ```
 Next, the total CNVs per cell; ideally, higher values will overlap with regions in the UMAP containing putative tumor cells.
 
-```{r fig.width=10}
-ggplot(per_cell_cnv_df) +
+```{r fig.width=10, warning = FALSE}
+# add clusters into data frame
+has_cnv_df <- infercnv_df |>
+  dplyr::select(
+    barcodes,
+    normal_reference,
+    infercnv_cluster = subcluster
+  ) |>
+  dplyr::inner_join(
+    has_cnv_df,
+    by = c("barcodes", "normal_reference")
+  )
+
+# noting we expect warnings with this plot since there's no UMAP coordinates
+# for cells from other libraries in the reference
+ggplot(has_cnv_df) +
   aes(x = UMAP1, y = UMAP2, color = total_cnv_per_cell) +
   geom_point(size = 0.1, alpha = 0.3) +
   scale_color_viridis_c() +
@@ -285,28 +307,109 @@ ggplot(per_cell_cnv_df) +
 ## Clusters
 
 Part of `inferCNV`'s algorithm involves clustering the data, and poor clusters have the potential to lead to inaccurate inferences of CNV. 
-To see whether we'd like to further tune the clustering parameters, we'll get a size of some of their properties here:
+To see whether we'd like to further tune the clustering parameters, we'll get a sense of their size and rough composition here.
 
-
-How many cells are there per cluster?
+First, how many cells are there per cluster?
 Clusters labeled `reference_` contain only normal reference cells, and clusters labeled `unknown_` contain the query cells.
 
 ```{r}
-cells_per_cluster <- per_cell_cnv_df |>
-  dplyr::count(infercnv_cluster, normal_reference)
-
-ggplot(cells_per_cluster) +
-  aes(
-    x = infercnv_cluster, # keep in default order so "reference" and "unknown" are grouped
-    y = n
-  ) +
-  geom_col() +
+ggplot(has_cnv_df) +
+  # keep in default order so "reference" and "unknown" are grouped
+  aes(x = infercnv_cluster) +
+  geom_bar() +
   facet_wrap(
     vars(normal_reference),
     scales = "free_x"
   ) +
   theme(axis.text.x = element_text(angle = 45, hjust = 1))
 ```
+
+Let's also look at the distributions of cell types in clusters.
+Is there a trend for which cell types tend to show up in which cluster?
+We'll plot this for both the consensus and ewing annotations, considering only the top 7 cell types for visual ease.
+
+```{r fig.width=12}
+ggplot(query_has_cnv_df) +
+  aes(x = infercnv_cluster, fill = forcats::fct_lump(consensus_annotation, 7)) +
+  geom_bar() +
+  scale_fill_brewer(palette = "Dark2") +
+  facet_wrap(
+    vars(normal_reference),
+    scales = "free_x"
+  ) +
+  labs(
+    title = "Consensus cell types",
+    fill = "annotation"
+  ) +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+```
+
+```{r fig.width=12}
+ggplot(query_has_cnv_df) +
+  aes(x = infercnv_cluster, fill = forcats::fct_lump(ewing_annotation, 7)) +
+  geom_bar() +
+  scale_fill_brewer(palette = "Set1") +
+  facet_wrap(
+    vars(normal_reference),
+    scales = "free_x"
+  ) +
+  labs(
+    title = "Ewing cell types",
+    fill = "annotation"
+  ) +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+```
+
+Let's also look more specifically at the `reference` clusters, where we might expect some batch effects since cells were taken from several different libraries.
+Do originating libraries cluster together?
+
+```{r fig.width=10}
+all_reference_clusters <- has_cnv_df |>
+  # bring in library_id
+  dplyr::inner_join(
+    infercnv_df |>
+      dplyr::select(barcodes, library_id) |>
+      unique()
+  ) |>
+  dplyr::filter(
+    normal_reference == "all-immune",
+    immune_reference_cell
+  )
+all_plot <- ggplot(all_reference_clusters) +
+  aes(x = infercnv_cluster, fill = library_id) +
+  geom_bar() +
+  labs("All immune reference") +
+  theme(legend.position = "bottom")
+
+
+subset_reference_clusters <- has_cnv_df |>
+  # bring in library_id
+  dplyr::inner_join(
+    infercnv_df |>
+      dplyr::select(barcodes, library_id) |>
+      unique()
+  ) |>
+  dplyr::filter(
+    normal_reference == "subset-immune",
+    subset_reference_cell
+  )
+subset_plot <- ggplot(subset_reference_clusters) +
+  aes(x = infercnv_cluster, fill = library_id) +
+  geom_bar() +
+  labs("Subset immune reference") +
+  theme(legend.position = "bottom")
+
+wrap_plots(all_plot, subset_plot, guides = "collect") &
+  theme(legend.position = "bottom")
+```
+
+
+
+
+
+
+How many CNVs were inferred per cluster?
+We expect a single value here, because with `analysis_mode = "subclusters"` (the `inferCNV` default), CNV parameters are estimated per cluster.
 
 
 ```{r}
@@ -325,14 +428,14 @@ ggplot(per_cell_cnv_df) +
 
 ## CNV across chromosomes
 
-We want to look across chrs now, specifically:
+Now, we'll look at CNVs across chromosomes, including specific CNVs we expect to see in Ewing sarcoma:
 
 ```{r}
 validation_df
 ```
 
 ```{r}
-cnv_validation_df <- per_cell_cnv_df |>
+cnv_validation_df <- infercnv_df |>
   dplyr::select(
     barcodes,
     infercnv_cluster,

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
@@ -25,10 +25,7 @@ This notebook explores `inferCNV` results run on library `params$library_id` fro
 
 * We used the `i6` HMM
 * We used the default `analysis_mode = "subclusters"`, which allows the HMM to call CNVs at the level of clusters rather than whole samples or individual cells
-* We used the following clustering parameters:
-  * Leiden clustering run on PCA (not the expression matrix)
-  * `k=20` nearest neighbors with a `resolution` parameter of 1 and using the `modularity` objective function 
-
+* We used the default `inferCNV` clustering parameters
 
 ## Setup
 
@@ -340,7 +337,7 @@ Is there a trend for which cell types tend to show up in which cluster?
 
 ```{r fig.width=12}
 ggplot(query_has_cnv_df) +
-  aes(x = subcluster, fill = celltype) +
+  aes(x = subcluster, fill = forcats::fct_lump(celltype, 8)) +
   geom_bar() +
   scale_fill_brewer(palette = "Set1") +
   facet_wrap(

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/ewings-infercnv-results.Rmd
@@ -78,6 +78,9 @@ data_dir <- file.path(repository_base, "data", "current")
 # TSV with expected Ewing CNVs
 validation_tsv <- file.path(ref_dir, "cnv-validation.tsv")
 
+# immune cell URL to check for ambiguous cell types
+immune_url <- "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-consensus/references/consensus-immune-cell-types.tsv"
+
 # References themselves so we know which cells belong to reference
 immune_ref_sce_file <- file.path(ref_dir, "normal-references", "SCPCP000015", "ref-all-immune.rds")
 subset_ref_sce_file <- file.path(ref_dir, "normal-references", "SCPCP000015", "ref-subset-immune.rds")
@@ -113,6 +116,9 @@ sce_file <- file.path(
 validation_df <- readr::read_tsv(validation_tsv) |>
   dplyr::filter(diagnosis == "Ewing sarcoma")
 
+immune_labels <- readr::read_tsv(immune_url) |>
+  dplyr::pull(consensus_annotation)
+
 immune_ref_barcodes <- readr::read_rds(immune_ref_sce_file) |>
   colnames() |>
   stringr::str_split_i("-", 2)
@@ -135,13 +141,30 @@ umap_df <- readr::read_rds(sce_file) |>
     barcodes,
     UMAP1 = UMAP.1,
     UMAP2 = UMAP.2
-  ) |>
-  # TODO: We currently are bringing in cell types from separate files, but in the next
-  # data release they will be in the SCE objects
-  dplyr::inner_join(
-    readr::read_tsv(ewings_tsv) |>
-      dplyr::select(barcodes, consensus_annotation, ewing_annotation)
   )
+
+# TODO: We currently are bringing in cell types from separate files, but in the next
+# data release they will be in the SCE objects this could be part of the colData wrangling above.
+celltype_df <- readr::read_tsv(ewings_tsv) |>
+  # Label cells as:
+  # - tumor-immune: Cells labeled as tumor by cell-type-ewings, but immune by cell-type-consensus
+  # - tumor: Cells labeled as tumor by cell-type-ewings
+  # - their existing ewing_annotation if none of the above
+  dplyr::mutate(
+    celltype = dplyr::case_when(
+      ## tumor-immune
+      consensus_annotation %in% immune_labels &
+        stringr::str_starts(ewing_annotation, "tumor") ~ "tumor-immune",
+      ## tumor
+      stringr::str_starts(ewing_annotation, "tumor") ~ "tumor",
+      ## default
+      .default = ewing_annotation
+    )
+  ) |>
+  dplyr::select(barcodes, celltype)
+
+umap_df <- umap_df |>
+  dplyr::left_join(celltype_df)
 ```
 
 
@@ -239,39 +262,27 @@ wrap_plots(all_plot, subset_plot) +
 Next, we'll look at the per-cell distributions of CNVs across cell types.
 Specifically, we'll look at both the cell types from the `cell-type-consensus` module and the `cell-type-ewings` module separately.
 
-Ideally, we'll see that Unknown cells from `cell-type-consensus` and cells labeled as tumor in `cell-type-ewings` will have relatively higher CNV scores compared to other cell types.
-In addition, comparing distributions between `all-immune` and `subset-immune` may be helpful to identify the optimal normal reference strategy.
+Ideally, we'll see that tumor and Unknown cells from `cell-type-consensus` and cells labeled as tumor in `cell-type-ewings` will have relatively higher CNV scores compared to other cell types.
+
+In addition, it will be useful to:
+
+* See values for cells labeled `tumor-immune`, which were labeled as `tumor` by `cell-type-ewings` but as an immune cell type by `cell-type-consensus`
+* Compare distributions between `all-immune` and `subset-immune` which may support identifying the optimal normal reference strategy.
 
 ```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}
 # drop cells from other libraries
 query_has_cnv_df <- has_cnv_df |>
   dplyr::filter(library_id == params$library_id)
 
-consensus_violin <- ggplot(query_has_cnv_df) +
+ggplot(query_has_cnv_df) +
   aes(
-    x = consensus_annotation,
+    x = celltype,
     y = total_cnv_per_cell,
     fill = normal_reference
   ) +
   geom_violin(scale = "width") +
   scale_fill_brewer(palette = "Pastel2") +
-  labs(title = "Annotations from cell-type-consensus") +
   theme(axis.text.x = element_text(angle = 45, hjust = 1))
-
-ewings_violin <- ggplot(query_has_cnv_df) +
-  aes(
-    x = ewing_annotation,
-    y = total_cnv_per_cell,
-    fill = normal_reference
-  ) +
-  geom_violin(scale = "width") +
-  scale_fill_brewer(palette = "Pastel2") +
-  labs(title = "Annotations from cell-type-ewings") +
-  theme(axis.text.x = element_text(angle = 45, hjust = 1))
-
-wrap_plots(consensus_violin, ewings_violin, ncol = 1, guides = "collect") +
-  plot_annotation(title = "CNV scores across cell types") &
-  theme(legend.position = "bottom")
 ```
 
 
@@ -280,13 +291,12 @@ wrap_plots(consensus_violin, ewings_violin, ncol = 1, guides = "collect") +
 
 Next, we'll visualize the total CNV counts as a UMAP.
 
-First, as a guide to interpret the UMAP, let's color by the top 10 `cell-type-ewings` cell types.
+First, as a guide to interpret the UMAP, let's color by cell types.
 
 ```{r, fig.width = 6}
 ggplot(umap_df) +
-  aes(x = UMAP1, y = UMAP2, color = forcats::fct_lump(ewing_annotation, 8)) +
+  aes(x = UMAP1, y = UMAP2, color = celltype) +
   geom_point(size = 0.1, alpha = 0.3) +
-  labs(color = "ewings annotation") +
   guides(color = guide_legend(override.aes = list(size = 2, alpha = 1))) +
   umap_theme
 ```
@@ -327,36 +337,15 @@ ggplot(has_cnv_df) +
 
 Let's also look at the distributions of cell types in clusters.
 Is there a trend for which cell types tend to show up in which cluster?
-We'll plot this for both the consensus and ewing annotations, considering only the top 7 cell types for visual ease.
 
 ```{r fig.width=12}
 ggplot(query_has_cnv_df) +
-  aes(x = subcluster, fill = forcats::fct_lump(consensus_annotation, 7)) +
-  geom_bar() +
-  scale_fill_brewer(palette = "Dark2") +
-  facet_wrap(
-    vars(normal_reference),
-    scales = "free_x"
-  ) +
-  labs(
-    title = "Consensus cell types",
-    fill = "annotation"
-  ) +
-  theme(axis.text.x = element_text(angle = 45, hjust = 1))
-```
-
-```{r fig.width=12}
-ggplot(query_has_cnv_df) +
-  aes(x = subcluster, fill = forcats::fct_lump(ewing_annotation, 7)) +
+  aes(x = subcluster, fill = celltype) +
   geom_bar() +
   scale_fill_brewer(palette = "Set1") +
   facet_wrap(
     vars(normal_reference),
     scales = "free_x"
-  ) +
-  labs(
-    title = "Ewing cell types",
-    fill = "annotation"
   ) +
   theme(axis.text.x = element_text(angle = 45, hjust = 1))
 ```


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Closes #1100


#### What is the goal of this pull request?

The goal of this PR is to add a template Rmd that can be used to explore the inferCNV results generated as part of #1094. 

Note that I ended up running those with the `i3` HMM since it was really helpful with runtime. But, after starting to look at some results here compared to what we observed in the `cell-type-ewings` module (albeit with different reference cells!), I do think we might want to just got for `i6 since I am not necessarily seeing the expected CNVs we'd want to see...

That said, I have not formally run all libraries through the template, since let's get it reviewed first! :)


#### Briefly describe the general approach you took to achieve this goal.

I added a new directory `notebook-templates` with this notebook in it. It contains visualizations of the following (it's a lot, but now we have a bunch to choose from for next steps!)

- the actual heatmaps
- distributions of CNVs per cell
- distributions of CNVs across cell types, considering both ewings & consensus
- UMAP colored by CNVs , using the ewings-colored UMAP as a guide
- A direct comparison of the number of CNVs inferred between the two references
- Some poking around at clusters: how big are they? any library batch effects? correspondance with cell types?
- A look at the actual CNV distributions themselves - here, I used the `proportion_scaled_` column because I borrowed a bit from the `cell-type-ewings` module, but I'm really open to discussion about the right column to use there?

I am very much aware that the code could be more modular since I am duplicating much of the plotting code when separate ggplot code is needed for the two references. We can absolutely firm these up if we want to, but I wanted to see what's going to make it through review first! Also, some can always move into a new utils file.  

Here is a copy of the template with `SCPCL000822`:
[ewings-infercnv-results.nb.html.zip](https://github.com/user-attachments/files/19763668/ewings-infercnv-results.nb.html.zip)

There are also these smaller changes:
- I updated the inferCNV script to use i6 as the default HMM, since it's their default. 
- I therefore updated the analysis script to specific i3, and added threads to be explicit as well

### Results

#### What is the name of your results bucket on S3?

`s3://researcher-654654257431-us-east-2`

#### What types of results does your code produce (e.g., table, figure)?

I have uploaded the inferCNV results into the bucket: `s3://researcher-654654257431-us-east-2/infercnv-consensus-cell-type/results/SCPCP000015/`. Again, these are all with `i3`. As part of review here, let me know if I should run with the `i6` HMM too or instead.

#### What is your summary of the results?

Haven't looked too in depth yet, only a little - that's the next step to be able to close out #1094!


### Provide directions for reviewers


#### What are the software and computational requirements needed to be able to run the code in this PR?

Just renv

#### Are there particularly areas you'd like reviewers to have a close look at?

Nothing beyond what I've noted above.


#### Is there anything that you want to discuss further?

N/A



### Author checklists

#### Analysis module and review

- [x] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [x] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [x] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [ ] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [x] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
