### PR TITLE
Clear disk space for scimilarity

### DIFF
--- a/.github/workflows/run_cell-type-scimilarity.yml
+++ b/.github/workflows/run_cell-type-scimilarity.yml
@@ -39,6 +39,26 @@ jobs:
         shell: bash -el {0}
 
     steps:
+      - name: Clear space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          # Software to remove
+          # see https://mathio28.medium.com/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-d5fbe4443692
+          sudo rm -rf \
+            /usr/lib/jvm \
+            /usr/share/dotnet \
+            /usr/share/swift \
+            /usr/local/.ghcup \
+            /usr/local/.rustup \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/share/powershell \
+            /opt/hostedtoolcache
+
+          echo "Disk space after cleanup:"
+          df -h
+
       - name: Checkout repo
         uses: actions/checkout@v4
         

--- a/.github/workflows/run_cell-type-scimilarity.yml
+++ b/.github/workflows/run_cell-type-scimilarity.yml
@@ -45,7 +45,7 @@ jobs:
           df -h
           # Software to remove
           # see https://mathio28.medium.com/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-d5fbe4443692
-          sudo rm -rf \
+          rm -rf \
             /usr/lib/jvm \
             /usr/share/dotnet \
             /usr/share/swift \


### PR DESCRIPTION
Closes #1363 
scimilarity is failing in CI due to disk space. Here, I ported over the step we recently added to the scpcaTools docker workflow to clear space first. Hopefully this does the trick!