### PR TITLE
Update infercnv-consensus GHA

### DIFF
--- a/.github/workflows/run_infercnv-consensus-cell-type.yml
+++ b/.github/workflows/run_infercnv-consensus-cell-type.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Run analysis module
         run: |
           cd ${MODULE_PATH}
-          bash run-analysis.sh
+          TESTING=1 bash run-analysis.sh

--- a/analyses/infercnv-consensus-cell-type/run-analysis.sh
+++ b/analyses/infercnv-consensus-cell-type/run-analysis.sh
@@ -8,9 +8,20 @@
 
 set -euo pipefail
 
+
 # Ensure script is being run from its directory
 module_dir=$(dirname "${BASH_SOURCE[0]}")
 cd ${module_dir}
+
+# Set up input variables
+TESTING=${testing:-0}
+
+# If we are testing, we should use the i3 HMM model with inferCNV
+if [[ $TESTING -eq 1 ]]; then
+    hmm_type="i3"
+else
+    hmm_type="i6"
+fi
 
 # Define directories and file paths
 data_dir="../../data/current"
@@ -69,11 +80,13 @@ for sample_id in $sample_ids; do
         Rscript ${script_dir}/01_run-infercnv.R \
             --sce_file $sce_file \
             --reference_file $immune_ref_file \
+            --hmm_type ${hmm_type} \
             --output_dir $sample_results_dir/ref-all-immune/
 
         Rscript ${script_dir}/01_run-infercnv.R \
             --sce_file $sce_file \
             --reference_file $immune_subset_ref_file \
+            --hmm_type ${hmm_type} \
             --output_dir $sample_results_dir/ref-subset-immune/
 
     done


### PR DESCRIPTION
Closes #1104 

#### What is the goal of this pull request?

This PR updates the `run` GHA for this module to move a little faster through PRs! Initially I planned to set this up to run `i3` on PRs and `i6` otherwise, but I decided when implementing that was maybe overkill and it seems fine to just have `i3` always run during _all_ testing, but run with `i6`  as default otherwise. So, I added a `TESTING` variable instead of a variable to control the HMM specifically.

Let me know if you think I should take the more fine-grained strategy where the HMM depends on the GHA context, rather than always running `i3` in GHAs.


