### PR TITLE
Don't include PDX samples in the normal references

### DIFF
--- a/.github/workflows/run_infercnv-consensus-cell-type.yml
+++ b/.github/workflows/run_infercnv-consensus-cell-type.yml
@@ -71,7 +71,8 @@ jobs:
         run: |
           ./download-results.py --module cell-type-ewings --test-data ${data}
           ./download-results.py --module merge-sce --project SCPCP000015 --test-data
-          ./download-data.py  --test-data ${data}
+          ./download-data.py --test-data ${data}
+          ./download-data.py --test-data --metadata-only
 
       - name: Run analysis module
         env:

--- a/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
+++ b/analyses/infercnv-consensus-cell-type/project-workflows/run-SCPCP000015.sh
@@ -35,6 +35,7 @@ results_dir="results/${project_id}"
 normal_ref_dir="references/normal-references/${project_id}"
 merged_sce_file="${top_data_dir}/results/merge-sce/${project_id}/${project_id}_merged.rds"
 cell_type_ewings_dir="${top_data_dir}/results/cell-type-ewings/${project_id}"
+metadata_file="${data_dir}/single_cell_metadata.tsv"
 
 mkdir -p ${normal_ref_dir}
 
@@ -65,6 +66,7 @@ sample_ids=$(basename -a ${data_dir}/SCPCS*)
 Rscript ${script_dir}/build-normal-reference/build-reference-SCPCP000015.R \
     --merged_sce_file ${merged_sce_file} \
     --cell_type_ewings_dir ${cell_type_ewings_dir} \
+    --metadata_file ${metadata_file} \
     --reference_immune ${immune_ref_file} \
     --reference_endo ${endo_ref_file} \
     --reference_endo_immune ${endo_immune_ref_file} \

--- a/analyses/infercnv-consensus-cell-type/references/README.md
+++ b/analyses/infercnv-consensus-cell-type/references/README.md
@@ -17,7 +17,7 @@ Normal references for use with `inferCNV` are formatted as SCE files and are exp
 The `normal-references/` directory contains the following references for each given project:
 
 * `SCPCP000015`
-  * `immune.rds` contains all immune cells across samples, excluding those which were annotated as `tumor` in the `cell-type-ewings` module
-  * `endo.rds` contains all endothelial cells across samples, excluding those which were annotated as `tumor` in the `cell-type-ewings` module
+  * `immune.rds` contains all immune cells across non-PDX samples, excluding those which were annotated as `tumor` in the `cell-type-ewings` module
+  * `endo.rds` contains all endothelial cells across non-PDX samples, excluding those which were annotated as `tumor` in the `cell-type-ewings` module
   * `endo-immune.rds` contains the union of the `immune` and `endo` references
   * `reference-celltypes.tsv` is a TSV of all consensus cell type labels that contribute to each normal reference

--- a/analyses/infercnv-consensus-cell-type/scripts/build-normal-reference/build-reference-SCPCP000015.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/build-normal-reference/build-reference-SCPCP000015.R
@@ -69,15 +69,6 @@ stopifnot(
   "cell_type_ewings_dir does not exist" = dir.exists(opts$cell_type_ewings_dir)
 )
 
-# Define PDX samples which should be excluded
-pdx_samples <- c(
-  "SCPCS000491",
-  "SCPCS000750",
-  "SCPCS000751",
-  "SCPCS000752",
-  "SCPCS000753",
-  "SCPCS000754"
-)
 
 # Paths -----------------
 


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Closes #1132

#### What is the goal of this pull request?

This PR updates the script that builds normal references to only include samples where it is true that `sample_type == "Tumor"`. This will get rid of those pesky cells from PDX samples!

This has shifted the size of references, but there are still definitely enough cells:

- Immune went from N=314 --> N=309
- Endothelial went from N=693 --> N=539
- Hence, the combined went from N=1007 --> N=848

Once this goes in, I'll re-run the workflow.

#### Briefly describe the general approach you took to achieve this goal.

I filtered to keep tumor, but could also filter to remove the PDX string if you think that's clearer for code. These are the only two sample types for this project either way.

#### If known, do you anticipate filing additional pull requests to complete this analysis module?

Sure do.


### Results

No results in bucket for this one.

### Provide directions for reviewers


#### What are the software and computational requirements needed to be able to run the code in this PR?

renv

#### Are there particularly areas you'd like reviewers to have a close look at?
N/A


#### Is there anything that you want to discuss further?
N/A


### Author checklists

_Check all those that apply._
_Note that you may find it easier to check off these items after the pull request is actually filed._


#### Analysis module and review

- [x] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [x] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [ ] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [x] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
