### PR TITLE
Use entrypoint to set conda environments in Docker

### DIFF
--- a/analyses/cell-type-neuroblastoma-04/Dockerfile
+++ b/analyses/cell-type-neuroblastoma-04/Dockerfile
@@ -84,6 +84,9 @@ RUN Rscript -e "proc <- basilisk::basiliskStart(env = zellkonverter::zellkonvert
   basilisk::basiliskStop(proc); \
   basilisk.utils::cleanConda()"
 
-# Set ENTRYPOINT to bash to activate the environment for any commands
-ENTRYPOINT [ "conda", "run", "--no-capture-output", "-n", "${ENV_NAME}" ]
+# Set ENTRYPOINT to activate the environment for any commands
+RUN echo "#!/bin/bash --login \n conda activate ${ENV_NAME}" > /.entrypoint.sh
+RUN echo 'exec "$@"' >> /.entrypoint.sh
+RUN chmod +x /.entrypoint.sh
+ENTRYPOINT [ "/.entrypoint.sh" ]
 CMD ["/bin/bash"]

--- a/analyses/cell-type-scimilarity/Dockerfile
+++ b/analyses/cell-type-scimilarity/Dockerfile
@@ -70,5 +70,8 @@ RUN Rscript -e 'renv::restore()' && \
   rm -rf /tmp/Rtmp*
 
 # Set ENTRYPOINT to activate the environment for any commands
-ENTRYPOINT [ "conda", "run", "--no-capture-output", "-n", "${ENV_NAME}" ]
+RUN echo "#!/bin/bash --login \n conda activate ${ENV_NAME}" > /.entrypoint.sh
+RUN echo 'exec "$@"' >> /.entrypoint.sh
+RUN chmod +x /.entrypoint.sh
+ENTRYPOINT [ "/.entrypoint.sh" ]
 CMD ["/bin/bash"]


### PR DESCRIPTION
I saw the changes in https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/1313 and https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/1311 go in last week, and I thought we might want to clean up those solutions a bit. 

While Adding the conda environment directory to the `PATH` does means that the correct `python` is used and that makes the libraries correct, it may not set the full conda environment quite as we might like always (it seems to work in these cases, but better to set a good pattern if we can).

The solution I am proposing here is inspired by https://pythonspeed.com/articles/activate-conda-dockerfile using something like their final solution. I create a little bash script that activates the environment, then executes whatever command was requested when launching Docker. This is then used as the `ENTRYPOINT` for all commands. 

This seems to work as expected, so that running `docker run IMAGENAME which python3` gives the python executable in the environment directory, and launching directly into python does allow `anndata` to be loaded as expected.

One other thing I noted while doing this was that the neuroblastoma Docker image was very slow to build, which seems to be because it is installing `scvi-tools` via `pip`, which means you have to compile quite a few things from scratch. @sjspielman is this because you were running into trouble with some dependencies? I was able to include `scvi-tools` in the standard conda dependency list and build the enviroments/Docker image just fine, but obviously you have more testing under your belt so I could be missing something!