### PR TITLE
Add shell script to run SCPCP000015

### DIFF
--- a/.github/workflows/run_infercnv-consensus-cell-type.yml
+++ b/.github/workflows/run_infercnv-consensus-cell-type.yml
@@ -72,6 +72,12 @@ jobs:
 
 
       - name: Run analysis module
+        env:
+          # To save cycles, when running this from a PR we run with a subset of normal references only.
+          # The full set of normal references is used otherwise.
+          # `testing=1` will run a subset of normal references and `testing=0` will run with all normal references
+          testing: ${{ github.event_name == 'pull_request' && 1 || 0 }}
+
         run: |
           cd ${MODULE_PATH}
-          bash run-analysis.sh
+          testing=${testing} bash run-analysis.sh

--- a/analyses/infercnv-consensus-cell-type/project-workflows/README.md
+++ b/analyses/infercnv-consensus-cell-type/project-workflows/README.md
@@ -1,0 +1,4 @@
+This directory contains scripts to run the module on a given project.
+Each script is expected to be called from `../run-analysis.sh`.
+
+* `run-SCPCP000015.sh` runs the module across samples from project `SCPCP000015`

--- a/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
+++ b/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
@@ -7,8 +7,9 @@
 
 set -euo pipefail
 
-# Ensure script is being run from its directory
-module_dir=$(dirname "${BASH_SOURCE[0]}")
+# Ensure script is being run from _one directory up_, which represents the root directory of the module
+# This is so `renv` loads properly, without needing to call `renv::load()` in scripts since code run in Docker containers won't use `renv`
+module_dir=$(dirname "${BASH_SOURCE[0]}")/..
 cd ${module_dir}
 
 # This script processes samples from SCPCP000015
@@ -22,11 +23,12 @@ threads=${threads:-4}
 seed=${seed:-2025}
 
 # Define input directories and files
-top_data_dir="../../../data/current"
-data_dir="../../../data/current/${project_id}"
-script_dir="../scripts"
-results_dir="../results/${project_id}"
-normal_ref_dir="../references/normal-references/${project_id}"
+# These should all be relative to `../`
+top_data_dir="../../data/current"
+data_dir="../../data/current/${project_id}"
+script_dir="scripts"
+results_dir="results/${project_id}"
+normal_ref_dir="references/normal-references/${project_id}"
 merged_sce_file="${top_data_dir}/results/merge-sce/${project_id}/${project_id}_merged.rds"
 cell_type_ewings_dir="${top_data_dir}/results/cell-type-ewings/${project_id}"
 

--- a/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
+++ b/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# This script runs the module workflow for SCPCP000015 and is meant to be called from ./run-analysis.sh.
+# It can be run as follows, optionally specifying the following variables:
+#
+# threads=<number of threads for inferCNV> seed=<random seed to set for inferCNV> ./run-SCPCP000015.sh
+
+set -euo pipefail
+
+# Ensure script is being run from its directory
+module_dir=$(dirname "${BASH_SOURCE[0]}")
+cd ${module_dir}
+
+# This script processes samples from SCPCP000015
+project_id="SCPCP000015"
+
+# Define library to exclude from analysis
+exclude_library="SCPCL001111"
+
+# inferCNV settings
+threads=${threads:-4}
+seed=${seed:-2025}
+
+# Define input directories and files
+top_data_dir="../../../data/current"
+data_dir="../../../data/current/${project_id}"
+script_dir="../scripts"
+results_dir="../results/${project_id}"
+normal_ref_dir="../references/normal-references/${project_id}"
+merged_sce_file="${top_data_dir}/results/merge-sce/${project_id}/${project_id}_merged.rds"
+cell_type_ewings_dir="${top_data_dir}/results/cell-type-ewings/${project_id}"
+
+mkdir -p ${normal_ref_dir}
+
+# Define normal reference files
+immune_ref_file="${normal_ref_dir}/ref_immune.rds"
+endo_ref_file="${normal_ref_dir}/ref_endo.rds"
+endo_immune_ref_file="${normal_ref_dir}/ref_endo-immune.rds"
+
+### Perform the analysis ###
+
+# Build the SCPCP000015 reference files
+Rscript ${script_dir}/build-normal-reference/build-reference-SCPCP000015.R \
+    --merged_sce_file ${merged_sce_file} \
+    --cell_type_ewings_dir ${cell_type_ewings_dir} \
+    --reference_immune ${immune_ref_file} \
+    --reference_endo ${endo_ref_file} \
+    --reference_endo_immune ${endo_immune_ref_file}
+
+# Define all sample ids
+sample_ids=$(basename -a ${data_dir}/SCPCS*)
+
+# Run inferCNV on all samples across conditions of interest
+for sample_id in $sample_ids; do
+
+    # There is only one library per sample for this project, so we can right away define the SCE
+    sce_file=`ls ${data_dir}/${sample_id}/*_processed.rds`
+
+    # skip `exclude_library`
+    library_id=$(basename $sce_file | sed 's/_processed.rds$//')
+    if [[ $library_id == $exclude_library ]]; then
+        continue
+    fi
+
+    # Loop over normal references of interest
+    # Use reference names (not file names) since these will be used to create directories
+    for normal_ref in "ref_immune" "ref_endo" "ref_endo-immune"; do
+
+        # create sample results directory
+        sample_results_dir="${results_dir}/${sample_id}/${normal_ref}"
+        mkdir -p ${sample_results_dir}
+
+        # define normal reference SCE file
+        normal_ref_file="${normal_ref_dir}/${normal_ref}.rds"
+
+        # run inferCNV
+        Rscript ${script_dir}/01_run-infercnv.R \
+            --sce_file $sce_file \
+            --reference_file $normal_ref_file \
+            --output_dir $sample_results_dir \
+            --threads $threads \
+            --seed $seed
+
+        # TODO: Next, we'll run the forthcoming exploratory notebook on each inferCNV result
+    done
+done

--- a/analyses/infercnv-consensus-cell-type/run-analysis.sh
+++ b/analyses/infercnv-consensus-cell-type/run-analysis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script runs the module workflow.
+# This script runs the module across projects
 #
 # Usage:
 #
@@ -12,43 +12,20 @@ set -euo pipefail
 module_dir=$(dirname "${BASH_SOURCE[0]}")
 cd ${module_dir}
 
-# Define directories and file paths
-data_dir="../../data/current"
+# Define directories
 script_dir="scripts"
-results_dir="results"
+scratch_dir="scratch"
 ref_dir="references"
-infercnv_ref_dir="${ref_dir}/normal-references"
-
-mkdir -p ${infercnv_ref_dir}
+mkdir -p ${scratch_dir}
+mkdir -p ${ref_dir}
 
 # Create the gene order file for input to inferCNV
-Rscript ${script_dir}/00-make-gene-order-file.R
+Rscript ${script_dir}/00-make-gene-order-file.R \
+    --scratch_dir ${scratch_dir} \
+    --local_ref_dir ${ref_dir}
 
-##### Analysis for SCPCP000015 #####
+# Run individual projects through the module
+# Each script prepares the project's normal references and runs inferCNV across relevant project samples
 
-project_id="SCPCP000015"
-project_data_dir="${data_dir}/${project_id}/"
-project_results_dir="${results_dir}/${project_id}/"
-mkdir -p ${project_results_dir}
-
-# Define library to exclude from inferCNV
-exclude_library="SCPCL001111"
-
-# Define input files for scripts
-merged_sce_file="${data_dir}/results/merge-sce/SCPCP000015/SCPCP000015_merged.rds"
-cell_type_ewings_dir="${data_dir}/results/cell-type-ewings/SCPCP000015"
-
-# Define normal reference files
-ewings_ref_dir="${infercnv_ref_dir}/SCPCP000015"
-mkdir -p ${ewings_ref_dir}
-immune_ref_file="${ewings_ref_dir}/ref_immune.rds"
-endo_ref_file="${ewings_ref_dir}/ref_endo.rds"
-endo_immune_ref_file="${ewings_ref_dir}/ref_endo-immune.rds"
-
-# Build the SCPCP000015 reference files
-Rscript ${script_dir}/build-normal-reference/build-reference-SCPCP000015.R \
-    --merged_sce_file ${merged_sce_file} \
-    --cell_type_ewings_dir ${cell_type_ewings_dir} \
-    --reference_immune ${immune_ref_file} \
-    --reference_endo ${endo_ref_file} \
-    --reference_endo_immune ${endo_immune_ref_file}
+# SCPCP000015: Ewing sarcoma samples
+./project-workflows/run-SCPCP000015.sh

--- a/analyses/infercnv-consensus-cell-type/run-analysis.sh
+++ b/analyses/infercnv-consensus-cell-type/run-analysis.sh
@@ -5,12 +5,17 @@
 # Usage:
 #
 # ./run-analysis.sh
+#
+# When running in CI or with test data, use:
+# testing=1 ./run-analysis.sh
 
 set -euo pipefail
 
 # Ensure script is being run from its directory
 module_dir=$(dirname "${BASH_SOURCE[0]}")
 cd ${module_dir}
+
+testing=${testing:-0}
 
 # Define directories
 script_dir="scripts"
@@ -28,4 +33,4 @@ Rscript ${script_dir}/00-make-gene-order-file.R \
 # Each script prepares the project's normal references and runs inferCNV across relevant project samples
 
 # SCPCP000015: Ewing sarcoma samples
-./project-workflows/run-SCPCP000015.sh
+testing=$testing ./project-workflows/run-SCPCP000015.sh

--- a/analyses/infercnv-consensus-cell-type/scripts/00-make-gene-order-file.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/00-make-gene-order-file.R
@@ -4,8 +4,6 @@
 # https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/b1b8dea054d30f081279be9277501bd189a3c4d0/analyses/cell-type-ewings/scripts/cnv-workflow/00-make-gene-order-file.R
 
 project_root <- here::here()
-renv::load(project_root)
-
 library(optparse)
 
 option_list <- list(

--- a/analyses/infercnv-consensus-cell-type/scripts/00-make-gene-order-file.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/00-make-gene-order-file.R
@@ -3,8 +3,8 @@
 # This script was adapted from:
 # https://github.com/AlexsLemonade/OpenScPCA-analysis/blob/b1b8dea054d30f081279be9277501bd189a3c4d0/analyses/cell-type-ewings/scripts/cnv-workflow/00-make-gene-order-file.R
 
-renv::load()
 project_root <- here::here()
+renv::load(project_root)
 
 library(optparse)
 

--- a/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
@@ -15,6 +15,7 @@
 #
 
 project_root <- here::here()
+renv::load(project_root)
 
 suppressPackageStartupMessages({
   library(SingleCellExperiment)

--- a/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
@@ -15,7 +15,6 @@
 #
 
 project_root <- here::here()
-renv::load(project_root)
 
 suppressPackageStartupMessages({
   library(SingleCellExperiment)


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Closes #1114


#### What is the goal of this pull request?

The goal of this PR was to add a script to process ewings samples through inferCNV. While writing this, I decided to go in a parallel direction so let me know what you think here during review! Described below...

#### Briefly describe the general approach you took to achieve this goal.



What I've done is split code into two scripts:
- `run-analysis.sh` which should wrap the whole module and calls the new shell script in....
- ...`project-workflows/run-SCPCP000015.sh` which contains code to run ewings samples through, including _both_ the code to build the normal reference and run inferCNV across references
  - In the future, I would expect we can expand this script with additional inferCNV conditions to run over.
  - I have a TODO step in there to then process each individual inferCNV run with the template notebook coming up as part of #1113
  - I also expect we end up adding additional scripts to `project-workflows/` to handle each project 

What do you think of this approach? Should we split out inferCNV code even more, or is this an ok level of modularity?

One possible important foible of this approach too - In the new project-specific script, I set it up to run as though it is _one level up_ in the module directory. Otherwise, we'd need to add `renv::load()` statements into scripts, which I am nervous to do because this won't work great once we get this module running in Docker. Alternatively, this script could just live at the top of the module, but things would be a bit more cluttered. Thoughts?


#### If known, do you anticipate filing additional pull requests to complete this analysis module?

👍 

### Results



#### What is the name of your results bucket on S3?

inferCNV results are not yet in the bucket, since I wanted to get a round of review first. But, results _will_ be in `researcher-654654257431-us-east-2`. This PR is mostly about code though with results coming next in the template notebook, probably.


### Provide directions for reviewers

#### What are the software and computational requirements needed to be able to run the code in this PR?

renv

#### Are there particularly areas you'd like reviewers to have a close look at?

Nothing beyond what I've already noted.

#### Is there anything that you want to discuss further?


N/A



### Author checklists

#### Analysis module and review

- [x] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [x] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [ ] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [x] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [x] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.

**EDIT:** This is still running through CI but it's looking fine so I'm going to go ahead and request review. I wonder if we'd like a testing behavior here to only run _one_ normal reference through CI. Let me know during review if that seems reasonable to you!
