### PR TITLE
Update valiation group <-> diagnosis map

### DIFF
--- a/analyses/infercnv-consensus-cell-type/references/diagnosis-celltype-groups.tsv
+++ b/analyses/infercnv-consensus-cell-type/references/diagnosis-celltype-groups.tsv
@@ -1,15 +1,15 @@
 diagnosis_group	celltype_groups
-B-cell leukemia	dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte, fibroblast
-T-cell leukemia	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, endothelial cell, pericyte, fibroblast
+B-cell leukemia	dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte, fibroblast
+T-cell leukemia	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, endothelial cell, pericyte, fibroblast
 Acute myeloid leukemia	B cell, innate lymphoid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte, fibroblast
 Mixed phenotype acute leukemia	endothelial cell, pericyte, fibroblast
-Sarcoma	B cell, dendritic cell, innate lymphoid cell, macrophage, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
-Brain and CNS	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
-Adrenal cortex carcinoma	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
-Gastrointestinal stromal tumor	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell
-Germ cell tumor	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
-Hepatoblastoma	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
-Melanoma	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte, fibroblast
-Rhabdoid tumor	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte, fibroblast
-Wilms tumor	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
-Neuroblastoma	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid, natural killer cell, plasma cell, T cell, endothelial cell, pericyte, fibroblast
+Sarcoma	B cell, dendritic cell, innate lymphoid cell, macrophage, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
+Brain and CNS	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
+Adrenal cortex carcinoma	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
+Gastrointestinal stromal tumor	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell
+Germ cell tumor	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
+Hepatoblastoma	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
+Melanoma	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte, fibroblast
+Rhabdoid tumor	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte, fibroblast
+Wilms tumor	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte
+Neuroblastoma	B cell, dendritic cell, innate lymphoid cell, macrophage, monocyte, myeloid cell, natural killer cell, plasma cell, T cell, endothelial cell, pericyte, fibroblast


### PR DESCRIPTION
Closes #1290 

Now that we have updated validation groups, I am updating the broad diagnosis <-> validation group mapping for building inferCNV normal references.

New validation groups include the following:
```
cardiocyte
chemoreceptor cell
ciliated cell
embryonic cell (metazoa)
endocrine cell
histamine secreting cell
kidney cell
lung secretory cell
myofibroblast cell
pigment cell
retinal cell
surfactant secreting cell
```

None of these seem like good candidates for definitively normal cells, so I didn't add any of these groups - let me know if you disagree! In the end I made only one "cosmetic" change - our updated groups have renamed `myeloid` -> `myeloid cell`, so I made that change here. That's it!