### PR TITLE
Use ontologyIndex to grab CL ids

### DIFF
--- a/analyses/cell-type-scimilarity/scripts/01-assign-ontology-ids.R
+++ b/analyses/cell-type-scimilarity/scripts/01-assign-ontology-ids.R
@@ -51,7 +51,8 @@ missing_df <- readr::read_tsv(opts$missing_ontology_tsv)
 # Prep ontology terms ----------------------------------------------------------
 
 # get ontology terms and ids
-cl_ont <- ontologyIndex::get_ontology("http://purl.obolibrary.org/obo/cl/releases/2024-09-26/cl-basic.obo") 
+# use the release that matches the release we grabbed when previously using rols
+cl_ont <- ontologyIndex::get_ontology("http://purl.obolibrary.org/obo/cl/releases/2025-07-30/cl-basic.obo") 
 
 # data frame of id and human readable value
 ontology_labels_df <- data.frame(

--- a/analyses/cell-type-scimilarity/scripts/01-assign-ontology-ids.R
+++ b/analyses/cell-type-scimilarity/scripts/01-assign-ontology-ids.R
@@ -7,6 +7,8 @@
 # the path to the annotation/reference_labels.tsv inside the unzipped model directory should be provided with the `--model_annotations_file` argument.
 # default is `models/model_v1.1/annotation/reference_labels.tsv`
 
+# uses the latest release at the time of creating this script for Ontology assignment 2025-07-30
+
 library(optparse)
 project_root <- here::here()
 

--- a/analyses/cell-type-scimilarity/scripts/01-assign-ontology-ids.R
+++ b/analyses/cell-type-scimilarity/scripts/01-assign-ontology-ids.R
@@ -50,16 +50,13 @@ missing_df <- readr::read_tsv(opts$missing_ontology_tsv)
 
 # Prep ontology terms ----------------------------------------------------------
 
-# get uberon ontology terms and ids
-ol <- rols::Ontologies()
-cell_ontology <- ol[["cl"]]
-terms <- rols::Terms(cell_ontology)
-labels <- rols::termLabel(terms)
+# get ontology terms and ids
+cl_ont <- ontologyIndex::get_ontology("http://purl.obolibrary.org/obo/cl/releases/2024-09-26/cl-basic.obo") 
 
 # data frame of id and human readable value
 ontology_labels_df <- data.frame(
-  ontology_id = names(labels),
-  cl_annotation = labels
+  ontology_id = cl_ont$id,
+  cl_annotation = cl_ont$name
 )
 
 # Add ontology IDs to annotation labels ----------------------------------------


### PR DESCRIPTION
Part 2 of #1348 

This just makes the change to the code to use `ontologyIndex` instead of `rols`. Here I'm specifying grabbing the release that matches what we were using previously (which is currently the latest release) when assigning the IDs for scimilarity annotations. 