### PR TITLE
Add diagnosis map TSV

### DIFF
--- a/analyses/infercnv-consensus-cell-type/references/broad-diagnosis-map.tsv
+++ b/analyses/infercnv-consensus-cell-type/references/broad-diagnosis-map.tsv
@@ -1,0 +1,56 @@
+ontology_id	human_readable_value	submitted_diagnosis	diagnosis_group
+MONDO:0016684	Anaplastic astrocytoma	Anaplastic astrocytoma	Brain and CNS
+MONDO:0016700	Anaplastic ependymoma	Anaplastic ependymoma	Brain and CNS
+MONDO:0016734	Anaplastic ganglioglioma	Anaplastic ganglioglioma	Brain and CNS
+MONDO:0021640	Grade III glioma	Anaplastic glioma	Brain and CNS
+MONDO:0020560	Atypical teratoid rhabdoid tumor	Atypical teratoid rhabdoid tumor	Brain and CNS
+MONDO:0022965	Desmoplastic infantile ganglioglioma	Desmoplastic ganglioglioma	Brain and CNS
+MONDO:0005499	Brain glioma	Diffuse midline glioma	Brain and CNS
+MONDO:0005505	Dysembryoplastic neuroepithelial tumor	Dysembryoplastic neuroepithelial tumor	Brain and CNS
+MONDO:0019002	Lhermitte-Duclos disease	Dysplastic gangliocytoma	Brain and CNS
+MONDO:0016698	Ependymoma	Ependymoma	Brain and CNS
+MONDO:0019009	Isolated focal cortical dysplasia	Focal cortical dysplasia	Brain and CNS
+MONDO:0016733	Ganglioglioma	Ganglioglioma	Brain and CNS
+MONDO:0021193	Neuroepithelial neoplasm	Ganglioglioma/ATRT	Brain and CNS
+MONDO:0016729	Mixed neuronal-glial tumor	Glial-neuronal tumor	Brain and CNS
+MONDO:0018177	Glioblastoma	Glioblastoma	Brain and CNS
+MONDO:0100342	Malignant glioma	High-grade glioma	Brain and CNS
+MONDO:0858940	Infant-type hemispheric glioma	Infant-type hemispheric glioma	Brain and CNS
+MONDO:0021637	Low grade glioma	Low-grade glioma	Brain and CNS
+MONDO:0007959	Medulloblastoma	Medulloblastoma	Brain and CNS
+MONDO:0016699	Myxopapillary ependymoma	Myxopapillary ependymoma	Brain and CNS
+MONDO:0016691	Pilocytic astrocyoma	Pilocytic astrocytoma	Brain and CNS
+MONDO:0016692	Pilomyxoid astrocytoma	Pilomyxoid astrocytoma	Brain and CNS
+MONDO:0016690	Pleomorphic xanthoastrocytoma	Pleomorphic xanthoastrocytoma	Brain and CNS
+MONDO:0000640	Central nervous system primitive neuroectodermal neoplasm	Primitive neuroectodermal tumor	Brain and CNS
+MONDO:0008380	Retinoblastoma	Retinoblastoma	Brain and CNS
+MONDO:0002546	Schwannoma	Schwannoma	Brain and CNS
+MONDO:0007667	Subependymoma	Subependymoma	Brain and CNS
+MONDO:0018874	Acute myeloid leukemia	Acute myeloid leukemia	AML
+MONDO:0004947	B-cell acute lymphoblastic leukemia	B-cell acute lymphoblastic leukemia	B-cell leukemia
+MONDO:0100291	Early T-cell progenitor acute lymphoblastic leukemia	Early T-cell precursor T-cell acute lymphoblastic leukemia	T-cell leukemia
+MONDO:0020743	Mixed phenotype acute leukemia	Mixed phenotype acute leukemia	Mixed-type leukemia
+MONDO:0004963	T-cell acute lymphoblastic leukemia	Non-early T-cell precursor T-cell acute lymphoblastic leukemia	T-cell leukemia
+MONDO:0004963	T-cell acute lymphoblastic leukemia	T-cell acute lymphoblastic leukemia	T-cell leukemia
+MONDO:0020743	Mixed phenotype acute leukemia	T-myeloid mixed phenotype acute leukemia	Mixed-type leukemia
+MONDO:0006639	Adrenal cortex carcinoma	Adrenocortical carcinoma	Other solid tumors
+MONDO:0011719	Gastrointestinal stromal tumor	Gastrointestinal stromal tumor	Other solid tumors
+MONDO:0005040	Germ cell tumor	Germ cell tumor	Other solid tumors
+MONDO:0018666	Hepatoblastoma	Hepatoblastoma	Other solid tumors
+MONDO:0005105	Melanoma	Melanoma	Other solid tumors
+MONDO:0002728	Rhabdoid tumor	Rhabdoid tumor	Other solid tumors
+MONDO:0006058	Wilms tumor	Wilms tumor	Other solid tumors
+MONDO:0005072	Neuroblastoma	Neuroblastoma	Other solid tumors
+MONDO:0002926	Clear cell sarcoma	Clear cell sarcoma	Sarcoma
+MONDO:0005006	Clear cell sarcoma of the kidney	Clear cell sarcoma of the kidney	Sarcoma
+MONDO:0019373	Desmoplastic small round cell tumor	Desmoplastic small round cell tumor	Sarcoma
+MONDO:0015795	Undifferentiated embryonal sarcoma of the liver	Embryonal sarcoma	Sarcoma
+MONDO:0017387	Epithelioid sarcoma	Epithelioid sarcoma	Sarcoma
+MONDO:0012817	Ewing sarcoma	Ewing sarcoma	Sarcoma
+MONDO:0005089	sarcoma	High-grade sarcoma	Sarcoma
+MONDO:0004557	Congenital fibrosarcoma	Infantile fibrosarcoma	Sarcoma
+MONDO:0009807	Osteosarcoma	Osteosarcoma	Sarcoma
+MONDO:0005212	Rhabdomyosarcoma	Rhabdomyosarcoma	Sarcoma
+MONDO:0002927	Spindle cell sarcoma	Spindle sarcoma	Sarcoma
+MONDO:0010434	Synovial sarcoma	Synovial sarcoma	Sarcoma
+MONDO:0020661	Undifferentiated round cell sarcoma	Undifferentiated round cell sarcoma	Sarcoma

--- a/analyses/infercnv-consensus-cell-type/references/broad-diagnosis-map.tsv
+++ b/analyses/infercnv-consensus-cell-type/references/broad-diagnosis-map.tsv
@@ -1,4 +1,5 @@
 ontology_id	human_readable_value	submitted_diagnosis	diagnosis_group
+MONDO:0006639	Adrenal cortex carcinoma	Adrenocortical carcinoma	Adrenal cortex carcinoma
 MONDO:0016684	Anaplastic astrocytoma	Anaplastic astrocytoma	Brain and CNS
 MONDO:0016700	Anaplastic ependymoma	Anaplastic ependymoma	Brain and CNS
 MONDO:0016734	Anaplastic ganglioglioma	Anaplastic ganglioglioma	Brain and CNS
@@ -26,21 +27,12 @@ MONDO:0000640	Central nervous system primitive neuroectodermal neoplasm	Primitiv
 MONDO:0008380	Retinoblastoma	Retinoblastoma	Brain and CNS
 MONDO:0002546	Schwannoma	Schwannoma	Brain and CNS
 MONDO:0007667	Subependymoma	Subependymoma	Brain and CNS
-MONDO:0018874	Acute myeloid leukemia	Acute myeloid leukemia	AML
-MONDO:0004947	B-cell acute lymphoblastic leukemia	B-cell acute lymphoblastic leukemia	B-cell leukemia
-MONDO:0100291	Early T-cell progenitor acute lymphoblastic leukemia	Early T-cell precursor T-cell acute lymphoblastic leukemia	T-cell leukemia
-MONDO:0020743	Mixed phenotype acute leukemia	Mixed phenotype acute leukemia	Mixed-type leukemia
-MONDO:0004963	T-cell acute lymphoblastic leukemia	Non-early T-cell precursor T-cell acute lymphoblastic leukemia	T-cell leukemia
-MONDO:0004963	T-cell acute lymphoblastic leukemia	T-cell acute lymphoblastic leukemia	T-cell leukemia
-MONDO:0020743	Mixed phenotype acute leukemia	T-myeloid mixed phenotype acute leukemia	Mixed-type leukemia
-MONDO:0006639	Adrenal cortex carcinoma	Adrenocortical carcinoma	Other solid tumors
-MONDO:0011719	Gastrointestinal stromal tumor	Gastrointestinal stromal tumor	Other solid tumors
-MONDO:0005040	Germ cell tumor	Germ cell tumor	Other solid tumors
-MONDO:0018666	Hepatoblastoma	Hepatoblastoma	Other solid tumors
-MONDO:0005105	Melanoma	Melanoma	Other solid tumors
-MONDO:0002728	Rhabdoid tumor	Rhabdoid tumor	Other solid tumors
-MONDO:0006058	Wilms tumor	Wilms tumor	Other solid tumors
-MONDO:0005072	Neuroblastoma	Neuroblastoma	Other solid tumors
+MONDO:0011719	Gastrointestinal stromal tumor	Gastrointestinal stromal tumor	Gastrointestinal stromal tumor
+MONDO:0005040	Germ cell tumor	Germ cell tumor	Germ cell tumor
+MONDO:0018666	Hepatoblastoma	Hepatoblastoma	Hepatoblastoma
+MONDO:0005105	Melanoma	Melanoma	Melanoma
+MONDO:0005072	Neuroblastoma	Neuroblastoma	Neuroblastoma
+MONDO:0002728	Rhabdoid tumor	Rhabdoid tumor	Rhabdoid tumor
 MONDO:0002926	Clear cell sarcoma	Clear cell sarcoma	Sarcoma
 MONDO:0005006	Clear cell sarcoma of the kidney	Clear cell sarcoma of the kidney	Sarcoma
 MONDO:0019373	Desmoplastic small round cell tumor	Desmoplastic small round cell tumor	Sarcoma
@@ -54,3 +46,11 @@ MONDO:0005212	Rhabdomyosarcoma	Rhabdomyosarcoma	Sarcoma
 MONDO:0002927	Spindle cell sarcoma	Spindle sarcoma	Sarcoma
 MONDO:0010434	Synovial sarcoma	Synovial sarcoma	Sarcoma
 MONDO:0020661	Undifferentiated round cell sarcoma	Undifferentiated round cell sarcoma	Sarcoma
+MONDO:0006058	Wilms tumor	Wilms tumor	Wilms tumor
+MONDO:0004947	B-cell acute lymphoblastic leukemia	B-cell acute lymphoblastic leukemia	B-cell leukemia
+MONDO:0020743	Mixed phenotype acute leukemia	Mixed phenotype acute leukemia	Mixed-type leukemia
+MONDO:0020743	Mixed phenotype acute leukemia	T-myeloid mixed phenotype acute leukemia	Mixed-type leukemia
+MONDO:0018874	Acute myeloid leukemia	Acute myeloid leukemia	Myeloid leukemia
+MONDO:0100291	Early T-cell progenitor acute lymphoblastic leukemia	Early T-cell precursor T-cell acute lymphoblastic leukemia	T-cell leukemia
+MONDO:0004963	T-cell acute lymphoblastic leukemia	Non-early T-cell precursor T-cell acute lymphoblastic leukemia	T-cell leukemia
+MONDO:0004963	T-cell acute lymphoblastic leukemia	T-cell acute lymphoblastic leukemia	T-cell leukemia

--- a/analyses/infercnv-consensus-cell-type/scripts/README.md
+++ b/analyses/infercnv-consensus-cell-type/scripts/README.md
@@ -1,5 +1,6 @@
 This directory contains scripts used in the analysis.
 
+* `prepare-diagnosis-map.R` is manually run to prepare the TSV file mapping broad diagnosis groups to specific ScPCA diagnoses
 * `00-make-gene-order-file.R` prepares the input gene order file needed for `inferCNV`
 * `01_run-infercnv.R` runs `inferCNV` on a given ScPCA library using a specified normal reference
   * The normal reference can either be "pooled" (created from combining cells across project libraries) or "internal" (created from cells in the given library only)

--- a/analyses/infercnv-consensus-cell-type/scripts/prepare-diagnosis-map.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/prepare-diagnosis-map.R
@@ -1,0 +1,25 @@
+#!/usr/bin/env Rscript
+
+# This script was manually run to create the file `../references/broad-diagnosis-map.tsv`
+# This script maps broad diagnosis categories to individual diagnoses in ScPCA that we plan to run inferCNV on
+
+# Read diagnosis map -----------
+diagnosis_grouping_url <- "https://raw.githubusercontent.com/AlexsLemonade/scpca-paper-figures/refs/heads/main/sample-info/diagnosis-groupings.tsv"
+diagnosis_map <- readr::read_tsv(diagnosis_grouping_url)
+
+# Prepare diagnosis map ---------
+updated_diagnosis_map <- diagnosis_map |>
+  # remove non-cancer
+  dplyr::filter(ontology_id != "PATO:0000461") |>
+  # split up leukemias based on cell types
+  dplyr::mutate(
+    diagnosis_group = dplyr::case_when(
+      diagnosis_group == "Leukemia" & stringr::str_detect(human_readable_value, "T-cell") ~ "T-cell leukemia",
+      diagnosis_group == "Leukemia" & stringr::str_detect(human_readable_value, "B-cell") ~ "B-cell leukemia",
+      diagnosis_group == "Leukemia" & stringr::str_detect(human_readable_value, "myeloid") ~ "AML",
+      diagnosis_group == "Leukemia" & stringr::str_detect(human_readable_value, "Mixed") ~ "Mixed-type leukemia",
+      .default = diagnosis_group
+    )) 
+
+# Export diagnosis map ------------
+readr::write_tsv(updated_diagnosis_map, "../references/broad-diagnosis-map.tsv")

--- a/analyses/infercnv-consensus-cell-type/scripts/prepare-diagnosis-map.R
+++ b/analyses/infercnv-consensus-cell-type/scripts/prepare-diagnosis-map.R
@@ -11,15 +11,22 @@ diagnosis_map <- readr::read_tsv(diagnosis_grouping_url)
 updated_diagnosis_map <- diagnosis_map |>
   # remove non-cancer
   dplyr::filter(ontology_id != "PATO:0000461") |>
-  # split up leukemias based on cell types
+  # split up leukemias based on cell types in their ontology name
+  # set the "Other solid tumors" to have their ontology diagnosis be the group
   dplyr::mutate(
     diagnosis_group = dplyr::case_when(
       diagnosis_group == "Leukemia" & stringr::str_detect(human_readable_value, "T-cell") ~ "T-cell leukemia",
       diagnosis_group == "Leukemia" & stringr::str_detect(human_readable_value, "B-cell") ~ "B-cell leukemia",
-      diagnosis_group == "Leukemia" & stringr::str_detect(human_readable_value, "myeloid") ~ "AML",
+      diagnosis_group == "Leukemia" & stringr::str_detect(human_readable_value, "myeloid") ~ "Myeloid leukemia",
       diagnosis_group == "Leukemia" & stringr::str_detect(human_readable_value, "Mixed") ~ "Mixed-type leukemia",
+      diagnosis_group == "Other solid tumors" ~ human_readable_value,
       .default = diagnosis_group
-    )) 
+    )) |>
+  dplyr::arrange(diagnosis_group) |>
+  # but keep leukemias together
+  dplyr::arrange(stringr::str_detect(diagnosis_group, "leukemia"))
+  
+  
 
 # Export diagnosis map ------------
 readr::write_tsv(updated_diagnosis_map, "../references/broad-diagnosis-map.tsv")


### PR DESCRIPTION
As discussed in review for #1284, this PR takes a quick detour to add a TSV mapping broad diagnosis groups to individual diagnoses in ScPCA. 

I used the map we have currently in the `scpca-paper-figures` repo, and make a new TSV from it where:
- I removed non-cancerous
- leukemias have been broken down by cell type
- the "other solid tumor" group is gone and replaced with the ontology diagnosis
- noting i didn't remove any columns, they all seem maybe useful and it's a small file!

For all of this, I used the `human_readable_value` to recode categories. Please let me know if you prefer I use actual ontology ids to parse the leukemias instead of using string matching based on `human_readable_value`. For that, I'd need to make some separate vectors with the ontologies grouped already and use those in the case_when.

I manually ran this script to add the TSV. I did add the script docs, but I will wait to add `references/README.md` docs for this file until #1284 since conflicts. 