### PR TITLE
Add ewings palette file

### DIFF
--- a/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
@@ -193,7 +193,9 @@ sce <- sce[, !(colnames(sce) %in% duplicated_cells)]
 raw_counts_matrix <- cbind(
   as.matrix(counts(sce)),
   as.matrix(counts(ref_sce))
-)
+) |>
+  # sparse for memory
+  as("CsparseMatrix")
 
 # Check that we removed the duplicates:
 stopifnot(
@@ -220,6 +222,11 @@ infercnv_obj <- infercnv::CreateInfercnvObject(
   gene_order_file = opts$gene_order_file,
   ref_group_name = reference_group_name
 )
+
+# Clean up some memory before running inferCNV
+rm(sce, ref_sce, raw_counts_matrix)
+gc()
+
 
 # run infercnv
 infercnv_obj <- infercnv::run(

--- a/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/01_run-infercnv.R
@@ -227,7 +227,6 @@ infercnv_obj <- infercnv::CreateInfercnvObject(
 rm(sce, ref_sce, raw_counts_matrix)
 gc()
 
-
 # run infercnv
 infercnv_obj <- infercnv::run(
   infercnv_obj,

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/README.md
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/README.md
@@ -1,3 +1,4 @@
 This directory contains template notebooks used to analyze results from running `inferCNV` on an individual library.
 
 * `SCPCP000015_explore-infercnv-results.Rmd` explores `inferCNV` results run on a library from `SCPCP000015`
+* The `palettes/` directory contains TSV files with celltype palettes used in project-specific notebooks

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/SCPCP000015_explore-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/SCPCP000015_explore-infercnv-results.Rmd
@@ -332,35 +332,20 @@ query_only_df <- library_has_cnv_df |>
       stringr::str_detect(ewing_annotation, "tumor"),
       "tumor",
       ewing_annotation
-    )
+    ),
+    # top 10 only - lump here to assist in color setup
+    celltype_fine = forcats::fct_lump(celltype_fine, 10)
   ) |>
   dplyr::add_count(celltype_fine) |>
-  dplyr::mutate(
-    celltype_fine_n = glue::glue("{celltype_fine} (n={n})"),
-    # top 10 only
-    celltype_fine_n = forcats::fct_lump(celltype_fine_n, 10)
-  )
-
-# add n() to "Other" for plot clarity and update factor to frequency order
-current_levels <- levels(query_only_df$celltype_fine_n)
-total_other <- query_only_df |>
-  dplyr::filter(celltype_fine_n == "Other") |>
-  nrow()
-updated_other <- glue::glue("Other (n={total_other})")
-
-query_only_df <- query_only_df |>
-  dplyr::mutate(
-    # update other level to have counts
-    celltype_fine_n = as.character(celltype_fine_n),
-    celltype_fine_n = ifelse(celltype_fine_n == "Other", updated_other, celltype_fine_n),
-    # order based on freq
-    celltype_fine_n = as.factor(celltype_fine_n),
-    celltype_fine_n = forcats::fct_infreq(celltype_fine_n),
-    celltype_fine_n = forcats::fct_relevel(celltype_fine_n, updated_other, after = Inf)
-  ) |>
+  dplyr::mutate(celltype_fine_n = glue::glue("{celltype_fine} (n={n})")) |>
   # exclude small clusters
   dplyr::add_count(subcluster, name = "subcluster_size") |>
   dplyr::filter(subcluster_size >= 10)
+
+# Set cell type factor order by frequency, with the "Other (n=XX)" at the end
+other_level <- grep("Other", unique(query_only_df$celltype_fine_n), value = TRUE)
+query_only_df$celltype_fine_n <- forcats::fct_infreq(query_only_df$celltype_fine_n) |>
+  forcats::fct_relevel(other_level, after = Inf)
 
 # Create color palette with (n=) in labels
 color_n_df <- query_only_df |>
@@ -373,9 +358,6 @@ color_n_df <- query_only_df |>
   unique()
 colors <- color_n_df$color
 names(colors) <- color_n_df$celltype_fine_n
-
-# Add in the other color with its label, since that won't be in the palette
-colors[updated_other] <- "#D2D2D2"
 ```
 
 
@@ -387,6 +369,10 @@ ggplot(query_only_df) +
   ) +
   geom_bar() +
   scale_fill_manual(values = colors) +
+  labs(
+    fill = "Cell type (number of cells)",
+    x = "InferCNV subcluster"
+  ) +
   theme(axis.text.x = element_blank())
 ```
 

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/SCPCP000015_explore-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/SCPCP000015_explore-infercnv-results.Rmd
@@ -111,6 +111,9 @@ infercnv_png <- file.path(
   infercnv_dir,
   glue::glue("{params$library_id}_infercnv.png")
 )
+
+# celltype palette file
+palette_file <- file.path("palettes", "SCPCP000015_palette.tsv")
 ```
 
 ### Read in data
@@ -149,8 +152,9 @@ umap_df <- readr::read_rds(sce_file) |>
     UMAP2 = UMAP.2
   )
 
-# Read ewings cell types
+# Read ewings cell types and colors
 celltype_df <- readr::read_tsv(ewings_tsv)
+colors_df <- readr::read_tsv(palette_file)
 ```
 
 
@@ -324,17 +328,17 @@ query_only_df <- library_has_cnv_df |>
   dplyr::filter(cell_group == "unknown") |>
   # create a finer cell type column for this plot
   dplyr::mutate(
-    celltype_fine = dplyr::case_when(
-      cell_group == "reference" ~ "reference cell",
-      stringr::str_detect(ewing_annotation, "tumor") ~ "tumor cell",
-      .default = ewing_annotation
+    celltype_fine = ifelse(
+      stringr::str_detect(ewing_annotation, "tumor"),
+      "tumor",
+      ewing_annotation
     )
   ) |>
-  dplyr::add_count(celltype_fine, name = "celltype_fine_count") |>
+  dplyr::add_count(celltype_fine) |>
   dplyr::mutate(
-    celltype_fine_n = glue::glue("{celltype_fine} (n={celltype_fine_count})"),
+    celltype_fine_n = glue::glue("{celltype_fine} (n={n})"),
     # top 10 only
-    celltype_fine_n = forcats::fct_lump(celltype_fine_n, 10),
+    celltype_fine_n = forcats::fct_lump(celltype_fine_n, 10)
   )
 
 # add n() to "Other" for plot clarity and update factor to frequency order
@@ -358,10 +362,20 @@ query_only_df <- query_only_df |>
   dplyr::add_count(subcluster, name = "subcluster_size") |>
   dplyr::filter(subcluster_size >= 10)
 
+# Create color palette with (n=) in labels
+color_n_df <- query_only_df |>
+  dplyr::select(celltype_fine, celltype_fine_n) |>
+  dplyr::inner_join(
+    colors_df,
+    by = c("celltype_fine" = "celltype")
+  ) |>
+  dplyr::select(celltype_fine_n, color) |>
+  unique()
+colors <- color_n_df$color
+names(colors) <- color_n_df$celltype_fine_n
 
-# 11 hex colors!
-# adapted from 'Classic 10' from paletteer: https://r-graph-gallery.com/color-palette-finder
-colors <- c("#1F77B4", "#FF7F0E", "#2CA02C", "#D6272F", "#9467BD", "#8C564B", "#E377C2", "#7F7F7F", "#BCBD22", "#17CFFB", "#17CF1F")
+# Add in the other color with its label, since that won't be in the palette
+colors[updated_other] <- "#D2D2D2"
 ```
 
 

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/palettes/SCPCP000015_palette.tsv
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/palettes/SCPCP000015_palette.tsv
@@ -15,3 +15,4 @@ fibroblast	#F8A19F
 smooth muscle cell	#3283FE
 muscle cell	#2ED9FF
 stromal cell	#1CFFCE
+Other	#D2D2D2

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/palettes/SCPCP000015_palette.tsv
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/palettes/SCPCP000015_palette.tsv
@@ -1,7 +1,7 @@
 celltype	color
-tumor	#AA0DFE
+tumor	#DF95FF
 plasma cell	#FBE426
-Unknown	#FE00FA
+Unknown	#B10DA1
 memory T cell	#325A9B
 mature T cell	#16FF32
 macrophage	#1C8356
@@ -11,7 +11,7 @@ adipocyte	#FEAF16
 chondrocyte	#F7E1A0
 endothelial cell	#FC1CBF
 epithelial cell	#C075A6
-fibroblast	#B10DA1
+fibroblast	#F8A19F
 smooth muscle cell	#3283FE
 muscle cell	#2ED9FF
 stromal cell	#1CFFCE

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/palettes/SCPCP000015_palette.tsv
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/palettes/SCPCP000015_palette.tsv
@@ -1,0 +1,17 @@
+celltype	color
+tumor	#AA0DFE
+plasma cell	#FBE426
+Unknown	#FE00FA
+memory T cell	#325A9B
+mature T cell	#16FF32
+macrophage	#1C8356
+monocyte	#1CBE4F
+myeloid leukocyte	#90AD1C
+adipocyte	#FEAF16
+chondrocyte	#F7E1A0
+endothelial cell	#FC1CBF
+epithelial cell	#C075A6
+fibroblast	#B10DA1
+smooth muscle cell	#3283FE
+muscle cell	#2ED9FF
+stromal cell	#1CFFCE


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Closes #1122 


#### What is the goal of this pull request?

This PR adds a palette file to `template_notebooks/palettes` (and documents in the README there) for ewings cell types. To determine which cell types to include, I identified the top 10 cell types across Ewings samples (collapsing all tumor into a single "tumor" category) and pooled together into a set of cell types we need for palettes. I assigned colors (mostly) from our unique colors from the consensus cell type validation palette.

Then, I updated the notebook to use this palette in the bar plot showing cell types across clusters, and simplified some of the plot code for setting factor order along the way; here is a screenshot of how the plot now looks for one sample, for example:

![Screenshot 2025-05-09 at 12 46 28 PM](https://github.com/user-attachments/assets/56081c87-437f-466c-8d2f-dd25d1cb0e56)


**In addition,** I updated the `inferCNV` script to help with memory since I was having some problems on our RStudio Server running it. In particular (h/t @jashapiro) I sparsified the input matrix, which really does help to drop the size of the interCNV object and that certainly doesn't _hurt_! I also did a bit of `rm()`/`gc()`.

### Results

N/A 

### Provide directions for reviewers

#### What are the software and computational requirements needed to be able to run the code in this PR?

renv

#### Are there particularly areas you'd like reviewers to have a close look at?


Let me know if, now that we have this palette, it would be helpful to incorporate further? For example, we currently have a UMAP showing cell type categories of only tumor, reference, and other query cell. We could have a UMAP with these colors (but honestly I don't think it's necessary since we get a decent amount of insight from what we have!).





### Author checklists

#### Analysis module and review

- [ ] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [ ] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [ ] The analytical code is documented and contains comments.
- [ ] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [ ] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
