### PR TITLE
Update NBAtlas anndata reference preparation

### DIFF
--- a/analyses/cell-type-neuroblastoma-04/run-analysis.sh
+++ b/analyses/cell-type-neuroblastoma-04/run-analysis.sh
@@ -142,6 +142,7 @@ echo "Preparing the NBAtlas reference..."
 # Define the NBAtlas Seurat and AnnData files
 nbatlas_sce="${ref_dir}/NBAtlas_sce.rds"
 nbatlas_anndata="${ref_dir}/NBAtlas_anndata.h5ad"
+nbatlas_hvg_file="${ref_dir}/NBAtlas_hvgs.txt"
 
 # First, download the NBAtlas Seurat objects from Mendeley with a helper function
 # This function takes two arguments in order, the URL and the filename to save to
@@ -168,6 +169,7 @@ if [ ! -f ${nbatlas_sce} ] || [ ! -f ${nbatlas_anndata} ] || [[ ${force_convert_
        --tumor_metadata_file "${nbatlas_tumor_metadata_file}" \
        --sce_file "${nbatlas_sce}" \
        --anndata_file "${nbatlas_anndata}" \
+       --nbatlas_hvg_file "${nbatlas_hvg_file}" \
        ${test_flag}
 fi
 

--- a/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R
+++ b/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R
@@ -110,6 +110,10 @@ if (!is.null(opts$sce_file)) {
 }
 
 if (!is.null(opts$anndata_file)) {
+  # We'll only need the counts matrix here
+  # remove logcounts to save space
+  logcounts(nbatlas_sce) <- NULL
+
   zellkonverter::writeH5AD(
     nbatlas_sce,
     opts$anndata_file,

--- a/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R
+++ b/analyses/cell-type-neuroblastoma-04/scripts/00_convert-nbatlas.R
@@ -109,13 +109,13 @@ colData(nbatlas_sce) <- colData(nbatlas_sce) |>
 
 
 # export reformatted NBAtlas objects if requested
-# if (!is.null(opts$sce_file)) {
-#   readr::write_rds(
-#     nbatlas_sce,
-#     opts$sce_file,
-#     compress = "gz"
-#   )
-# }
+if (!is.null(opts$sce_file)) {
+  readr::write_rds(
+    nbatlas_sce,
+    opts$sce_file,
+    compress = "gz"
+  )
+}
 
 if (!is.null(opts$anndata_file)) {
   # We can pare this object down substantially to save space:


### PR DESCRIPTION
### Purpose/implementation Section


#### Please link to the GitHub issue that this pull request addresses.

Closes #1229


#### What is the goal of this pull request?


The goal of this PR is to update the code that prepares the NBAtlas for improved downstream efficiency. Specifically, for AnnData export only, I remove object innards we won't need as well as identify and subset to the top 2000 HVGs. I do this because it's in fact [the first step of running scANVI/scArches](https://docs.scvi-tools.org/en/1.3.2/tutorials/notebooks/multimodal/scarches_scvi_tools.html#reference-mapping-with-scvi) - getting the object down to the top n HVGs and running the scvi methods on that subsetted object. (Note that the tutorial I link shows this code in the `SCVI` section, but it's relevant to `scANVI` since `scANVI` itself starts with `SCVI` model). Some more details on this:
- I chose to go with 2000, but there are no strict guidelines here so we could also make this an argument if we wanted to test this value. 2000 is just commonly used in tutorials and is a reasonable place to start!
- We could instead do this HVG selection in `scverse` after reading NBAtlas into python, but the NBAtlas anndata file is really (inefficiently) big since it would need both counts and logcounts, and also the `scverse` hvg function actually implements the Seurat approach under the hood. Therefore, I felt that performing this step in `scran` would be a reasonable choice to keep the module more efficient compute-wise, and consistent with `Bioconductor` methods when possible.
- The query object passed into `scANVI` [also gets subsetted to these genes](https://docs.scvi-tools.org/en/stable/api/reference/scvi.model.SCANVI.html#scvi.model.SCANVI.prepare_query_anndata) before getting integrated into the reference. I therefore also exported a text file of that HVG list so we can perform that query subsetting in the script that prepares the SCPCP000004 merged anndata object (#1228; recall, we are not using the existing `merged_rna.h5ad` file since we need to convert rowids to gene symbols using `rOpenScPCA`). This is the update to `run-analysis.sh`.
	- Note that `scANVI` gives a big ol' warning if fewer than 80% of genes in the reference are present in the query since that's not enough overlap! I looked into if we're in trouble here, and we're not! 98.75% of the NBAtlas hvg's are in our objects (1975/2000), so this enough overlap to be able to run the method :) 


### Provide directions for reviewers

#### What are the software and computational requirements needed to be able to run the code in this PR?

renv, runs on laptop

#### Are there particularly areas you'd like reviewers to have a close look at?

N/A


#### Is there anything that you want to discuss further?


N/A


### Author checklists

#### Analysis module and review

- [x] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [x] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [ ] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [x] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
