### PR TITLE
Try to fix Ewing error 

### DIFF
--- a/analyses/cell-type-ewings/scripts/auc-singler-workflow/01-run-aucell.R
+++ b/analyses/cell-type-ewings/scripts/auc-singler-workflow/01-run-aucell.R
@@ -47,6 +47,12 @@ option_list <- list(
     type = "integer",
     default = 1,
     help = "Number of multiprocessing threads to use."
+  ),
+  make_option(
+    opt_str = c("--seed"),
+    type = "integer",
+    default = 2024,
+    help = "A random seed for reproducibility."
   )
 )
 
@@ -54,6 +60,9 @@ option_list <- list(
 opt <- parse_args(OptionParser(option_list = option_list))
 
 # Set up -----------------------------------------------------------------------
+
+# set seed
+set.seed(opt$seed)
 
 # make sure input files exist
 stopifnot(

--- a/analyses/cell-type-ewings/template_notebooks/auc-singler-workflow/02-singler-results.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/auc-singler-workflow/02-singler-results.Rmd
@@ -172,11 +172,11 @@ caret_df <- classification_df |>
 
 # get the cell types in both
 # these should be tumor normal but sometimes that's not the case
-singler_cell_types <- unique(caret_df$singler_tumor_normal) |> as.character() |> sort()
-aucell_cell_types <- unique(caret_df$aucell_annotation) |> as.character() |> sort()
+singler_cell_types <- unique(caret_df$singler_tumor_normal) |> as.character()
+aucell_cell_types <- unique(caret_df$aucell_annotation) |> as.character()
 
 # only calculate confusion matrix if all cell types are the same
-if (all(singler_cell_types == aucell_cell_types) & length(singler_cell_types) > 1) {
+if (setequal(singler_cell_types, aucell_cell_types) & length(singler_cell_types) > 1) {
   caret::confusionMatrix(
     table(
       caret_df$aucell_annotation,

--- a/analyses/cell-type-ewings/template_notebooks/auc-singler-workflow/02-singler-results.Rmd
+++ b/analyses/cell-type-ewings/template_notebooks/auc-singler-workflow/02-singler-results.Rmd
@@ -172,11 +172,11 @@ caret_df <- classification_df |>
 
 # get the cell types in both
 # these should be tumor normal but sometimes that's not the case
-singler_cell_types <- unique(caret_df$singler_tumor_normal) |> as.character()
-aucell_cell_types <- unique(caret_df$aucell_annotation) |> as.character()
+singler_cell_types <- unique(caret_df$singler_tumor_normal) |> as.character() |> sort()
+aucell_cell_types <- unique(caret_df$aucell_annotation) |> as.character() |> sort()
 
 # only calculate confusion matrix if all cell types are the same
-if (all(singler_cell_types == aucell_cell_types)) {
+if (all(singler_cell_types == aucell_cell_types) & length(singler_cell_types) > 1) {
   caret::confusionMatrix(
     table(
       caret_df$aucell_annotation,


### PR DESCRIPTION
Right now just testing to see if the Ewing error is resolved. 

**Edited:**

I looked into the error that we were seeing and I have not been able to reproduce it locally (see https://github.com/AlexsLemonade/OpenScPCA-analysis/actions/runs/16268047910/job/45928302549). It seems we were trying to create a confusion matrix with just one annotation level, either all tumor or all normal, in one of the reports. Or at least I think that's why it was complaining. I added a check to make sure there's at least 2 classifications before making the matrix to that report. 

I think part of the issue is that we weren't setting a seed when running `AUCell`. This means any of the 0 genes were probably getting randomly ordered differently and maybe affecting the classifications, resulting in either all tumor or all normal cells? This is the only thing I could think of as to why it works most of the time but occasionally runs into an issue when making the classification matrix. I added a seed so hopefully we don't see it pop up in the future. 

It looks like we've passed the area that we were seeing an error before so I'm going to mark this ready for review. 

