### PR TITLE
Add leukemias to dictionary

### DIFF
--- a/.github/components/dictionary.txt
+++ b/.github/components/dictionary.txt
@@ -153,6 +153,7 @@ LCA
 LCA's
 leiden
 leptomeningeal
+leukemias
 leukocytes
 LGBTQ
 LGG


### PR DESCRIPTION
Closes #1342; there was one typo for a non-in-progress module, and it just needed to be added to the dictionary.