### PR TITLE
Update infercnv script, including clustering parameters

### DIFF
--- a/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
@@ -160,7 +160,6 @@ if (dir.exists(scratch_dir)) {
   fs::dir_delete(scratch_dir)
 }
 
-
 # ensure directories we need exist
 fs::dir_create(c(
   opts$output_dir,
@@ -180,7 +179,6 @@ output_obj_file <- file.path(opts$output_dir, glue::glue("{library_id}_cnv-obj.r
 # png file to save
 scratch_png <- file.path(scratch_dir, "infercnv.png")
 output_png <- file.path(opts$output_dir, glue::glue("{library_id}_infercnv.png"))
-
 
 # Prepare input data  ---------------------------------------------
 
@@ -222,7 +220,6 @@ infercnv_obj <- infercnv::CreateInfercnvObject(
   gene_order_file = opts$gene_order_file,
   ref_group_name = reference_group_name
 )
-
 
 # run infercnv
 infercnv_obj <- infercnv::run(


### PR DESCRIPTION
This is a quick PR to update some aspects of the `inferCNV` script for running ewings with the normal references. Note that some of these changes are in #1102, but can't really stack from a fork so sending them in here instead, will merge into that open PR!

- I updated the HMM default to `i6` instead of `i3`
- We need to clear out the scratch directory between runs to avoid conflict previous results from using the other normal reference
- For any clustering parameters that updated the defaults for clustering parameters when running inferCNV, based on this discussion: https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/1102#issuecomment-2814045014
  - `leiden_function` default has been updated to CPM
  - `leiden_resolution` default has been updated to "auto" but if a number is provided the script will update this to a numeric

Using this updated script, I will run `inferCNV` through with our immune references and see how results are looking!