### PR TITLE
Add git into (non)-ETP docker

### DIFF
--- a/analyses/cell-type-ETP-ALL-03/Dockerfile
+++ b/analyses/cell-type-ETP-ALL-03/Dockerfile
@@ -35,6 +35,13 @@ RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
 RUN conda install --channel=conda-forge --name=base conda-lock \
   && conda clean --all --yes
 
+# Install git
+RUN apt-get -y update &&  \
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends -y \
+  git \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install renv
 RUN Rscript -e "install.packages('renv')"
 

--- a/analyses/cell-type-nonETP-ALL-03/Dockerfile
+++ b/analyses/cell-type-nonETP-ALL-03/Dockerfile
@@ -36,6 +36,13 @@ RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
 RUN conda install --channel=conda-forge --name=base conda-lock \
   && conda clean --all --yes
 
+# Install git
+RUN apt-get -y update &&  \
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends -y \
+  git \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install renv
 RUN Rscript -e "install.packages('renv')"
 


### PR DESCRIPTION
In #1238, I implement CI fixes for the (non-)ETP modules!

One aspect of that was updating paths because can't use `git` in Docker, but Josh reasonably pointed out: leave the paths alone and just...install `git` into the container: https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/1238#discussion_r2237030733

This PR just updates these modules' Docker images to get git in there. Note that the modules still have potential to stochastically fail CI at this point, so as long as Docker still builds, it's fine for this PR.