### PR TITLE
Account for new consensus cell types in the validation groups

### DIFF
--- a/analyses/cell-type-consensus/README.md
+++ b/analyses/cell-type-consensus/README.md
@@ -21,7 +21,7 @@ We used the following criteria to assign a consensus cell type for each possible
 - If the LCA has greater than 170 descendants, no consensus label is set, with some exceptions: 
   - When the LCA is `neuron`, `neuron` is used as the consensus label. 
   - When the LCA is `epithelial cell`, `columnar/cuboidal epithelial cell` or `endo-epithelial cell` and the annotation from `BlueprintEncodeData` is `Epithelial cells`, then the LCA is used as the consensus label. 
-  - If the LCA is `bone cell`, `lining cell`, `blood cell`, `progenitor cell`, `supporting cell`, `biogenic amine secreting cell`, `protein secreting cell`, or `extracellular matrix secreting cell` no consensus label is defined. 
+  - If the LCA is `bone cell`, `lining cell`, `blood cell`, `progenitor cell`, `supporting cell`, `biogenic amine secreting cell`, `protein secreting cell`, `extracellular matrix secreting cell`, `serotonin secreting cell`, `peptide hormone secreting cell`, `exocrine cell`, `sensory receptor cell`, or `interstitial cell` no consensus label is defined. 
 - If the terms share more than 1 LCA, then the LCA with the fewest descendants is kept and all others are discarded. 
 
 The final consensus cell type between `SingleR`, `CellAssign`, and `SCimilarity` is assigned if 2 out of 3 methods have an LCA that meets the above criteria. 

--- a/analyses/cell-type-consensus/references/consensus-validation-groups.tsv
+++ b/analyses/cell-type-consensus/references/consensus-validation-groups.tsv
@@ -1,31 +1,147 @@
 consensus_ontology	consensus_annotation	validation_group_ontology	validation_group_annotation
-CL:0000136	adipocyte	CL:0000136	adipocyte
 CL:0000236	B cell	CL:0000236	B cell
 CL:0000945	lymphocyte of B lineage	CL:0000236	B cell
 CL:0000785	mature B cell	CL:0000236	B cell
 CL:0000788	naive B cell	CL:0000236	B cell
 CL:0000787	memory B cell	CL:0000236	B cell
+CL:0000972	class switched memory B cell	CL:0000236	B cell
+CL:0001201	B cell, CD19-positive	CL:0000236	B cell
+CL:0000946	antibody secreting cell	CL:0000236	B cell
+CL:0000084	T cell	CL:0000084	T cell
+CL:0000624	CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000791	mature alpha-beta T cell	CL:0000084	T cell
+CL:0002419	mature T cell	CL:0000084	T cell
+CL:0000815	regulatory T cell	CL:0000084	T cell
+CL:0000813	memory T cell	CL:0000084	T cell
+CL:0000904	central memory CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0001204	CD4-positive, alpha-beta memory T cell, CD45RO-positive	CL:0000084	T cell
+CL:0000898	naive T cell	CL:0000084	T cell
+CL:0000625	CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0001203	CD8-positive, alpha-beta memory T cell, CD45RO-positive	CL:0000084	T cell
+CL:0000913	effector memory CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000798	gamma-delta T cell	CL:0000084	T cell
+CL:0000907	central memory CD8-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000893	thymocyte	CL:0000084	T cell
+CL:0000905	effector memory CD4-positive, alpha-beta T cell	CL:0000084	T cell
+CL:0000909	CD8-positive, alpha-beta memory T cell	CL:0000084	T cell
+CL:0000814	mature NK T cell	CL:0000084	T cell
+CL:0000897	CD4-positive, alpha-beta memory T cell	CL:0000084	T cell
+CL:0002038	T follicular helper cell	CL:0000084	T cell
+CL:0000492	CD4-positive helper T cell	CL:0000084	T cell
+CL:0000911	effector T cell	CL:0000084	T cell
+CL:0000789	alpha-beta T cell	CL:0000084	T cell
+CL:0000136	adipocyte	CL:0000136	adipocyte
+CL:0000127	astrocyte	CL:0000127	astrocyte
+CL:0002494	cardiocyte	CL:0002494	cardiocyte
+CL:0000206	chemoreceptor cell	CL:0000206	chemoreceptor cell
 CL:0000138	chondrocyte	CL:0000138	chondrocyte
+CL:0000064	ciliated cell	CL:0000064	ciliated cell
 CL:0000451	dendritic cell	CL:0000451	dendritic cell
+CL:0000784	plasmacytoid dendritic cell	CL:0000451	dendritic cell
+CL:0000990	conventional dendritic cell	CL:0000451	dendritic cell
+CL:0000453	Langerhans cell	CL:0000451	dendritic cell
+CL:0002321	embryonic cell (metazoa)	CL:0002321	embryonic cell (metazoa)
+CL:0000222	mesodermal cell	CL:0002321	embryonic cell (metazoa)
+CL:0000163	endocrine cell	CL:0000163	endocrine cell
 CL:0000115	endothelial cell	CL:0000115	endothelial cell
 CL:0000071	blood vessel endothelial cell	CL:0000115	endothelial cell
 CL:2000008	microvascular endothelial cell	CL:0000115	endothelial cell
+CL:0002139	endothelial cell of vascular tree	CL:0000115	endothelial cell
+CL:1000413	endothelial cell of artery	CL:0000115	endothelial cell
+CL:4033054	perivascular cell	CL:0000115	endothelial cell
 CL:0000066	epithelial cell	CL:0000066	epithelial cell
 CL:0002077	ecto-epithelial cell	CL:0000066	epithelial cell
 CL:0000312	keratinocyte	CL:0000066	epithelial cell
 CL:0000076	squamous epithelial cell	CL:0000066	epithelial cell
 CL:0000362	epidermal cell	CL:0000066	epithelial cell
+CL:0000150	glandular epithelial cell	CL:0000066	epithelial cell
+CL:0002076	endo-epithelial cell	CL:0000066	epithelial cell
+CL:0000164	enteroendocrine cell	CL:0000066	epithelial cell
+CL:0000171	pancreatic A cell	CL:0000066	epithelial cell
+CL:0008024	pancreatic endocrine cell	CL:0000066	epithelial cell
+CL:0000083	epithelial cell of pancreas	CL:0000066	epithelial cell
+CL:0000169	type B pancreatic cell	CL:0000066	epithelial cell
+CL:0000173	pancreatic D cell	CL:0000066	epithelial cell
+CL:0000069	branched duct epithelial cell	CL:0000066	epithelial cell
+CL:0000068	duct epithelial cell	CL:0000066	epithelial cell
+CL:0002079	pancreatic ductal cell	CL:0000066	epithelial cell
+CL:0000622	acinar cell	CL:0000066	epithelial cell
+CL:1001433	epithelial cell of exocrine pancreas	CL:0000066	epithelial cell
+CL:0000160	goblet cell	CL:0000066	epithelial cell
+CL:0002368	respiratory epithelial cell	CL:0000066	epithelial cell
+CL:0002370	respiratory goblet cell	CL:0000066	epithelial cell
+CL:0002202	epithelial cell of tracheobronchial tree	CL:0000066	epithelial cell
+CL:0002632	epithelial cell of lower respiratory tract	CL:0000066	epithelial cell
+CL:0000158	club cell	CL:0000066	epithelial cell
+CL:0005006	ionocyte	CL:0000066	epithelial cell
+CL:0000082	epithelial cell of lung	CL:0000066	epithelial cell
+CL:0000075	columnar/cuboidal epithelial cell	CL:0000066	epithelial cell
+CL:0000710	neurecto-epithelial cell	CL:0000066	epithelial cell
+CL:0000322	pulmonary alveolar epithelial cell	CL:0000066	epithelial cell
+CL:0002063	pulmonary alveolar type 2 cell	CL:0000066	epithelial cell
+CL:0000067	ciliated epithelial cell	CL:0000066	epithelial cell
+CL:0002062	pulmonary alveolar type 1 cell	CL:0000066	epithelial cell
+CL:0002078	meso-epithelial cell	CL:0000066	epithelial cell
+CL:0000077	mesothelial cell	CL:0000066	epithelial cell
+CL:0002326	luminal epithelial cell of mammary gland	CL:0000066	epithelial cell
+CL:0002327	mammary gland epithelial cell	CL:0000066	epithelial cell
+CL:0000584	enterocyte	CL:0000066	epithelial cell
+CL:0002563	intestinal epithelial cell	CL:0000066	epithelial cell
+CL:0002251	epithelial cell of alimentary canal	CL:0000066	epithelial cell
+CL:0000239	brush border epithelial cell	CL:0000066	epithelial cell
+CL:0000510	paneth cell	CL:0000066	epithelial cell
+CL:0002584	renal cortical epithelial cell	CL:0000066	epithelial cell
+CL:1000615	kidney cortex tubule cell	CL:0000066	epithelial cell
+CL:1000449	epithelial cell of nephron	CL:0000066	epithelial cell
+CL:1000494	nephron tubule epithelial cell	CL:0000066	epithelial cell
+CL:0002518	kidney epithelial cell	CL:0000066	epithelial cell
+CL:0002306	epithelial cell of proximal tubule	CL:0000066	epithelial cell
+CL:1000450	epithelial cell of glomerular capsule	CL:0000066	epithelial cell
+CL:0005010	renal intercalated cell	CL:0000066	epithelial cell
+CL:0005009	renal principal cell	CL:0000066	epithelial cell
+CL:0002204	brush cell	CL:0000066	epithelial cell
+CL:0000182	hepatocyte	CL:0000066	epithelial cell
+CL:1000488	cholangiocyte	CL:0000066	epithelial cell
+CL:0002305	epithelial cell of distal tubule	CL:0000066	epithelial cell
+CL:1000909	kidney loop of Henle epithelial cell	CL:0000066	epithelial cell
 CL:0000057	fibroblast	CL:0000057	fibroblast
+CL:0002410	pancreatic stellate cell	CL:0000057	fibroblast
+CL:0000125	glial cell	CL:0000125	glial cell
+CL:0000126	macroglial cell	CL:0000125	glial cell
+CL:0000095	neuron associated cell	CL:0000125	glial cell
+CL:0000681	radial glial cell	CL:0000125	glial cell
+CL:0000128	oligodendrocyte	CL:0000125	glial cell
+CL:0000636	Mueller cell	CL:0000125	glial cell
+CL:0000123	neuron associated cell (sensu Vertebrata)	CL:0000125	glial cell
+CL:0002453	oligodendrocyte precursor cell	CL:0000125	glial cell
 CL:0008001	hematopoietic precursor cell	CL:0008001	hematopoietic precursor cell
 CL:0000037	hematopoietic stem cell	CL:0008001	hematopoietic precursor cell
+CL:0002032	hematopoietic oligopotent progenitor cell	CL:0008001	hematopoietic precursor cell
+CL:0000051	common lymphoid progenitor	CL:0008001	hematopoietic precursor cell
+CL:0002031	hematopoietic lineage restricted progenitor cell	CL:0008001	hematopoietic precursor cell
+CL:0000038	erythroid progenitor cell	CL:0008001	hematopoietic precursor cell
+CL:0002274	histamine secreting cell	CL:0002274	histamine secreting cell
 CL:0001065	innate lymphoid cell	CL:0001065	innate lymphoid cell
+CL:0002681	kidney cortical cell	CL:1000497	kidney cell
+CL:1000497	kidney cell	CL:1000497	kidney cell
+CL:1000272	lung secretory cell	CL:1000272	lung secretory cell
 CL:0000235	macrophage	CL:0000235	macrophage
-CL:0000148	melanocyte	CL:0000148	melanocyte
+CL:0000864	tissue-resident macrophage	CL:0000235	macrophage
+CL:1001603	lung macrophage	CL:0000235	macrophage
+CL:0000583	alveolar macrophage	CL:0000235	macrophage
+CL:0000091	Kupffer cell	CL:0000235	macrophage
+CL:0000863	inflammatory macrophage	CL:0000235	macrophage
+CL:0000861	elicited macrophage	CL:0000235	macrophage
+CL:0000129	microglial cell	CL:0000235	macrophage
 CL:0000650	mesangial cell	CL:0000650	mesangial cell
 CL:0000576	monocyte	CL:0000576	monocyte
 CL:0000192	smooth muscle cell	CL:0000187	muscle cell
 CL:0000187	muscle cell	CL:0000187	muscle cell
 CL:0000188	cell of skeletal muscle	CL:0000187	muscle cell
+CL:0000737	striated muscle cell	CL:0000187	muscle cell
+CL:0000746	cardiac muscle cell	CL:0000187	muscle cell
+CL:0000359	vascular associated smooth muscle cell	CL:0000187	muscle cell
+CL:0019019	tracheobronchial smooth muscle cell	CL:0000187	muscle cell
 CL:0000766	myeloid leukocyte	CL:0000763	myeloid
 CL:0000094	granulocyte	CL:0000763	myeloid
 CL:0000775	neutrophil	CL:0000763	myeloid
@@ -33,21 +149,33 @@ CL:0000113	mononuclear phagocyte	CL:0000763	myeloid
 CL:0000764	erythroid lineage cell	CL:0000763	myeloid
 CL:0000556	megakaryocyte	CL:0000763	myeloid
 CL:0000771	eosinophil	CL:0000763	myeloid
+CL:0000233	platelet	CL:0000763	myeloid cell
+CL:0000232	erythrocyte	CL:0000763	myeloid cell
+CL:0000097	mast cell	CL:0000763	myeloid cell
+CL:0000186	myofibroblast cell	CL:0000186	myofibroblast cell
 CL:0000623	natural killer cell	CL:0000623	natural killer cell
 CL:0000540	neuron	CL:0000540	neuron
-CL:0000127	astrocyte	CL:0000127	astrocyte
-CL:0000125	glial cell	CL:0000125	glial cell
-CL:0000126	macroglial cell	CL:0000125	glial cell
-CL:0000095	neuron associated cell	CL:0000125	glial cell
+CL:0000679	glutamatergic neuron	CL:0000540	neuron
+CL:0000527	efferent neuron	CL:0000540	neuron
+CL:0000210	photoreceptor cell	CL:0000540	neuron
+CL:0000099	interneuron	CL:0000540	neuron
+CL:0008028	visual system neuron	CL:0000540	neuron
+CL:0000740	retinal ganglion cell	CL:0000540	neuron
+CL:0000117	CNS neuron (sensu Vertebrata)	CL:0000540	neuron
+CL:0000101	sensory neuron	CL:0000540	neuron
+CL:0000165	neuroendocrine cell	CL:0000540	neuron
 CL:0000669	pericyte	CL:0000669	pericyte
+CL:0000148	melanocyte	CL:0000147	pigment cell
+CL:0000147	pigment cell	CL:0000147	pigment cell
 CL:0000786	plasma cell	CL:0000786	plasma cell
+CL:0009004	retinal cell	CL:0009004	retinal cell
 CL:0000723	somatic stem cell	CL:0000034	stem cell
 CL:0000034	stem cell	CL:0000034	stem cell
+CL:0000048	multi fate stem cell	CL:0000034	stem cell
+CL:0000646	basal cell	CL:0000034	stem cell
+CL:0000134	mesenchymal stem cell	CL:0000034	stem cell
+CL:0002250	intestinal crypt stem cell	CL:0000034	stem cell
 CL:0000499	stromal cell	CL:0000499	stromal cell
-CL:0000327	extracellular matrix secreting cell	CL:0000499	stromal cell
-CL:0000084	T cell	CL:0000084	T cell
-CL:0000624	CD4-positive, alpha-beta T cell	CL:0000084	T cell
-CL:0000791	mature alpha-beta T cell	CL:0000084	T cell
-CL:0002419	mature T cell	CL:0000084	T cell
-CL:0000815	regulatory T cell	CL:0000084	T cell
-CL:0000813	memory T cell	CL:0000084	T cell
+CL:0002132	stromal cell of ovary	CL:0000499	stromal cell
+CL:0000632	hepatic stellate cell	CL:0000499	stromal cell
+CL:0000157	surfactant secreting cell	CL:0000157	surfactant secreting cell

--- a/analyses/cell-type-consensus/references/consensus-validation-groups.tsv
+++ b/analyses/cell-type-consensus/references/consensus-validation-groups.tsv
@@ -142,13 +142,13 @@ CL:0000737	striated muscle cell	CL:0000187	muscle cell
 CL:0000746	cardiac muscle cell	CL:0000187	muscle cell
 CL:0000359	vascular associated smooth muscle cell	CL:0000187	muscle cell
 CL:0019019	tracheobronchial smooth muscle cell	CL:0000187	muscle cell
-CL:0000766	myeloid leukocyte	CL:0000763	myeloid
-CL:0000094	granulocyte	CL:0000763	myeloid
-CL:0000775	neutrophil	CL:0000763	myeloid
-CL:0000113	mononuclear phagocyte	CL:0000763	myeloid
-CL:0000764	erythroid lineage cell	CL:0000763	myeloid
-CL:0000556	megakaryocyte	CL:0000763	myeloid
-CL:0000771	eosinophil	CL:0000763	myeloid
+CL:0000766	myeloid leukocyte	CL:0000763	myeloid cell
+CL:0000094	granulocyte	CL:0000763	myeloid cell
+CL:0000775	neutrophil	CL:0000763	myeloid cell
+CL:0000113	mononuclear phagocyte	CL:0000763	myeloid cell
+CL:0000764	erythroid lineage cell	CL:0000763	myeloid cell
+CL:0000556	megakaryocyte	CL:0000763	myeloid cell
+CL:0000771	eosinophil	CL:0000763	myeloid cell
 CL:0000233	platelet	CL:0000763	myeloid cell
 CL:0000232	erythrocyte	CL:0000763	myeloid cell
 CL:0000097	mast cell	CL:0000763	myeloid cell

--- a/analyses/cell-type-consensus/scripts/03-prepare-consensus-reference.R
+++ b/analyses/cell-type-consensus/scripts/03-prepare-consensus-reference.R
@@ -135,7 +135,12 @@ celltypes_to_exclude <- c(
   "supporting cell", 
   "biogenic amine secreting cell", 
   "protein secreting cell", 
-  "extracellular matrix secreting cell"
+  "extracellular matrix secreting cell",
+  "serotonin secreting cell", # platelets and neurons
+  "peptide hormone secreting cell", # parathyroid and peancreatic cells
+  "exocrine cell", # mucus and pancreatic cells
+  "sensory receptor cell", # retinal rod and taste or olfactory cells 
+  "interstitial cell" #kidney and leydig (testis) cells
   )
 
 # create a table with all pairs and their LCA


### PR DESCRIPTION
### Purpose/implementation Section
#### Please link to the GitHub issue that this pull request addresses.

Closes #1299 

#### What is the goal of this pull request?

Here I am updating the validation group reference to incorporate all the fun new consensus cell type options that we have.  There are now 180 possible consensus cell types that have been added to the validation groups file with an appropriate validation group annotation and ontology ID. 

#### Briefly describe the general approach you took to achieve this goal.

First, I looked to see if any of the new terms had ancestors that were in our original groups. For example a new B cell type should just be added to the existing B cell validation group. This was done by checking to see if the ancestors of the new consensus cell types were found as validation group ontology Ids in the old groups. If there was one match, (B cell for any B cell types) then that gets assigned as the validation group for that new term. 

After doing this, there was a handful of terms (30) that had multiple possible groups or no groups so I went through those manually. I made the following choices when doing that: 

- `microglial cell` belonged to either `glial cell` or `macrophage`. I think for the purposes of validation, which is mostly used for marker gene expression, these should be categorized as `macrophage`. Alternatively they could be their own group? 
- `intestinal crypt stem cell` could be part of `epithelial cell` or `stem cell` and I went with `stem cell`. 
-  I assigned `neuron associated cell (sensu Vertebrata)` to the `glial cell` validation group. We have another `neuron associated cell` in `glial cell` and looking at the matches that give rise to that term it's all OPCs and glial cells. 
- We now have `pigment cell` as an option, which is an ancestor of `melanocyte`. I got rid of the `melanocyte` group and instead made a `pigment cell` group that includes both `pigment cell` and `melanocyte`. 
- I grouped new terms as much as possible, but there were some pretty new additions (kidney cells, lung cells) that I felt belonged in their own group. 

For some additional context here are the terms that I ended up assigning "manually": 

```
consensus_annotation                     	 consensus_ontology	 validation_group_ontology	 validation_group_annotation
Langerhans cell                          	 CL:0000453        	 CL:0000451               	 dendritic cell
erythroid progenitor cell                	 CL:0000038        	 CL:0008001               	 hematopoietic precursor cell
neuroendocrine cell                      	 CL:0000165        	 CL:0000540               	 neuron
intestinal crypt stem cell               	 CL:0002250        	 CL:0000034               	 stem cell
hepatic stellate cell                    	 CL:0000632        	 CL:0000499               	 stromal cell
perivascular cell                        	 CL:4033054        	 CL:0000115               	 endothelial cell
neuron associated cell (sensu Vertebrata)	 CL:0000123        	 CL:0000125               	 glial cell
oligodendrocyte precursor cell           	 CL:0002453        	 CL:0000125               	 glial cell
microglial cell                          	 CL:0000129        	 CL:0000235               	 macrophage
antibody secreting cell                  	 CL:0000946        	 CL:0000236               	 B cell
embryonic cell (metazoa)                 	 CL:0002321        	 CL:0002321               	 embryonic cell (metazoa)
endocrine cell                           	 CL:0000163        	 CL:0000163               	 endocrine cell
ciliated cell                            	 CL:0000064        	 CL:0000064               	 ciliated cell
histamine secreting cell                 	 CL:0002274        	 CL:0002274               	 histamine secreting cell
surfactant secreting cell                	 CL:0000157        	 CL:0000157               	 surfactant secreting cell
myofibroblast cell                       	 CL:0000186        	 CL:0000186               	 myofibroblast cell
lung secretory cell                      	 CL:1000272        	 CL:1000272               	 lung secretory cell
cardiocyte                               	 CL:0002494        	 CL:0002494               	 cardiocyte
kidney cortical cell                     	 CL:0002681        	 CL:1000497               	 kidney cell
kidney cell                              	 CL:1000497        	 CL:1000497               	 kidney cell
mesodermal cell                          	 CL:0000222        	 CL:0002321               	 embryonic cell (metazoa)
retinal cell                             	 CL:0009004        	 CL:0009004               	 retinal cell
pigment cell                             	 CL:0000147        	 CL:0000147               	 pigment cell
chemoreceptor cell                       	 CL:0000206        	 CL:0000206               	 chemoreceptor cell
```

**Updates to consensus cell types**

While I was going through the new consensus cell types there were a handful of terms that I was struggling to assign groups to. I went back and reviewed the original pairs that gave rise to these annotations, and ultimately felt that they didn't really warrant a combined annotation, so I updated the script to create a reference that excludes those terms. For the most part, these are cells with similar functions but different tissues that we just didn't catch in the other notebooks. Here are the terms and the combinations that they were derived from: 

- `serotonin secreting cell`: platelets and types of neuron cells. 
- `peptide hormone secreting cell`: pancreatic A/B/C/D cells and parathyroid cell types 
- `exocrine cell`: pancreatic A/B/C/D cells and mucus secretory cells 
- `sensory receptor cell`: Reinal rod cells and taste or olfactory cells 
- `interstitial cell`: Kidney and Leydig (testis) interstitial cell types 

Let me know if you disagree with removing any of these. 

#### If known, do you anticipate filing additional pull requests to complete this analysis module?

Yes, next up we need to update the marker gene list. 

### Results

After updating the validation groups, here are the new groups: 
```
> unique(new_validation_df$validation_group_annotation)
 [1] "B cell"                       "T cell"                       "adipocyte"                    "astrocyte"                    "cardiocyte"                  
 [6] "chemoreceptor cell"           "chondrocyte"                  "ciliated cell"                "dendritic cell"               "embryonic cell (metazoa)"    
[11] "endocrine cell"               "endothelial cell"             "epithelial cell"              "fibroblast"                   "glial cell"                  
[16] "hematopoietic precursor cell" "histamine secreting cell"     "innate lymphoid cell"         "kidney cell"                  "lung secretory cell"         
[21] "macrophage"                   "mesangial cell"               "monocyte"                     "muscle cell"                  "myeloid"                     
[26] "myeloid cell"                 "myofibroblast cell"           "natural killer cell"          "neuron"                       "pericyte"                    
[31] "pigment cell"                 "plasma cell"                  "retinal cell"                 "stem cell"                    "stromal cell"                
[36] "surfactant secreting cell"
```




### Author checklists

#### Analysis module and review

- [ ] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [x] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [ ] The analytical code is documented and contains comments.
- [ ] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [ ] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
