### PR TITLE
Add conda env to path in NB-04 image

### DIFF
--- a/analyses/cell-type-neuroblastoma-04/Dockerfile
+++ b/analyses/cell-type-neuroblastoma-04/Dockerfile
@@ -61,6 +61,9 @@ RUN conda-lock install -n ${ENV_NAME} conda-lock.yml \
 # Activate conda environment on bash launch
 RUN echo "conda activate ${ENV_NAME}" >> ~/.bashrc
 
+# add to path to ensure its used by default (helpful for running python in nextflow)
+ENV PATH="/opt/conda/envs/${ENV_NAME}/bin:${PATH}"
+
 ### Setup the R environment ###
 
 # Install renv to enable later package installation


### PR DESCRIPTION
This PR is my version of https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/1311 for the `cell-type-neuroblastoma-04` module, after getting the error below when testing. 

```
Command error:
  2:44PM INF instance metadata ami-id=ami-0ed843a06c28c7dfe instance-id=i-07b06054a1e7cd7d0 instance-type=m6a.4xlarge
  Traceback (most recent call last):
    File "/usr/bin/train-scanvi-model.py", line 11, in <module>
      import anndata
  ModuleNotFoundError: No module named 'anndata'
```