### PR TITLE
SingleR report: library size and PDX

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,6 +8,8 @@ regexes = [
     # skip base64 encoded images, which might have substrings that look like tokens
     '''(?i)<img src="data:image\/.+;base64,.+?".+\/>''',
     '''(?i)<img role="img" src="data:image\/.+;base64,.+?".+\/>''',
+    # skip certain html lines in Rmds
+    '''(?i)rnb-output-begin.+?''',
     # skip jQuery definition function
     '''^!function\(.+?jQuery'''
 ]

--- a/analyses/cell-type-neuroblastoma-04/exploratory-notebooks/singler-results.Rmd
+++ b/analyses/cell-type-neuroblastoma-04/exploratory-notebooks/singler-results.Rmd
@@ -632,7 +632,7 @@ The left-most gene set on the x-axis is `Neuroendocrine`, and normal cell types 
 This plot suggests that the normal cells `SingleR` is picking up are likely to be normal cells: normal gene expression for non-NE cells is higher compared to NE cells, and we see the opposite trend for the `Neuroendocrine` marker genes.
 
 
-## Inferences from libraries with lower cell counts
+## Inferences from smaller vs. larger libraries 
 
 In this section, we briefly look at annotation results for libraries with fewer than 1000 cells which may be lower quality than other libraries.
 
@@ -646,6 +646,27 @@ libraries_low_cells <- celltype_recoded_df |>
   dplyr::filter(total_cells < 1000) 
 libraries_low_cells
 ```
+
+### Distirbution of cell types
+
+
+```{r, fig.width = 10, fig.height = 4}
+celltype_recoded_wide_df |>
+  dplyr::mutate(
+    library_size = ifelse(library_id %in% libraries_low_cells$library_id, "<1000 cells", ">1000 cells")
+  ) |>
+  ggplot() + 
+  aes(x = library_id, fill = singler) + 
+  geom_bar(position = "fill") + 
+  scale_fill_manual(values = recoded_celltype_pal) + 
+  facet_wrap(vars(library_size), scales = "free_x") + 
+  scale_y_continuous(expand = c(0,0)) +
+  theme(
+    legend.position = "bottom",
+    axis.text.x = element_blank()
+  )
+```
+Although there are only four libraries with <1000 cells so it is challenging to make definitive conclusions, it does not seem like the overall cell type distributions are very different between smaller and larger libraries.
 
 ### Heatmap
 
@@ -666,25 +687,94 @@ Note that because this heatmap includes fewer libraries, there are fewer cell ty
 
 ### Percent of unclassified cells
 
-Next, we'll ask whether the percent of unclassified cells (aka, `unknown_singler`) is much higher in these libraries compared to larger libraries.
+Next, we'll ask whether the percent of unclassified cells (aka, `unknown_singler`) can be explained by library size.
+Below, we plot the relationship between total cells and fraction of cells that SingleR failed to confidently classify.
 
 ```{r}
 unknown_singler_df <- celltype_recoded_wide_df |>
   dplyr::group_by(library_id) |>
   dplyr::summarize(unknown_cells= sum(singler == "unknown_singler"))
 
-celltype_recoded_wide_df |>
+percent_unclassified_df <- celltype_recoded_wide_df |>
   dplyr::add_count(library_id, name = "total_cells") |>
   dplyr::inner_join(unknown_singler_df, by = "library_id") |>
   dplyr::select(library_id, total_cells, unknown_cells) |>
   dplyr::distinct() |>
-  dplyr::mutate(percent_singler_unclassified = round(unknown_cells/total_cells, 2)) |>
-  dplyr::arrange(total_cells)
+  dplyr::mutate(frac_singler_unclassified = unknown_cells/total_cells)
+
+ggplot(percent_unclassified_df) + 
+  aes(x = total_cells, y = frac_singler_unclassified) + 
+  geom_point() + 
+  geom_smooth(method = "lm")
 ```
 
+There doesn't appear to be a relationship here, and further the percent of unclassified cells are all under 7\% with most below around 4\%. 
 
-Most cells in the relatively smaller libraries are classified, and the percentage of unclassified cells (when non-0) is fully in line with the larger libraries.
+## Inferences from PDX libraries
 
+In this section, we briefly look at annotation results for libraries from PDX samples, which may show distinct trends.
+Here is the breakdown of the number of PDX vs tissue libraries: 
+
+```{r}
+# This was being developed while this bug was present, so we have to check the type first
+# https://github.com/AlexsLemonade/scpcaTools/issues/302
+pdx_class <- class(colData(merged_sce)$is_xenograft)
+if (pdx_class == "character") {
+  pdx_val <- "TRUE"
+} else {
+  pdx_val <- TRUE
+}
+
+pdx_libraries <- colData(merged_sce) |>
+  as.data.frame() |>
+  dplyr::filter(is_xenograft == pdx_val) |>
+  dplyr::pull(library_id) |>
+  unique()
+
+celltype_recoded_wide_df <- celltype_recoded_wide_df |>
+  dplyr::mutate(sample_type = ifelse(library_id %in% pdx_libraries, "pdx", "tissue"))
+
+celltype_recoded_wide_df |>
+  dplyr::select(library_id, sample_type) |>
+  dplyr::distinct() |>
+  dplyr::count(sample_type)
+```
+
+### Distribution of cell types
+
+We'll first look at the cell type distributions for each library between sample types:
+
+```{r, fig.width = 14, fig.height = 6}
+ggplot(celltype_recoded_wide_df) + 
+  aes(x = library_id, fill = singler) + 
+  geom_bar(position = "fill") + 
+  scale_fill_manual(values = recoded_celltype_pal) + 
+  facet_wrap(vars(sample_type), scales = "free_x") + 
+  scale_y_continuous(expand = c(0,0)) +
+  theme(
+    legend.position = "bottom",
+    axis.text.x = element_blank()
+  )
+```
+
+PDX samples have, not unexpectedly, much less cell type diversity overall with most cells being tumor or similar and immune cells rarely present.
+This is consistent with expectations in general for the biology of PDX's.
+
+
+### Heatmap
+
+This section shows a heatmap compaing SingleR annotations to consensus cell types, for PDX samples only.
+
+```{r, fig.width = 8, fig.height = 8}
+make_jaccard_heatmap(
+  celltype_recoded_wide_df |> dplyr::filter(sample_type == "pdx"),
+  "consensus_validation",
+  "singler",
+  "Consensus validation label",
+  "SingleR NBAtlas label"
+)
+```
+This heatmap comparison seems reasonable, again taking into consideration that there are relatively fewer cell types in the PDX samples, and corresponding cell types tend to match up.
 
 
 

--- a/analyses/cell-type-neuroblastoma-04/exploratory-notebooks/singler-results.Rmd
+++ b/analyses/cell-type-neuroblastoma-04/exploratory-notebooks/singler-results.Rmd
@@ -265,8 +265,6 @@ celltype_recoded_wide_df <- celltype_recoded_df |>
     values_from = label_recoded
   )
 
-heatmap_col_fun <- circlize::colorRamp2(c(0, 1), colors = c("white", "darkslateblue"))
-
 make_jaccard_heatmap(
   celltype_recoded_wide_df,
   "consensus_validation",
@@ -632,6 +630,63 @@ ggplot(compare_annotations_expr_df) +
 ```
 The left-most gene set on the x-axis is `Neuroendocrine`, and normal cell types follow.
 This plot suggests that the normal cells `SingleR` is picking up are likely to be normal cells: normal gene expression for non-NE cells is higher compared to NE cells, and we see the opposite trend for the `Neuroendocrine` marker genes.
+
+
+## Inferences from libraries with lower cell counts
+
+In this section, we briefly look at annotation results for libraries with fewer than 1000 cells which may be lower quality than other libraries.
+
+Those libraries are:
+
+```{r}
+libraries_low_cells <- celltype_recoded_df |>
+  dplyr::filter(annotation_type == "singler") |>
+  dplyr::select(-annotation_type) |>
+  dplyr::count(library_id, name = "total_cells") |>
+  dplyr::filter(total_cells < 1000) 
+libraries_low_cells
+```
+
+### Heatmap
+
+This section shows a heatmap comparing annotations from these libraries only to the consensus annotations.
+
+```{r, fig.width = 8, fig.height = 8}
+make_jaccard_heatmap(
+  celltype_recoded_wide_df |> dplyr::filter(library_id %in% libraries_low_cells$library_id),
+  "consensus_validation",
+  "singler",
+  "Consensus validation label",
+  "SingleR NBAtlas label"
+)
+```
+
+The heatmap comparison to consensus cell types for these libraries looks reasonable; corresponding cell types tend to match up.
+Note that because this heatmap includes fewer libraries, there are fewer cell types to display overall.
+
+### Percent of unclassified cells
+
+Next, we'll ask whether the percent of unclassified cells (aka, `unknown_singler`) is much higher in these libraries compared to larger libraries.
+
+```{r}
+unknown_singler_df <- celltype_recoded_wide_df |>
+  dplyr::group_by(library_id) |>
+  dplyr::summarize(unknown_cells= sum(singler == "unknown_singler"))
+
+celltype_recoded_wide_df |>
+  dplyr::add_count(library_id, name = "total_cells") |>
+  dplyr::inner_join(unknown_singler_df, by = "library_id") |>
+  dplyr::select(library_id, total_cells, unknown_cells) |>
+  dplyr::distinct() |>
+  dplyr::mutate(percent_singler_unclassified = round(unknown_cells/total_cells, 2)) |>
+  dplyr::arrange(total_cells)
+```
+
+
+Most cells in the relatively smaller libraries are classified, and the percentage of unclassified cells (when non-0) is fully in line with the larger libraries.
+
+
+
 
 ## Session Info
 

--- a/analyses/cell-type-neuroblastoma-04/exploratory-notebooks/singler-results.Rmd
+++ b/analyses/cell-type-neuroblastoma-04/exploratory-notebooks/singler-results.Rmd
@@ -673,8 +673,11 @@ Although there are only four libraries with <1000 cells so it is challenging to 
 This section shows a heatmap comparing annotations from these libraries only to the consensus annotations.
 
 ```{r, fig.width = 8, fig.height = 8}
+low_cells_df <- celltype_recoded_wide_df |> 
+  dplyr::filter(library_id %in% libraries_low_cells$library_id)
+
 make_jaccard_heatmap(
-  celltype_recoded_wide_df |> dplyr::filter(library_id %in% libraries_low_cells$library_id),
+  low_cells_df,
   "consensus_validation",
   "singler",
   "Consensus validation label",

--- a/analyses/cell-type-neuroblastoma-04/exploratory-notebooks/singler-results.Rmd
+++ b/analyses/cell-type-neuroblastoma-04/exploratory-notebooks/singler-results.Rmd
@@ -120,15 +120,28 @@ merged_sce <- readRDS(sce_file)
 # immediately remove assays we don't need for space
 assay(merged_sce, "spliced") <- NULL
 assay(merged_sce, "counts") <- NULL
+reducedDim(merged_sce, "PCA") <- NULL
 
-# Ensure cell_id is correct
-merged_sce$cell_id <- colnames(merged_sce)
+# Define libraries to remove
+# See: https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/1234#issuecomment-3113966395
+remove_libraries <- c("SCPCL000124", "SCPCL001058")
+keep_cells <- grep(
+  paste(remove_libraries, collapse="|"), 
+  colnames(merged_sce), 
+  invert = TRUE,
+  value = TRUE
+)
+
+merged_sce <- merged_sce[, keep_cells]
+rm(keep_cells)
 ```
 
 Read cell type data frames:
 
 ```{r}
 singler_df <- singler_files |>
+  # remove libraries
+  purrr::discard_at(remove_libraries) |>
   purrr::map(readr::read_tsv) |>
   purrr::list_rbind(names_to = "library_id") |>
   dplyr::select(-delta.next, -labels) |>


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Closes #1234

#### What is the goal of this pull request?

The goal of this PR is to see if library quality/size strongly influenced cell type annotations with SingleR for the neuroblastoma samples. I ended up also adding a section of similar scope to look at PDX vs tissue samples to see if there were any differences there.

#### Briefly describe the general approach you took to achieve this goal.

- First, I removed two _super bad_ libraries from the notebook altogether (see issue comment). These are so rough in the QCs that I don't think it's worth even looking at their annotations. We should definitely remove these from scANVI.
- Then, I added 2 sections at the bottom to look into each of library size and PDX vs tissue, with things like:
  - barplots of proportion of cell types in each library. Probably should have had this from the beginning, and now we have it!
  - heatmaps comparing to consensus
  - a check at the relationship between library size and % unclassified cells

Overall, the smaller libraries (>100, <1000) seem to have reasonable inferences, so I'm not worried about keeping them in the mix for analysis moving forward. The PDXs as well have limited cell type diversity which is not expected, but their annotations seem reasonable too! I ended up not adding in any additional dot plots since it didn't seem like they were needed given the results of the comparisons I did, but let me know if you think we'd benefit from it! I could also, as always, add more UMAPs....

Here is the updated report:
[singler-results.nb.html.zip](https://github.com/user-attachments/files/21416943/singler-results.nb.html.zip)




### Provide directions for reviewers

#### What are the software and computational requirements needed to be able to run the code in this PR?

renv; no changes

#### Are there particularly areas you'd like reviewers to have a close look at?

N/A

#### Is there anything that you want to discuss further?

N/A




### Author checklists


#### Analysis module and review

- [x] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [ ] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [ ] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [ ] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
