### PR TITLE
Fix cell-type-wilms-tumor-06: Use the ubuntu 22.04 runner

### DIFF
--- a/.github/workflows/run_cell-type-wilms-tumor-06.yml
+++ b/.github/workflows/run_cell-type-wilms-tumor-06.yml
@@ -56,7 +56,7 @@ jobs:
           # - they are the subset of samples explored when evaluating CNV methods, so they must be present to run the module workflow in full if that is ever specified
           # - they do not use a reference with inferCNV so we would like to test that they are properly handled
           # - they have been known to cause CI failures in edge cases
-          DOWNLOAD_FLAG: ${{ github.event_name != 'pull_request' && '--projects SCPCP000006' || '--samples SCPCS000199' }}
+          DOWNLOAD_FLAG: ${{ github.event_name != 'pull_request' && '--projects SCPCP000006' || '--samples SCPCS000199,SCPCS000173,SCPCS000179,SCPCS000184,SCPCS000194,SCPCS000205,SCPCS000208,SCPCS000177,SCPCS000190' }}
         run: |
           ./download-data.py --test-data --format SCE ${DOWNLOAD_FLAG}
           ./download-data.py --test-data --metadata-only --projects SCPCP000006


### PR DESCRIPTION
The `cell-type-wilms-tumor-06` module is failing in CI with a new `inferCNV` error we have not seen before with this project (#1249). Here I'm seeing if it passes CI on the `ubuntu 22.04` runner instead of the recently-updated latest runner on which it's failing for sample `SCPCS000199`.