### PR TITLE
Notebook text patch

### DIFF
--- a/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
+++ b/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
@@ -44,20 +44,6 @@ immune_ref_file="${normal_ref_dir}/immune.rds"
 endo_ref_file="${normal_ref_dir}/endo.rds"
 endo_immune_ref_file="${normal_ref_dir}/endo-immune.rds"
 
-### Perform the analysis ###
-
-# Build the SCPCP000015 reference files
-Rscript ${script_dir}/build-normal-reference/build-reference-SCPCP000015.R \
-    --merged_sce_file ${merged_sce_file} \
-    --cell_type_ewings_dir ${cell_type_ewings_dir} \
-    --reference_immune ${immune_ref_file} \
-    --reference_endo ${endo_ref_file} \
-    --reference_endo_immune ${endo_immune_ref_file} \
-    --reference_tsv ${ref_celltypes_tsv}
-
-# Define all sample ids
-sample_ids=$(basename -a ${data_dir}/SCPCS*)
-
 # Define array of references to run across based on $testing
 # Use reference names (not file names) since these will be used to create directories below
 if [[ $testing -eq 1 ]]; then
@@ -70,6 +56,21 @@ else
     test_flag=""
 fi
 
+# Define all sample ids
+sample_ids=$(basename -a ${data_dir}/SCPCS*)
+
+### Perform the analysis ###
+
+# Build the SCPCP000015 reference files
+Rscript ${script_dir}/build-normal-reference/build-reference-SCPCP000015.R \
+    --merged_sce_file ${merged_sce_file} \
+    --cell_type_ewings_dir ${cell_type_ewings_dir} \
+    --reference_immune ${immune_ref_file} \
+    --reference_endo ${endo_ref_file} \
+    --reference_endo_immune ${endo_immune_ref_file} \
+    --reference_tsv ${ref_celltypes_tsv}
+
+
 # Run inferCNV with all samples across references of interest
 for sample_id in $sample_ids; do
 
@@ -81,19 +82,19 @@ for sample_id in $sample_ids; do
     if [[ $library_id == $exclude_library ]]; then
         continue
     fi
-    
+
     # define exploratory notebook name for this library
     # the name is be the same for all references, organized into different directories
     html_name="${library_id}_infercnv-results.nb.html"
-    
+
     # Define TSV file with cell type information, used when running with internal references
     celltype_tsv="${cell_type_ewings_dir}/${sample_id}/${library_id}_ewing-celltype-assignments.tsv"
 
     # Loop over normal references of interest
     for normal_ref in "${normal_refs[@]}"; do
-    
+
         ####### First, run with the pooled reference #######
-        
+
         # add _pooled suffix for output directory
         ref_name="${normal_ref}_pooled"
 
@@ -101,7 +102,7 @@ for sample_id in $sample_ids; do
         sample_results_dir="${results_dir}/${sample_id}/${ref_name}"
         mkdir -p ${sample_results_dir}
 
-        # define normal reference SCE file with 
+        # define normal reference SCE file with
         normal_ref_file="${normal_ref_dir}/${normal_ref}.rds"
 
         # run inferCNV with the pooled reference
@@ -120,20 +121,20 @@ for sample_id in $sample_ids; do
             params = list(library_id = '${library_id}', sample_id = '${sample_id}', reference_name = '${ref_name}'),
             output_dir = '${sample_results_dir}',
             output_file = '${html_name}')"
-            
+
         ####### Second, run with the internal reference #######
         # See https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/1125
         if [[ $sample_id == "SCPCS000490" || $sample_id == "SCPCS000492" || $sample_id == "SCPCS000750" ]]; then
-           
+
             # Only run SCPCS000750 with the endo reference; continue otherwise
             if [[ ${sample_id} == "SCPCS000750" && ${normal_ref} != "endo" ]]; then
                 continue
             fi
-        
+
             # update variables to have _internal suffix
             ref_name="${normal_ref}_internal"
             sample_results_dir="${results_dir}/${sample_id}/${ref_name}"
-            
+
             # run inferCNV with the internal reference
             Rscript ${script_dir}/01_run-infercnv.R \
                 --sce_file $sce_file \
@@ -145,7 +146,7 @@ for sample_id in $sample_ids; do
                 --threads $threads \
                 --seed $seed \
                 ${test_flag}
-            
+
             Rscript -e "rmarkdown::render('${notebook_dir}/SCPCP000015_explore-infercnv-results.Rmd',
                 params = list(library_id = '${library_id}', sample_id = '${sample_id}', reference_name = '${ref_name}'),
                 output_dir = '${sample_results_dir}',

--- a/analyses/infercnv-consensus-cell-type/template-notebooks/SCPCP000015_explore-infercnv-results.Rmd
+++ b/analyses/infercnv-consensus-cell-type/template-notebooks/SCPCP000015_explore-infercnv-results.Rmd
@@ -19,8 +19,8 @@ params:
 This notebook explores `inferCNV` results run on library `r params$library_id` from `SCPCP000015`.
 
 ```{r, results = 'asis'}
-ref_celltype <- stringr::str_split(params$reference_name, "_")[1]
-ref_type <- stringr::str_split(params$reference_name, "_")[2]
+ref_celltype <- stringr::str_split_1(params$reference_name, "_")[1]
+ref_type <- stringr::str_split_1(params$reference_name, "_")[2]
 
 ref_text <- list(
   "endo" = "endothelial",
@@ -35,7 +35,7 @@ if (ref_type == "internal") {
 
 glue::glue(
   "`inferCNV` was run with the following normal reference: `{params$reference_name}`.
-  This reference contains all {ref_celltype} cells {reference_type_text}, excluding any which were also identified as tumor in the `cell-type-ewings` analysis module.
+  This reference contains all {ref_text[[ref_celltype]]} cells {reference_type_text}, excluding any which were also identified as tumor in the `cell-type-ewings` analysis module.
   "
 )
 ```


### PR DESCRIPTION
While running inferCNV for #1125, I caught a tiny bug in the notebook that we missed for text printing - 

For example, it was wrongly printing as (see the array!):
![Screenshot 2025-05-15 at 11 22 02 AM](https://github.com/user-attachments/assets/467e2ebb-9c84-44ea-a0d8-5240ef42639c)

It's now fixed: 
![Screenshot 2025-05-15 at 11 21 53 AM](https://github.com/user-attachments/assets/f9713373-241c-4491-a093-63079c33a035)

I also did a quick organizational update to the workflow script to move some general definitions including the testing check up in the file to _before_ the section that performs the analysis.