### PR TITLE
Add neuroblastoma CNVs to reference tsv

### DIFF
--- a/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
+++ b/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
@@ -4,14 +4,14 @@ Ewing sarcoma	8	NA	gain	TRUE	https://doi.org/10.1158/2159-8290.CD-14-0622; https
 Ewing sarcoma	12	NA	gain	FALSE	https://doi.org/10.1158/2159-8290.CD-14-0622
 Ewing sarcoma	16	q	loss	FALSE	https://doi.org/10.1158/2159-8290.CD-14-0622
 Neuroblastoma	1	p	loss	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.1016/j.celrep.2024.114804; https://doi.org/10.1158/2159-8290.CD-14-0622
-Neuroblastoma	1	q	gain	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	1	q	gain	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	2	p	gain	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	3	p	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	4	p	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	6	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	7	q	gain	FALSE	https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	8	p	loss	FALSE	https://doi.org/10.18632/oncotarget.22495
-Neuroblastoma	11	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	11	q	loss	TRUE	https://doi.org/10.1038/nrdp.2016.78
 Neuroblastoma	12	q	gain	FALSE	https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	14	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	17	q	gain	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.1016/j.celrep.2024.114804; https://doi.org/10.1158/2159-8290.CD-14-0622

--- a/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
+++ b/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
@@ -1,19 +1,20 @@
-diagnosis	chromosome	arm	cnv_type	source
-Ewing sarcoma	1	q	gain	https://doi.org/10.1158/2159-8290.CD-14-0622; https://doi.org/10.1158/2159-8290.CD-13-1037
-Ewing sarcoma	8	NA	gain	https://doi.org/10.1158/2159-8290.CD-14-0622; https://doi.org/10.1158/2159-8290.CD-13-1037
-Ewing sarcoma	12	NA	gain	https://doi.org/10.1158/2159-8290.CD-14-0622
-Ewing sarcoma	16	q	loss	https://doi.org/10.1158/2159-8290.CD-14-0622
-Neuroblastoma	1	p	loss	https://doi.org/10.1038/nrdp.2016.78
-Neuroblastoma	1	q	gain	https://doi.org/10.1038/nrdp.2016.78
-Neuroblastoma	2	p	gain	https://doi.org/10.1038/nrdp.2016.78
-Neuroblastoma	3	p	loss	https://doi.org/10.1038/nrdp.2016.78
-Neuroblastoma	4	p	loss	https://doi.org/10.1038/nrdp.2016.78
-Neuroblastoma	6	q	gain	https://doi.org/10.18632/oncotarget.22495
-Neuroblastoma	7	q	gain	https://doi.org/10.18632/oncotarget.22495
-Neuroblastoma	8	p	loss	https://doi.org/10.18632/oncotarget.22495
-Neuroblastoma	11	q	loss	https://doi.org/10.1038/nrdp.2016.78
-Neuroblastoma	12	q	gain	https://doi.org/10.18632/oncotarget.22495
-Neuroblastoma	14	q	loss	https://doi.org/10.1038/nrdp.2016.78
-Neuroblastoma	17	q	gain	https://doi.org/10.1038/nrdp.2016.78
-Neuroblastoma	19	p	loss	https://doi.org/10.18632/oncotarget.22495
-Neuroblastoma	22	q	loss	https://doi.org/10.18632/oncotarget.22495
+diagnosis	chromosome	arm	cnv_type	common_cnv	source
+Ewing sarcoma	1	q	gain	FALSE	https://doi.org/10.1158/2159-8290.CD-14-0622; https://doi.org/10.1158/2159-8290.CD-13-1037
+Ewing sarcoma	8	NA	gain	TRUE	https://doi.org/10.1158/2159-8290.CD-14-0622; https://doi.org/10.1158/2159-8290.CD-13-1037
+Ewing sarcoma	12	NA	gain	FALSE	https://doi.org/10.1158/2159-8290.CD-14-0622
+Ewing sarcoma	16	q	loss	FALSE	https://doi.org/10.1158/2159-8290.CD-14-0622
+Neuroblastoma	1	p	loss	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.1016/j.celrep.2024.114804; https://doi.org/10.1158/2159-8290.CD-14-0622
+Neuroblastoma	1	q	gain	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	2	p	gain	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	3	p	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	4	p	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	6	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	7	q	gain	FALSE	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	8	p	loss	FALSE	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	11	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	12	q	gain	FALSE	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	14	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	17	q	gain	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.1016/j.celrep.2024.114804; https://doi.org/10.1158/2159-8290.CD-14-0622
+Neuroblastoma	19	p	loss	FALSE	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	19	q	loss	FALSE	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	22	q	loss	FALSE	https://doi.org/10.18632/oncotarget.22495

--- a/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
+++ b/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
@@ -13,7 +13,7 @@ Neuroblastoma	7	q	gain	FALSE	https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	8	p	loss	FALSE	https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	11	q	loss	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	12	q	gain	FALSE	https://doi.org/10.18632/oncotarget.22495
-Neuroblastoma	14	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	14	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78
 Neuroblastoma	17	q	gain	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.1016/j.celrep.2024.114804; https://doi.org/10.1158/2159-8290.CD-14-0622
 Neuroblastoma	19	p	loss	FALSE	https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	19	q	loss	FALSE	https://doi.org/10.18632/oncotarget.22495

--- a/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
+++ b/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
@@ -3,3 +3,17 @@ Ewing sarcoma	1	q	gain	https://doi.org/10.1158/2159-8290.CD-14-0622; https://doi
 Ewing sarcoma	8	NA	gain	https://doi.org/10.1158/2159-8290.CD-14-0622; https://doi.org/10.1158/2159-8290.CD-13-1037
 Ewing sarcoma	12	NA	gain	https://doi.org/10.1158/2159-8290.CD-14-0622
 Ewing sarcoma	16	q	loss	https://doi.org/10.1158/2159-8290.CD-14-0622
+Neuroblastoma	1	p	loss	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	1	q	gain	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	2	p	gain	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	3	p	loss	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	4	p	loss	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	6	q	gain	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	7	q	gain	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	8	p	loss	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	11	q	loss	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	12	q	gain	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	14	q	loss	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	17	q	gain	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	19	p	loss	https://doi.org/10.18632/oncotarget.22495
+Neuroblastoma	22	q	loss	https://doi.org/10.18632/oncotarget.22495

--- a/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
+++ b/analyses/infercnv-consensus-cell-type/references/cnv-validation.tsv
@@ -11,7 +11,7 @@ Neuroblastoma	4	p	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.o
 Neuroblastoma	6	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	7	q	gain	FALSE	https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	8	p	loss	FALSE	https://doi.org/10.18632/oncotarget.22495
-Neuroblastoma	11	q	loss	TRUE	https://doi.org/10.1038/nrdp.2016.78
+Neuroblastoma	11	q	loss	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	12	q	gain	FALSE	https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	14	q	loss	FALSE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.18632/oncotarget.22495
 Neuroblastoma	17	q	gain	TRUE	https://doi.org/10.1038/nrdp.2016.78; https://doi.org/10.1016/j.celrep.2024.114804; https://doi.org/10.1158/2159-8290.CD-14-0622


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Closes #1145


#### What is the goal of this pull request?

This PR updates `references/cnv-validation.tsv` with a bunch of CNVs in neuroblastoma. I drew from two main papers for this, and it's worth noting that some of these are "more canonical" than others. We could consider adding another column to record that type of metadata, we could also pare this down to just the higher-frequency CNVs, or we could just record it all as I've done here. Let me know if you have a preference! 

I _think_ I like the idea of adding another column called `notes` or so where we can include info like `more common` or `less common`? Thoughts?

