### PR TITLE
Account for multiple sample types in consensus cell type assignment

### DIFF
--- a/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
+++ b/analyses/cell-type-consensus/scripts/04-assign-consensus-celltypes.R
@@ -144,7 +144,7 @@ coldata_df <- colData(sce) |>
     sample_id = sample_id,
     library_id = library_id,
     # add in sample type to make sure we don't assign consensus cell types to cell lines
-    sample_type = sample_type
+    sample_type = paste0(sample_type, collapse = ", ") # account for multiple sample types
   )
 
 # only select sample info and cell type info, we don't need the rest of the coldata


### PR DESCRIPTION
In working on AlexsLemonade/OpenScPCA-nf#184, I noticed we had a discrepancy between the two scripts for adding consensus cell types in how we handle multiple sample type options. This just makes the change to account for more than one sample type being possible to the script here, so things are in sync between the two repos. 
See https://github.com/AlexsLemonade/OpenScPCA-nf/blob/dc2a3334283094916f3e37282742a2d7bfcd700f/modules/cell-type-consensus/resources/usr/bin/assign-consensus-celltypes.R#L125