### PR TITLE
Fix hello-clusters

### DIFF
--- a/.github/workflows/run_all-modules.yml
+++ b/.github/workflows/run_all-modules.yml
@@ -19,9 +19,6 @@ jobs:
   hello-python:
     uses: ./.github/workflows/run_hello-python.yml
 
-  hello-clusters:
-    uses: ./.github/workflows/run_hello-clusters.yml
-
   doublet-detection:
     uses: ./.github/workflows/run_doublet-detection.yml
 


### PR DESCRIPTION
As noted in #1375, `hello-clusters` had some issues! We've addressed this in `rOpenScPCA`, so updating this repo accordingly:

- I added the module to the run all modules GHA
- I updated `renv.lock` with the most recent version (we were already a bit behind, as evidenced by the added `scuttle` too which has been in `Imports` for a minute!)

I ran the module locally with test data sans error, so hopefully we're good here too.