### PR TITLE
Add scimilarity annotations to assigning consensus cell types

### DIFF
--- a/analyses/cell-type-consensus/assign-consensus-celltypes.sh
+++ b/analyses/cell-type-consensus/assign-consensus-celltypes.sh
@@ -27,6 +27,7 @@ consensus_ref_file="references/consensus-cell-type-reference.tsv"
 
 # marker gene file to use for validation 
 validation_markers_file="references/validation-markers.tsv"
+consensus_markers_file="references/consensus-markers.tsv"
 
 # scimilarity results directory 
 scimilarity_results_dir="${data_dir}/results/cell-type-scimilarity/${project_id}"
@@ -63,7 +64,8 @@ for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
       --blueprint_ref_file $blueprint_ref_file\
       --panglao_ref_file $panglao_ref_file \
       --consensus_ref_file $consensus_ref_file \
-      --marker_gene_file $validation_markers_file \
+      --validation_marker_gene_file $validation_markers_file \
+      --consensus_marker_gene_file $consensus_markers_file \
       --consensus_output_file $consensus_output_file \
       --gene_exp_output_file $gene_exp_output_file \
       $scimilarity_arg

--- a/analyses/cell-type-consensus/assign-consensus-celltypes.sh
+++ b/analyses/cell-type-consensus/assign-consensus-celltypes.sh
@@ -28,6 +28,9 @@ consensus_ref_file="references/consensus-cell-type-reference.tsv"
 # marker gene file to use for validation 
 validation_markers_file="references/validation-markers.tsv"
 
+# scimilarity results directory 
+scimilarity_results_dir="${data_dir}/results/cell-type-scimilarity/${project_id}"
+
 for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
 
   # grab sample id
@@ -42,6 +45,13 @@ for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
 
     # define library ID
     library_id=$(basename $sce_file | sed 's/_processed.rds$//')
+    
+    # get scimilarity file if it exists, otherwise don't provide it
+    scimilarity_arg=""
+    scimilarity_results_file="${scimilarity_results_dir}/${sample_id}/${library_id}__processed_scimilarity-celltype-assignments.tsv.gz"
+    if [[ -f $scimilarity_results_file ]]; then
+      scimilarity_arg="--scimilarity_annotations_file ${scimilarity_results_file}"
+    fi
 
     # define output files
     consensus_output_file="${sample_results_dir}/${library_id}_consensus-cell-type-assignments.tsv.gz"
@@ -55,7 +65,8 @@ for sample_dir in ${data_dir}/${project_id}/SCPCS*; do
       --consensus_ref_file $consensus_ref_file \
       --marker_gene_file $validation_markers_file \
       --consensus_output_file $consensus_output_file \
-      --gene_exp_output_file $gene_exp_output_file
+      --gene_exp_output_file $gene_exp_output_file \
+      $scimilarity_arg
 
   done 
 

--- a/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
+++ b/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
@@ -223,7 +223,7 @@ consensus_ref_df <- readr::read_tsv(opt$consensus_ref_file) |>
     starts_with(consensus_column_prefix)
   ) |> 
   # now just filter to join columns and get unique combinations
-  dplyr::select(all_of(join_columns), starts_with("consensus")) |> 
+  dplyr::select(all_of(join_columns), starts_with(consensus_column_prefix)) |> 
   dplyr::distinct() |> 
   # make sure the columns used to get the consensus cell type actually have the consensus_ prefix
   dplyr::rename_with(~ stringr::str_replace(.x,consensus_column_prefix, "consensus"), starts_with(consensus_column_prefix))

--- a/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
+++ b/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
@@ -186,7 +186,6 @@ if(file.exists(opt$scimilarity_annotations_file)) {
   scimilarity_df <- readr::read_tsv(opt$scimilarity_annotations_file) |> 
     dplyr::select(
       barcodes = barcode,
-      # match columns to the 
       scimilarity_celltype_ontology,
       scimilarity_celltype_annotation,
       scimilarity_annotation_cl = cl_annotation

--- a/analyses/cell-type-consensus/scripts/README.md
+++ b/analyses/cell-type-consensus/scripts/README.md
@@ -17,14 +17,16 @@ The terms and names are saved to a new file, `references/blueprint-mapped-ontolo
 The output table will contain one row for each combination of cell types in `PanglaoDB`, `BlueprintEncodeData` from `celldex`, and `SCimilarity` where a consensus cell type was identified.  
 If the combination is not included in the reference file, then no consensus cell type is assigned and can be set to "Unknown". 
 
-5. `04-assign-consensus-celltypes.R`: This script is used to grab the existing cell type annotations from the `colData` of an individual processed SCE object and assign the appropriate consensus cell type based on the `singler_celltype_ontology` (`BlueprintEncodeData`) and the `cellassign_celltype_ontology` (`PanglaoDB`). 
+5. `04-assign-consensus-celltypes.R`: This script is used to assign a consensus cell type using the existing cell type annotations from the `colData` of an individual processed SCE object and the cell type annotations from `cell-type-scimilarity`, if present.
+If `SCimilarity` is present, the appropriate consensus cell type is assigned based on the `singler_celltype_ontology` (`BlueprintEncodeData`), `cellassign_celltype_ontology` (`PanglaoDB`), and `scimilarity_celltype_ontology` (`SCimilarity`), otherwise only `singler_celltype_ontology` and `cellassign_celltype_ontology` are used.
 All annotations, including the consensus annotation, are then saved to a TSV file. 
-An additional TSV file containing the gene expression for all marker genes found in `references/validation-markers.tsv` will also be saved. 
+An additional TSV file containing the gene expression for all marker genes found in `references/validation-markers.tsv` and `references/consensus-markers.tsv` will also be saved. 
 
 6. `00-download-cellmarker-ref.sh`: This script is used to download the [marker genes for all Human tissues from `CellMarker2.0`](http://117.50.127.228/CellMarker/CellMarker_download.html). 
 This file will be stored in `references/Cell_markers_Human.xlsx`. 
 
-7. `05-generate-validation-markers.R`: This script is used to create a table of top marker genes for each cell types represented in the consensus cell type labels. 
+7. `05-generate-validation-markers.R`: This script is used to create two tables of top marker genes for each cell types represented in the consensus cell type labels. 
 Prior to running this script, the marker gene file from `CellMarker2.0` must be downloaded with `00-download-cellmarker-ref.sh`. 
-The output includes the top observed marker genes for all cell types in the `validation_group_ontology` column of `references/consensus-validation-groups.tsv`. 
+The `validation-markers.tsv` output includes the top observed marker genes for all cell types in the `validation_group_ontology` column of `references/consensus-validation-groups.tsv`. 
+The `consensus-markers.tsv` output includes the top observed marker genes for all cell types in the `consensus_ontology` column of `references/consensus-validation-groups.tsv`.
 Marker genes are ranked based on how frequently they are observed in all tissues present in `CellMarker2.0`. 


### PR DESCRIPTION
### Purpose/implementation Section

#### Please link to the GitHub issue that this pull request addresses.

Closes #1031

#### What is the goal of this pull request?

Here I'm modifying the existing script for assigning consensus cell types to consider the `SCimilarity` annotations. 


#### Briefly describe the general approach you took to achieve this goal.

- I added an optional argument to the script to provide the SCimilarity annotations TSV file as input. If that's provided, then they are read in and combined with the other cell type annotations before assigning consensus cell types. 
- I made this optional because as noted in #1321, we do not have SCimilarity annotations for multiplexed libraries (or at least we don't do that in the `OpenScPCA-nf` module). This is because we read in the `_processed.h5ad` file directly and those don't exist for multiplexed (or at least not yet). So for now, this is optional. 
- If annotations are provided then we use the combination of all three and take the annotation that is in the `consensus_annotation` column of the reference file. 
- If `SCimilarity` annotations are not provided then we use the combination betwen SingleR/CellAssign and assign that label as the consensus. 
- I also updated the script to now take in both the validation and consensus markers and include all genes in the output gene expression TSV file. 
- Finally, I updated the workflow script that gets run in GHA to optionally provide the SCimilarity file if it exists. One thing to note here is that we don't yet have SCimilarity results in the workflow results bucket. They are only in staging, so it will only run the script in the absence of annotations. Once we release those then we can update the GHA to download the results first. 

#### If known, do you anticipate filing additional pull requests to complete this analysis module?

Yes, but first we should port over these changes to the `cell-type-consensus` module in `OpenScPCA-nf`. When we do that we might want to include both the singleR/CellAssign consensus output and the overall consensus so we can easily compare between the "old" and "new" consensus cell types. 

### Author checklists

#### Analysis module and review

- [ ] This analysis module [uses the analysis template and has the expected directory structure](https://openscpca.readthedocs.io/en/latest/contributing-to-analyses/analysis-modules/).
- [ ] The analysis module `README.md` has been updated to reflect code changes in this pull request.
- [x] The analytical code is documented and contains comments.
- [ ] Any results and/or plots this code produces have been added to your S3 bucket for review.

#### Reproducibility checklist

- [ ] Code in this pull request has been added to the GitHub Action workflow that runs this module.
- [ ] The dependencies required to run the code in this pull request have been added to the analysis module `Dockerfile`.
- [ ] If applicable, the dependencies required to run the code in this pull request have been added to the analysis module conda `environment.yml` file.
- [ ] If applicable, R package dependencies required to run the code in this pull request have been added to the analysis module `renv.lock` file.
