### PR TITLE
Make sure conda environment has the correct name

### DIFF
--- a/analyses/cell-type-scimilarity/Dockerfile
+++ b/analyses/cell-type-scimilarity/Dockerfile
@@ -14,7 +14,7 @@ ENV OPENSCPCA_DOCKER=TRUE
 # Disable the renv cache to install packages directly into the R library
 ENV RENV_CONFIG_CACHE_ENABLED=FALSE
 # set a name for the conda environment
-ARG ENV_NAME=openscpca-cell-type-scmilarity
+ARG ENV_NAME=openscpca-cell-type-scimilarity
 
 # set environment variables to install conda
 ENV PATH="/opt/conda/bin:${PATH}"


### PR DESCRIPTION
This is a small PR to fix the spelling of `scimilarity` in the environment name within the docker image. 