### PR TITLE
Add celltype reference file

### DIFF
--- a/analyses/infercnv-consensus-cell-type/.gitignore
+++ b/analyses/infercnv-consensus-cell-type/.gitignore
@@ -8,6 +8,5 @@
 
 # Ignore any large reference files
 references/Homo_sapiens.GRCh38.104.gene_order.txt
-references/normal-references/*
-!references/normal-references/README.md
+references/normal-references/SCPCP000015/*
 !references/normal-references/SCPCP000015/reference-celltypes.tsv

--- a/analyses/infercnv-consensus-cell-type/.gitignore
+++ b/analyses/infercnv-consensus-cell-type/.gitignore
@@ -10,3 +10,4 @@
 references/Homo_sapiens.GRCh38.104.gene_order.txt
 references/normal-references/*
 !references/normal-references/README.md
+!references/normal-references/SCPCP000015/reference-celltypes.tsv

--- a/analyses/infercnv-consensus-cell-type/.gitignore
+++ b/analyses/infercnv-consensus-cell-type/.gitignore
@@ -8,4 +8,5 @@
 
 # Ignore any large reference files
 references/Homo_sapiens.GRCh38.104.gene_order.txt
-references/normal-references/
+references/normal-references/*
+!references/normal-references/README.md

--- a/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
+++ b/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
@@ -39,6 +39,7 @@ cell_type_ewings_dir="${top_data_dir}/results/cell-type-ewings/${project_id}"
 mkdir -p ${normal_ref_dir}
 
 # Define normal reference files
+ref_celltypes_tsv="${normal_ref_dir}/reference-celltypes.tsv"
 immune_ref_file="${normal_ref_dir}/ref_immune.rds"
 endo_ref_file="${normal_ref_dir}/ref_endo.rds"
 endo_immune_ref_file="${normal_ref_dir}/ref_endo-immune.rds"
@@ -51,7 +52,8 @@ Rscript ${script_dir}/build-normal-reference/build-reference-SCPCP000015.R \
     --cell_type_ewings_dir ${cell_type_ewings_dir} \
     --reference_immune ${immune_ref_file} \
     --reference_endo ${endo_ref_file} \
-    --reference_endo_immune ${endo_immune_ref_file}
+    --reference_endo_immune ${endo_immune_ref_file} \
+    --reference_tsv ${ref_celltypes_tsv}
 
 # Define all sample ids
 sample_ids=$(basename -a ${data_dir}/SCPCS*)

--- a/analyses/infercnv-consensus-cell-type/references/README.md
+++ b/analyses/infercnv-consensus-cell-type/references/README.md
@@ -5,7 +5,6 @@ This directory contains reference information needed for analysis.
   * This file is created with `../scripts/00-make-gene-order-file.R` when running the analysis pipeline, but it is ignored from the repository due to its large size
 * `normal-references/`: This directory contains, organized by project, RDS files containing SCE objects for use as normal references with `inferCNV`.
 More information about these files is provided below.
-This directory is ignored from the repository due to its large size
 
 ## Normal references
 
@@ -17,10 +16,10 @@ Normal references for use with `inferCNV` are formatted as SCE files and are exp
   * Column names (cell ids) formatted as `{library_id}-{barcode}`
   * A `colData` column `consensus_annotation` recording each cell's consensus annotation
 
-
 The `normal-references/` directory contains the following references for each given project:
 
 * `SCPCP000015`
   * `ref_immune.rds` contains all immune cells across samples, excluding those which were annotated as `tumor` in the `cell-type-ewings` module
   * `ref_endo.rds` contains all endothelial cells across samples, excluding those which were annotated as `tumor` in the `cell-type-ewings` module
   * `ref_endo-immune.rds` contains the union of `ref_immune` and `ref_endo`
+  * `reference-celltypes.tsv` is a TSV of all consensus cell type labels that contribute to each normal reference

--- a/analyses/infercnv-consensus-cell-type/references/normal-references/README.md
+++ b/analyses/infercnv-consensus-cell-type/references/normal-references/README.md
@@ -1,0 +1,7 @@
+# Normal references
+
+This directory stores RDS files with SCE objects to use as normal cell references with `inferCNV`, organized by project.
+The RDS files are not stored in version control due to their large size.
+Each project directory will also have a TSV tile listing all of the consensus cell types included in each reference, which is included in version control.
+
+All files are created by project-specific scripts found in `../../scripts/build-normal-reference/`.

--- a/analyses/infercnv-consensus-cell-type/references/normal-references/SCPCP000015/reference-celltypes.tsv
+++ b/analyses/infercnv-consensus-cell-type/references/normal-references/SCPCP000015/reference-celltypes.tsv
@@ -1,0 +1,61 @@
+reference_name	consensus_celltype
+immune	hematopoietic stem cell
+immune	T cell
+immune	granulocyte
+immune	mononuclear phagocyte
+immune	macrophage
+immune	B cell
+immune	dendritic cell
+immune	megakaryocyte
+immune	monocyte
+immune	natural killer cell
+immune	CD4-positive, alpha-beta T cell
+immune	erythroid lineage cell
+immune	myeloid leukocyte
+immune	eosinophil
+immune	neutrophil
+immune	mature B cell
+immune	plasma cell
+immune	memory B cell
+immune	naive B cell
+immune	mature alpha-beta T cell
+immune	memory T cell
+immune	regulatory T cell
+immune	lymphocyte of B lineage
+immune	innate lymphoid cell
+immune	mature T cell
+immune	hematopoietic precursor cell
+endo	endothelial cell
+endo	blood vessel endothelial cell
+endo	microvascular endothelial cell
+endo	pericyte
+endo-immune	endothelial cell
+endo-immune	blood vessel endothelial cell
+endo-immune	microvascular endothelial cell
+endo-immune	pericyte
+endo-immune	hematopoietic stem cell
+endo-immune	T cell
+endo-immune	granulocyte
+endo-immune	mononuclear phagocyte
+endo-immune	macrophage
+endo-immune	B cell
+endo-immune	dendritic cell
+endo-immune	megakaryocyte
+endo-immune	monocyte
+endo-immune	natural killer cell
+endo-immune	CD4-positive, alpha-beta T cell
+endo-immune	erythroid lineage cell
+endo-immune	myeloid leukocyte
+endo-immune	eosinophil
+endo-immune	neutrophil
+endo-immune	mature B cell
+endo-immune	plasma cell
+endo-immune	memory B cell
+endo-immune	naive B cell
+endo-immune	mature alpha-beta T cell
+endo-immune	memory T cell
+endo-immune	regulatory T cell
+endo-immune	lymphocyte of B lineage
+endo-immune	innate lymphoid cell
+endo-immune	mature T cell
+endo-immune	hematopoietic precursor cell


### PR DESCRIPTION
Closes #1127 

As discussed in review for #1125, this PR adds a TSV file with normal reference cell types for SCPCP000015. I added the code to do this into the same script where we build the reference, and the TSV is exported to the same directory where the normal references are held. I also tossed in `pericyte` while I was here, can't hurt even though it won't actually do anything since there aren't any of those right now (but hey you never know what a future release brings!).

I also figured this is a reasonable file to keep under version control, so I modified the `.gitignore` so that these files are now present in the repo:
- `references/normal-references/README.md`: overall docs/description of normal references folder
- `references/normal-references/SCPCP000015/reference-celltypes.tsv`: the tsv established in this PR
