### PR TITLE
Add `cell-type-scimilarity` to build all docker images

### DIFF
--- a/.github/workflows/docker_all-modules.yml
+++ b/.github/workflows/docker_all-modules.yml
@@ -46,6 +46,7 @@ jobs:
           - seurat-conversion
           - infercnv-consensus-cell-type
           - cell-type-neuroblastoma-04
+          - cell-type-scimilarity
     uses: ./.github/workflows/build-push-docker-module.yml
     if: github.repository_owner == 'AlexsLemonade'
     with:


### PR DESCRIPTION
Looks like I forgot to add `cell-type-scimilarity` to the module list with Docker images. 