### PR TITLE
Remove clustering workflow for Ewing's from CI

### DIFF
--- a/.github/workflows/run_cell-type-ewings.yml
+++ b/.github/workflows/run_cell-type-ewings.yml
@@ -49,5 +49,4 @@ jobs:
           conda activate openscpca-cell-type-ewings
           cd $MODULE_PATH
           bash aucell-singler-annotation.sh
-          bash evaluate-clusters.sh
           bash run-aucell-ews-signatures.sh

--- a/analyses/cell-type-ewings/README.md
+++ b/analyses/cell-type-ewings/README.md
@@ -186,6 +186,8 @@ Note that `SingleR` does take up to 1 hour to run with 4 CPUs for some samples i
 
 ## Clustering workflow 
 
+**NOTE:** This workflow is no longer used in the cell type annotation analysis, has been removed from CI, and is no longer maintained! 
+
 The clustering workflow (`evaluate-clusters.sh`) can be used to perform and evaluate clusters across a range of parameters. 
 For all processed `SingleCellExperiment` objects that are part of `SCPCP000015`, clustering is performed using the following options: 
 

--- a/analyses/cell-type-ewings/evaluate-clusters.sh
+++ b/analyses/cell-type-ewings/evaluate-clusters.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+## THIS WORKFLOW IS NO LONGER USED IN THE CELL TYPE ANNOTATION ANALYSIS. ##
+## THIS WORKFLOW HAS BEEN REMOVED FROM CI AND IS NO LONGER BEING MAINTAINED ##
+
 # This script is used to evaluate clustering with varying parameters for all samples in SCPCP000015
 # Clusters are calculated using the following parameters: 
 


### PR DESCRIPTION
Here I'm removing the clustering workflow from CI for the Ewing's module, since the results aren't actually used anywhere for annotation. We did the same thing for the inferCNV module a few months ago, so I just followed the same procedure of removing it from the GHA and then noting both in the readme and at the top of the workflow script that it is no longer run in CI and not maintained. This should hopefully decrease the run time for the module!