### PR TITLE
Add optparse to ETP module

### DIFF
--- a/analyses/cell-type-ETP-ALL-03/renv.lock
+++ b/analyses/cell-type-ETP-ALL-03/renv.lock
@@ -1401,6 +1401,16 @@
       ],
       "Hash": "b052bd270aeddeca332c20feecfb039d"
     },
+    "getopt": {
+      "Package": "getopt",
+      "Version": "1.20.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "stats"
+      ],
+      "Hash": "ed33b16c6d24f7ced1d68877ac2509ee"
+    },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.5.1",
@@ -2136,6 +2146,18 @@
       ],
       "Hash": "c62edf62de70cadf40553e10c739049d"
     },
+    "optparse": {
+      "Package": "optparse",
+      "Version": "1.7.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "getopt",
+        "methods"
+      ],
+      "Hash": "ce5f8381cd2c38d1fc14c83d8b21efd0"
+    },
     "parallelDist": {
       "Package": "parallelDist",
       "Version": "0.2.6",
@@ -2369,11 +2391,11 @@
       "Version": "0.1.0",
       "Source": "GitHub",
       "RemoteType": "github",
-      "RemoteHost": "api.github.com",
       "RemoteUsername": "AlexsLemonade",
       "RemoteRepo": "rOpenScPCA",
       "RemoteRef": "main",
       "RemoteSha": "f71a8191130fa543e6506c73c7b62ffa55e8ba3f",
+      "RemoteHost": "api.github.com",
       "Requirements": [
         "BiocParallel",
         "SingleCellExperiment",


### PR DESCRIPTION
Trying to once and for all stop copyKAT problems from coming up every month or two in #1202 by adding a testing flag for copyKAT runs, but I need to get optparse into the Docker container first! This PR just updates renv.lock so the updated Docker gets pushed so we can get testing in #1202.