### PR TITLE
Make sure conda environment is used by default in SCimilarity image

### DIFF
--- a/analyses/cell-type-scimilarity/Dockerfile
+++ b/analyses/cell-type-scimilarity/Dockerfile
@@ -56,6 +56,8 @@ RUN conda-lock install -n ${ENV_NAME} conda-lock.yml \
 
 # Activate conda environment on bash launch
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
+# add to path to ensure its used by default (helpful for running python in nextflow)
+ENV PATH="/opt/conda/envs/${ENV_NAME}/bin:${PATH}"
 
 # Copy the renv.lock file from the host environment to the image
 COPY renv.lock renv.lock


### PR DESCRIPTION
This is a fix to hopefully help with the issues I'm seeing in https://github.com/AlexsLemonade/OpenScPCA-nf/pull/175 where the scripts are being run in the image container without using the conda environment when running in Nextflow. This adds the path to the conda environment to `PATH` and tells the image to use the conda environment by default, even when not running interactively. 

I built the image locally and did a test run with `OpenScPCA-nf` where I just printed out the Python version and made sure it could load the `anndata` module and it works so I think this should be good 🤞 